### PR TITLE
[FEATURE] 테스트 환경 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 src/main/resources/application-dev.yml
+src/main/resources/application-test.yml

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // H2
-    implementation 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.named('test') {
 }
 
 jacoco {
-    toolVersion = '0.8.8'
+    toolVersion = '0.8.12'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'or.sopt'
@@ -77,4 +78,31 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination file("$buildDir/reports/jacoco/index.html")
+        xml.destination file("$buildDir/reports/jacoco/index.xml")
+        csv.destination file("$buildDir/reports/jacoco/index.csv")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            // 여기에 제외할 테스트 영역을 설정 할 수 있습니다. 이 부분은 논의 후 설정하면 좋을 것 같습니다
+                    ])
+                })
+        )
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // H2
+    implementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/test/java/or/sopt/houme/HoumeApplicationTests.java
+++ b/src/test/java/or/sopt/houme/HoumeApplicationTests.java
@@ -1,12 +1,18 @@
 package or.sopt.houme;
 
+import jdk.jfr.Name;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
+@DisplayName("테스트 환경 Health Check")
 @SpringBootTest
 class HoumeApplicationTests {
 
     @Test
+    @DisplayName("테스트 환경이 정상적으로 작동하는지 확인합니다")
     void contextLoads() {
     }
 

--- a/src/test/java/or/sopt/houme/HoumeApplicationTests.java
+++ b/src/test/java/or/sopt/houme/HoumeApplicationTests.java
@@ -1,6 +1,5 @@
 package or.sopt.houme;
 
-import jdk.jfr.Name;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #13 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- application-test.yml 구현
- 자코코 도입

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 테스트 환경 구축을 위한 yml 을 구현했습니다. 노션에 올려두었으니 파일명 꼭 참고해서 gitignore에 제대로 설정되는지 확인하고 사용해주세요
- 자코코 사용방법은 다음과 같습니다

1. ./gradlew test 를 통한 전체 테스트 실행
2. build/reports/jacoco/index.html 파일을 웹에서 실행

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/7b96af01-f3a8-4c4f-ad1c-9d091b257d3b" />

그러면 이런 테스트 report를 확인 할 수 있습니다. 각 파일에 들어가서 세부 커버리지를 확인 할 수 있습니다.

논의사항은 다음과 같습니다
---


1. 테스트 커버리지를 통한 CI 실패 로직 구현
자코코는 특정 커버리지를 설정하고 수치를 넘지 못하면 gradlew test 를 실패 시킬 수 있습니다. 이는 곧 CI 에서의 실패를 의미하기에 통합이 불가능해지는 기능을 제공합니다.

사전에 논의했던 대로, 이 부분은 앱잼 이후, 외부 API와 회원 기능의 커버리지를 올리면서 구현 할 수 있겠습니다.
아니면 해당 기능들을 scope에서 제외시키고 남은 부분에 대한 커버리지를 강제하는 방법도 있습니다. 다른 분들의 의견이 궁금하네요.

2. 테스트 scope 설정
테스트의 대상이되는 범위를 설정하는데에 논의가 필요합니다.

