### PR TITLE
[CHORE] 이미지 생성 이력이 없는 경우 예외를 터트리지 않게 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -45,7 +45,6 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public UserImageHistoryListResponse getUserImageHistoryList(User user) {
         User findUser = findUser(user);
-        validateImageHistoryExists(findUser);  // 생성된 이미지 이력이 없으면 예외터짐
         List<UserImageHistoryDTO> histories = userRepository.getUserImageHistory(findUser.getId());
         return UserImageHistoryListResponse.of(histories);
     }
@@ -81,9 +80,5 @@ public class UserServiceImpl implements UserService {
 
     private User findUser(User user) {
         return userRepository.findById(user.getId()).orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private void validateImageHistoryExists(User user) {
-        userRepository.findImageHistoryById(user.getId()).orElseThrow(() -> new UserException(ErrorCode.IMAGE_HISTORY_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #182 

## 📝 Summary

- 마이페이지에서 이미지 생성 이력이 없는 경우 40403 에외가 터지지 않고, 빈 리스트를 응답함.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<img width="197" height="158" alt="image" src="https://github.com/user-attachments/assets/b1ce1c2b-ee4d-44e9-8106-cfa2efbe9392" />
