### PR TITLE
[FEATURE] 랜딩페이지 이미지 생성 이력 조회 API 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
@@ -1,5 +1,7 @@
 package or.sopt.houme.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +15,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "회원 랜딩페이지 관련 API")
 public class UserLandingController {
 
     private final UserLandingService userLandingService;
 
     @GetMapping("/check-has-generated-image")
+    @Operation(summary = "회원 이미지 생성 이력 조회 API",
+    description = "회원의 리프레시 토큰의 유효성과 이미지 생성 이력을 조회합니다 <br><br>" +
+            "이미지 생성 이력이 없으면 **false** 있다면 **true** 를 반환합니다")
     public ResponseEntity<ApiResponse<Boolean>> checkHasGeneratedImage(HttpServletRequest request) {
 
         Boolean result = userLandingService.getHasGeneratedImage(request);

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.domain.user.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.service.UserLandingService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserLandingController {
+
+    private final UserLandingService userLandingService;
+
+    @GetMapping("/check-has-generated-image")
+    public ResponseEntity<ApiResponse<Boolean>> checkHasGeneratedImage(HttpServletRequest request) {
+
+        Boolean result = userLandingService.getHasGeneratedImage(request);
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/entity/User.java
+++ b/src/main/java/or/sopt/houme/domain/user/entity/User.java
@@ -37,6 +37,9 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = true)
     private String password;
 
+    @Column(name = "has_generated_image")
+    private Boolean hasGeneratedImage;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", nullable = true)
     private SocialType socialType;

--- a/src/main/java/or/sopt/houme/domain/user/service/JWTService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/JWTService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.domain.user.valid.RefreshTokenValidator;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.TokenException;
 import or.sopt.houme.global.api.handler.UserException;
@@ -25,6 +26,7 @@ public class JWTService {
     private final JWTConfig jwtConfig;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRedisTemplateUtil;
+    private final RefreshTokenValidator refreshTokenValidator;
 
 
     // 토큰 발급기를 위한 메서드입니다
@@ -45,50 +47,8 @@ public class JWTService {
      * */
     public void refreshRotate(HttpServletRequest request, HttpServletResponse response){
 
-        String refresh = null;
 
-        // 0. 쿠키를 탐색
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) throw new TokenException(ErrorCode.COOKIE_NULL);
-
-        // 1. 쿠키를 순차적으로 돌면서 우리가 이전에 설정해놓은 쿠키의 키값과 일치하는 쿠키가 존재하는지 탐색
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh-token")) {
-
-                refresh = cookie.getValue();
-            }
-        }
-
-        // 1-1. 쿠키 속에 우리가 만들어놓은 리프레시 토큰이 존재하지 않는다면 예외 발생
-        if (refresh == null) {
-
-            throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
-        }
-
-        // 1-2. 토큰의 유효기간이 만료되었다면 예외 발생
-        try {
-            jwtUtil.isExpired(refresh);
-        } catch (ExpiredJwtException e) {
-
-            throw new TokenException(ErrorCode.REFRESH_TOKEN_EXPIRED);
-        }
-
-        // 2. 발견한 토큰의 카테고리가 refresh 가 맞는지 확인
-        String category = jwtUtil.getCategory(refresh);
-
-        if (!category.equals("refresh")) {
-            throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
-        }
-
-        // 3. 리프레시 토큰에서 ID를 가져와서 해당 토큰이 서버에 존재하는지 확인
-        Long userId = jwtUtil.getId(refresh);
-
-        Boolean isExist = refreshTokenRedisTemplateUtil.existsById(userId);
-
-        if (!isExist) {
-            throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
-        }
-
+        Long userIdFromRefreshToken = refreshTokenValidator.validateRefreshToken(request);
 
         /**
          * 위의 모든 검증절차를 통과하였다면
@@ -96,7 +56,7 @@ public class JWTService {
          *
          * 액세스 토큰과 리프레시 토큰을 새롭게 발급합니다
          * */
-        User findUser = userRepository.findById(userId)
+        User findUser = userRepository.findById(userIdFromRefreshToken)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
 
@@ -104,9 +64,9 @@ public class JWTService {
         String newRefresh = jwtUtil.createJwt("refresh", findUser.getId(), findUser.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
 
 
-        refreshTokenRedisTemplateUtil.deleteById(userId);
+        refreshTokenRedisTemplateUtil.deleteById(userIdFromRefreshToken);
 
-        refreshTokenRedisTemplateUtil.saveRefreshToken(userId,newRefresh,jwtConfig.getRefreshTokenValidityInSeconds());
+        refreshTokenRedisTemplateUtil.saveRefreshToken(userIdFromRefreshToken,newRefresh,jwtConfig.getRefreshTokenValidityInSeconds());
 
         response.setHeader("access-token", access);
 

--- a/src/main/java/or/sopt/houme/domain/user/service/UserLandingService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserLandingService.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.domain.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface UserLandingService {
+    Boolean getHasGeneratedImage(HttpServletRequest request);
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
@@ -1,0 +1,29 @@
+package or.sopt.houme.domain.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.domain.user.valid.RefreshTokenValidator;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.UserException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserLandingServiceImpl implements UserLandingService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenValidator refreshTokenValidator;
+
+    @Override
+    public Boolean getHasGeneratedImage(HttpServletRequest request){
+
+        Long findUserIdByRefreshToken = refreshTokenValidator.validateRefreshToken(request);
+
+        User findUser = userRepository.findById(findUserIdByRefreshToken)
+                .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        return findUser.getHasGeneratedImage();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
+++ b/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
@@ -1,0 +1,58 @@
+package or.sopt.houme.domain.user.valid;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.TokenException;
+import or.sopt.houme.global.jwt.JWTUtil;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenValidator {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Long validateRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) throw new TokenException(ErrorCode.COOKIE_NULL);
+
+        String refresh = null;
+
+        for (Cookie cookie : cookies) {
+            if ("refresh-token".equals(cookie.getName())) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
+
+        try {
+
+            jwtUtil.isExpired(refresh);
+
+            if (!"refresh".equals(jwtUtil.getCategory(refresh))) {
+                throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
+            }
+
+            Long userId = jwtUtil.getId(refresh);
+            if (!refreshTokenRepository.existsById(userId)) {
+                throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
+            }
+
+            return userId;
+
+        } catch (ExpiredJwtException e) {
+            throw new TokenException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        } catch (SignatureException e) {
+            throw new TokenException(ErrorCode.INVALID_SIGNATURE);
+        } catch (Exception e) {
+            throw new TokenException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,40004 ,"리프레시 토큰이 만료되었습니다" ),
     ROLE_INVALID_TYPE(HttpStatus.BAD_REQUEST,40005,"권한이 일치하지 않습니다"),
     ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED,40401 ,"회원의 액세스 토큰이 블랙리스트 처리되었습니다" ),
+    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED,40402,"토큰의 서명이 유효하지 않습니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED,40403,"유효하지 않은 토큰입니다"),
 
     // HouseEnum 처리 예외
     HOUSE_NOT_ALLOWED_OPTION(HttpStatus.BAD_REQUEST, 40007, "유효하지 않은 집 구조 옵션입니다."),

--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -91,6 +91,7 @@ public class SecurityConfig {
                 .requestMatchers(WhiteListConfig.oauthWhitelist().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.serverWhitelist().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.makeHouseWhitelist().toArray(new String[0])).permitAll()
+                .requestMatchers(WhiteListConfig.userWhiteList().toArray(new String[0])).permitAll()
                 .anyRequest().authenticated());
 
 

--- a/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
@@ -43,4 +43,11 @@ public class WhiteListConfig {
                 "/api/v1/housing-selections"
         );
     }
+
+    // 회원 관련 인가 설정
+    public static final List<String> userWhiteList() {
+        return List.of(
+                "/api/v1/check-has-generated-image"
+        );
+    }
 }

--- a/src/test/java/or/sopt/houme/domain/user/controller/UserLandingControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/UserLandingControllerTest.java
@@ -45,6 +45,7 @@ class UserLandingControllerTest {
                 .andExpect(jsonPath("$.data").value(true));
     }
 
+
     @Test
     @DisplayName("checkHasGeneratedImage()는 false를 반환한다")
     void checkHasGeneratedImage_false() throws Exception {

--- a/src/test/java/or/sopt/houme/domain/user/controller/UserLandingControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/UserLandingControllerTest.java
@@ -1,0 +1,61 @@
+package or.sopt.houme.domain.user.controller;
+
+import or.sopt.houme.domain.user.service.UserLandingService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class UserLandingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserLandingService userLandingService;
+
+    @Test
+    @DisplayName("checkHasGeneratedImage()는 true를 반환한다")
+    void checkHasGeneratedImage_true() throws Exception {
+        // given
+        Mockito.when(userLandingService.getHasGeneratedImage(any()))
+                .thenReturn(true);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/check-has-generated-image")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    @DisplayName("checkHasGeneratedImage()는 false를 반환한다")
+    void checkHasGeneratedImage_false() throws Exception {
+        // given
+        Mockito.when(userLandingService.getHasGeneratedImage(any()))
+                .thenReturn(false);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/check-has-generated-image")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(false));
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/user/service/UserLandingServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserLandingServiceImplTest.java
@@ -1,0 +1,73 @@
+package or.sopt.houme.domain.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.domain.user.service.UserLandingServiceImpl;
+import or.sopt.houme.domain.user.valid.RefreshTokenValidator;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.UserException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserLandingServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenValidator refreshTokenValidator;
+
+    @InjectMocks
+    private UserLandingServiceImpl userLandingService;
+
+    @Test
+    @DisplayName("getHasGeneratedImage()는 회원의 이미지 생성이력을 Boolean 타입으로 반환 할 수 있다")
+    void getHasGeneratedImage_success() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Long mockUserId = 1L;
+
+        User mockUser = User.builder()
+                .id(mockUserId)
+                .hasGeneratedImage(true)
+                .build();
+
+        when(refreshTokenValidator.validateRefreshToken(request)).thenReturn(mockUserId);
+        when(userRepository.findById(mockUserId)).thenReturn(Optional.of(mockUser));
+
+        // when
+        Boolean result = userLandingService.getHasGeneratedImage(request);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("getHasGeneratedImage() 는 회원을 찾을 수 없으면 정해진 예외를 반환한다")
+    void getHasGeneratedImage_userNotFound() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Long mockUserId = 999L;
+
+        when(refreshTokenValidator.validateRefreshToken(request)).thenReturn(mockUserId);
+        when(userRepository.findById(mockUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        UserException e = assertThrows(UserException.class, () ->
+                userLandingService.getHasGeneratedImage(request)
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
@@ -10,24 +10,27 @@ import or.sopt.houme.global.jwt.JWTUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class RefreshTokenValidatorTest {
 
+
+    @Mock
     private JWTUtil jwtUtil;
+
+    @Mock
     private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
     private RefreshTokenValidator refreshTokenValidator;
 
-
-
-    @BeforeEach
-    void setUp() {
-        jwtUtil = mock(JWTUtil.class);
-        refreshTokenRepository = mock(RefreshTokenRepository.class);
-        refreshTokenValidator = new RefreshTokenValidator(jwtUtil, refreshTokenRepository);
-    }
 
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
@@ -106,10 +106,6 @@ class RefreshTokenValidatorTest {
     @DisplayName("validateRefreshToken()는 토큰이 만료되면 정해진 예외를 반환한다")
     void validateRefreshToken_expired() {
         // given
-        JWTUtil jwtUtil = mock(JWTUtil.class);
-        RefreshTokenRepository repository = mock(RefreshTokenRepository.class);
-        RefreshTokenValidator validator = new RefreshTokenValidator(jwtUtil, repository);
-
         String token = "expired-refresh-token";
         Cookie cookie = new Cookie("refresh-token", token);
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -121,7 +117,7 @@ class RefreshTokenValidatorTest {
 
         // when & then
         TokenException e = assertThrows(TokenException.class, () ->
-                validator.validateRefreshToken(request)
+                refreshTokenValidator.validateRefreshToken(request)
         );
 
         assertEquals(ErrorCode.REFRESH_TOKEN_EXPIRED, e.getErrorCode());

--- a/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/valid/RefreshTokenValidatorTest.java
@@ -1,0 +1,127 @@
+package or.sopt.houme.domain.user.valid;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.TokenException;
+import or.sopt.houme.global.jwt.JWTUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RefreshTokenValidatorTest {
+
+    private JWTUtil jwtUtil;
+    private RefreshTokenRepository refreshTokenRepository;
+    private RefreshTokenValidator refreshTokenValidator;
+
+
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = mock(JWTUtil.class);
+        refreshTokenRepository = mock(RefreshTokenRepository.class);
+        refreshTokenValidator = new RefreshTokenValidator(jwtUtil, refreshTokenRepository);
+    }
+
+
+    @Test
+    @DisplayName("validateRefreshToken()는 유효한 토큰이 들어오면 회원 id를 반환한다")
+    void validateRefreshToken_success() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        String token = "valid-refresh-token";
+        Cookie cookie = new Cookie("refresh-token", token);
+        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+
+        when(jwtUtil.isExpired(token)).thenReturn(false); // 내부에서 void일 경우 doNothing()
+        when(jwtUtil.getCategory(token)).thenReturn("refresh");
+        when(jwtUtil.getId(token)).thenReturn(123L);
+        when(refreshTokenRepository.existsById(123L)).thenReturn(true);
+
+        // when
+        Long result = refreshTokenValidator.validateRefreshToken(request);
+
+        // then
+        assertEquals(123L, result);
+    }
+
+
+    @Test
+    @DisplayName("validateRefreshToken()는 쿠키를 찾지 못하면 정해진 예외가 발생한다")
+    void validateRefreshToken_cookieNull() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(null);
+
+        TokenException e = assertThrows(TokenException.class, () ->
+                refreshTokenValidator.validateRefreshToken(request)
+        );
+
+        assertEquals(ErrorCode.COOKIE_NULL, e.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("validateRefreshToken()는 쿠키안에 리프레시 토큰이 없다면 정해진 예외를 반환한다")
+    void validateRefreshToken_noRefreshTokenCookie() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(new Cookie[]{new Cookie("other", "abc")});
+
+        TokenException e = assertThrows(TokenException.class, () ->
+                refreshTokenValidator.validateRefreshToken(request)
+        );
+
+        assertEquals(ErrorCode.REFRESH_TOKEN_NULL, e.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("validateRefreshToken()는 서명이 위조된 토큰이 있다면 정해진 예외를 반환한다")
+    void validateRefreshToken_signatureException() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        String token = "invalid-signature-token";
+        Cookie cookie = new Cookie("refresh-token", token);
+        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+
+        doThrow(new io.jsonwebtoken.security.SignatureException("Invalid"))
+                .when(jwtUtil).isExpired(token);
+
+        TokenException e = assertThrows(TokenException.class, () ->
+                refreshTokenValidator.validateRefreshToken(request)
+        );
+
+        assertEquals(ErrorCode.INVALID_SIGNATURE, e.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("validateRefreshToken()는 토큰이 만료되면 정해진 예외를 반환한다")
+    void validateRefreshToken_expired() {
+        // given
+        JWTUtil jwtUtil = mock(JWTUtil.class);
+        RefreshTokenRepository repository = mock(RefreshTokenRepository.class);
+        RefreshTokenValidator validator = new RefreshTokenValidator(jwtUtil, repository);
+
+        String token = "expired-refresh-token";
+        Cookie cookie = new Cookie("refresh-token", token);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+
+        // 만료된 토큰이므로 isExpired 에서 예외를 던지도록 설정
+        doThrow(new ExpiredJwtException(null, null, "Token expired"))
+                .when(jwtUtil).isExpired(token);
+
+        // when & then
+        TokenException e = assertThrows(TokenException.class, () ->
+                validator.validateRefreshToken(request)
+        );
+
+        assertEquals(ErrorCode.REFRESH_TOKEN_EXPIRED, e.getErrorCode());
+    }
+
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #63 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
-  회원의 리프레시 토큰의 유효성을 검증
- 이미지 생성이력을 조회

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 초기 이미지 생성 시, hasGeneratedImage 필드를 true 로 바꾸는 로직이 추가돼야합니다.
- 그리고 그 후에 이미지를 생성할때는 해당 필드가 true 라면 건너뛰는 로직이 필요합니다.


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/5e73ff38-5eba-4ba0-8947-b84311844ea2" />

