### PR TITLE
[FIX] 회원 이미지 생성 이력 조회 API 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.user.service.UserLandingService;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "회원 랜딩페이지 관련 API")
-@Slf4j
 public class UserLandingController {
 
     private final UserLandingService userLandingService;
@@ -29,7 +27,6 @@ public class UserLandingController {
     public ResponseEntity<ApiResponse<Boolean>> checkHasGeneratedImage(HttpServletRequest request) {
 
         Boolean result = userLandingService.getHasGeneratedImage(request);
-        System.out.println(result);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserLandingController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.user.service.UserLandingService;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "회원 랜딩페이지 관련 API")
+@Slf4j
 public class UserLandingController {
 
     private final UserLandingService userLandingService;
@@ -23,10 +25,11 @@ public class UserLandingController {
     @GetMapping("/check-has-generated-image")
     @Operation(summary = "회원 이미지 생성 이력 조회 API",
     description = "회원의 리프레시 토큰의 유효성과 이미지 생성 이력을 조회합니다 <br><br>" +
-            "이미지 생성 이력이 없으면 **false** 있다면 **true** 를 반환합니다")
+            "이미지 생성 이력이 존재하면 **false** 이미지 생성 이력이 존재하지 않거나 리프레시 토큰이 없다면 **true** 를 반환합니다")
     public ResponseEntity<ApiResponse<Boolean>> checkHasGeneratedImage(HttpServletRequest request) {
 
         Boolean result = userLandingService.getHasGeneratedImage(request);
+        System.out.println(result);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -104,6 +104,7 @@ public class OAuthService {
                     .role(Role.ROLE_USER)
                     .socialType(SocialType.KAKAO)
                     .status(UserStatus.ACTIVE)
+                    .hasGeneratedImage(Boolean.FALSE)
                     .build();
 
             userRepository.save(newUser);

--- a/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
@@ -1,13 +1,19 @@
 package or.sopt.houme.domain.user.service;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.domain.user.valid.RefreshTokenValidator;
 import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.TokenException;
 import or.sopt.houme.global.api.handler.UserException;
+import or.sopt.houme.global.jwt.JWTUtil;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,15 +21,49 @@ public class UserLandingServiceImpl implements UserLandingService {
 
     private final UserRepository userRepository;
     private final RefreshTokenValidator refreshTokenValidator;
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public Boolean getHasGeneratedImage(HttpServletRequest request){
 
-        Long findUserIdByRefreshToken = refreshTokenValidator.validateRefreshToken(request);
 
-        User findUser = userRepository.findById(findUserIdByRefreshToken)
+        /**
+         * 리프레시 토큰을 검증해서
+         * 쿠키가 존재하지 않거나 & 리프레시 토큰이 존재하지 않으면
+         *
+         * Boolean.TRUE 를 반환한다
+         * */
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Boolean.TRUE;
+        }
+
+        String refresh = null;
+        for (Cookie cookie : cookies) {
+            if ("refresh-token".equals(cookie.getName())) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            return Boolean.TRUE;
+        }
+
+
+        Long userId = jwtUtil.getId(refresh);
+        if (!refreshTokenRepository.existsById(userId)) {
+            throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
+        }
+
+        User findUser = userRepository.findById(userId)
                 .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        return findUser.getHasGeneratedImage();
+        if (!findUser.getHasGeneratedImage()){
+            return Boolean.TRUE;
+        }
+
+        return Boolean.FALSE;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserLandingServiceImpl.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 public class UserLandingServiceImpl implements UserLandingService {
 
     private final UserRepository userRepository;
-    private final RefreshTokenValidator refreshTokenValidator;
     private final JWTUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -50,6 +49,7 @@ public class UserLandingServiceImpl implements UserLandingService {
         if (refresh == null) {
             return Boolean.TRUE;
         }
+
 
 
         Long userId = jwtUtil.getId(refresh);

--- a/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
+++ b/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class RefreshTokenValidator {
 
     private final JWTUtil jwtUtil;
@@ -32,10 +31,7 @@ public class RefreshTokenValidator {
             }
         }
 
-        log.info("old refresh token: {}", refresh);
         if (refresh == null) throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
-
-        log.info(refresh);
 
         try {
 

--- a/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
+++ b/src/main/java/or/sopt/houme/domain/user/valid/RefreshTokenValidator.java
@@ -35,6 +35,8 @@ public class RefreshTokenValidator {
         log.info("old refresh token: {}", refresh);
         if (refresh == null) throw new TokenException(ErrorCode.REFRESH_TOKEN_NULL);
 
+        log.info(refresh);
+
         try {
 
             jwtUtil.isExpired(refresh);

--- a/src/test/java/or/sopt/houme/domain/user/service/UserLandingServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserLandingServiceImplTest.java
@@ -1,12 +1,16 @@
 package or.sopt.houme.domain.user.service;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.domain.user.service.UserLandingServiceImpl;
 import or.sopt.houme.domain.user.valid.RefreshTokenValidator;
 import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.TokenException;
 import or.sopt.houme.global.api.handler.UserException;
+import or.sopt.houme.global.jwt.JWTUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,46 +32,110 @@ class UserLandingServiceImplTest {
     @Mock
     private RefreshTokenValidator refreshTokenValidator;
 
+    @Mock
+    private JWTUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
     @InjectMocks
     private UserLandingServiceImpl userLandingService;
 
     @Test
-    @DisplayName("getHasGeneratedImage()는 회원의 이미지 생성이력을 Boolean 타입으로 반환 할 수 있다")
-    void getHasGeneratedImage_success() {
-        // given
+    @DisplayName("쿠키가 없으면 true 반환")
+    void getHasGeneratedImage_noCookies_returnsTrue() {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        Long mockUserId = 1L;
+        when(request.getCookies()).thenReturn(null);
 
-        User mockUser = User.builder()
-                .id(mockUserId)
-                .hasGeneratedImage(true)
-                .build();
-
-        when(refreshTokenValidator.validateRefreshToken(request)).thenReturn(mockUserId);
-        when(userRepository.findById(mockUserId)).thenReturn(Optional.of(mockUser));
-
-        // when
         Boolean result = userLandingService.getHasGeneratedImage(request);
 
-        // then
         assertTrue(result);
     }
 
     @Test
-    @DisplayName("getHasGeneratedImage() 는 회원을 찾을 수 없으면 정해진 예외를 반환한다")
-    void getHasGeneratedImage_userNotFound() {
-        // given
+    @DisplayName("리프레시 토큰이 없으면 true 반환")
+    void getHasGeneratedImage_noRefreshToken_returnsTrue() {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        Long mockUserId = 999L;
+        Cookie[] cookies = {new Cookie("other-cookie", "value")};
+        when(request.getCookies()).thenReturn(cookies);
 
-        when(refreshTokenValidator.validateRefreshToken(request)).thenReturn(mockUserId);
-        when(userRepository.findById(mockUserId)).thenReturn(Optional.empty());
+        Boolean result = userLandingService.getHasGeneratedImage(request);
 
-        // when & then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰이 존재하지 않으면 예외 발생")
+    void getHasGeneratedImage_invalidRefreshToken_throwsException() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie[] cookies = {new Cookie("refresh-token", "fakeToken")};
+        when(request.getCookies()).thenReturn(cookies);
+        when(jwtUtil.getId("fakeToken")).thenReturn(1L);
+        when(refreshTokenRepository.existsById(1L)).thenReturn(false);
+
+        TokenException e = assertThrows(TokenException.class, () ->
+                userLandingService.getHasGeneratedImage(request)
+        );
+
+        assertEquals(ErrorCode.REFRESH_TOKEN_NULL, e.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저가 없으면 USER_NOT_FOUND 예외 발생")
+    void getHasGeneratedImage_userNotFound_throwsException() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie[] cookies = {new Cookie("refresh-token", "token")};
+        when(request.getCookies()).thenReturn(cookies);
+        when(jwtUtil.getId("token")).thenReturn(99L);
+        when(refreshTokenRepository.existsById(99L)).thenReturn(true);
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
         UserException e = assertThrows(UserException.class, () ->
                 userLandingService.getHasGeneratedImage(request)
         );
 
         assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저가 이미 이미지를 생성한 경우 false 반환")
+    void getHasGeneratedImage_userHasImage_returnsFalse() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie[] cookies = {new Cookie("refresh-token", "token")};
+        when(request.getCookies()).thenReturn(cookies);
+
+        User mockUser = User.builder()
+                .id(1L)
+                .hasGeneratedImage(true)
+                .build();
+
+        when(jwtUtil.getId("token")).thenReturn(1L);
+        when(refreshTokenRepository.existsById(1L)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        Boolean result = userLandingService.getHasGeneratedImage(request);
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("유저가 이미지를 생성하지 않은 경우 true 반환")
+    void getHasGeneratedImage_userHasNotImage_returnsTrue() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Cookie[] cookies = {new Cookie("refresh-token", "token")};
+        when(request.getCookies()).thenReturn(cookies);
+
+        User mockUser = User.builder()
+                .id(1L)
+                .hasGeneratedImage(false)
+                .build();
+
+        when(jwtUtil.getId("token")).thenReturn(1L);
+        when(refreshTokenRepository.existsById(1L)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        Boolean result = userLandingService.getHasGeneratedImage(request);
+
+        assertTrue(result);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #180 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이전에 리프레시 토큰 검증을 하던 로직을 재활용하다보니, 예기치 못한 예외가 발생

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 리프레시 토큰이 존재하지 않거나, 이미지 생성 이력이 없다면 -> true
- 이미지 생성이력이 존재하면 -> false
- 회원 생성시, 이미지 생성 이력 False 로 초기화

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
