### PR TITLE
[FIX] 이미지 이력 제공 API에서 생성된 이미지 id도 함께 제공

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/dto/UserImageHistoryDTO.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/dto/UserImageHistoryDTO.java
@@ -4,17 +4,18 @@ import or.sopt.houme.domain.house.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.entity.enums.Form;
 
 public record UserImageHistoryDTO(
+        Long imageId,
         String generatedImageUrl,
         String tasteTag,
         String equilibrium,
         String houseForm
 ) {
-    public static UserImageHistoryDTO of(String generatedImageUrl, String tasteTag, String equilibrium, String houseForm) {
-        return new UserImageHistoryDTO(generatedImageUrl, tasteTag, equilibrium, houseForm);
+    public static UserImageHistoryDTO of(Long imageId, String generatedImageUrl, String tasteTag, String equilibrium, String houseForm) {
+        return new UserImageHistoryDTO(imageId, generatedImageUrl, tasteTag, equilibrium, houseForm);
     }
 
     // ENUM타입으로 받아 String으로 저장
-    public UserImageHistoryDTO(String generatedImageUrl, String tasteTag, Equilibrium equilibrium, Form form) {
-        this(generatedImageUrl, tasteTag, equilibrium.toString(), form.toString());
+    public UserImageHistoryDTO(Long imageId, String generatedImageUrl, String tasteTag, Equilibrium equilibrium, Form form) {
+        this(imageId, generatedImageUrl, tasteTag, equilibrium.toString(), form.toString());
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryImpl.java
@@ -50,6 +50,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         return queryFactory
                 .select(Projections.constructor(
                         UserImageHistoryDTO.class,
+                        generateImage.id,
                         generateImage.url,
                         tag.tagName,
                         house.equilibrium,

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -110,8 +110,8 @@ class UserServiceImplTest {
                 .url("test.png")
                 .build();
         List<UserImageHistoryDTO> mockHistories = List.of(
-                new UserImageHistoryDTO("url1.png", "모던", "5평 이하", "원룸"),
-                new UserImageHistoryDTO("url2.png", "빈티지", "6~10평", "단독주택")
+                new UserImageHistoryDTO(1L, "url1.png", "모던", "5평 이하", "원룸"),
+                new UserImageHistoryDTO(2L, "url2.png", "빈티지", "6~10평", "단독주택")
         );
 
         // 유저조회 -> mockUser반환


### PR DESCRIPTION
## 📣 Related Issue

이미지 이력 제공 API에서 생성된 이미지 id를 제공

- close #194 

## 📝 Summary

- 응답 DTO에 imageId 추가
- 조회 쿼리에서 imageId도 함께 조회하도록 추가

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
