### PR TITLE
[HOTFIX] 이미지 이력 클릭시 결과페이지 api 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/taste/repository/tag/TagRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/taste/repository/tag/TagRepositoryImpl.java
@@ -28,10 +28,23 @@ public class TagRepositoryImpl implements TagRepositoryCustom {
         QHouseTaste houseTaste = QHouseTaste.houseTaste;
 
         return Optional.ofNullable(
+//                queryFactory
+//                        .selectFrom(tag)
+//                        .join(tasteTag).on(tasteTag.tag.eq(tag))
+//                        .join(tasteTag.taste, taste)
+//                        .join(houseTaste).on(houseTaste.taste.eq(taste))
+//                        .join(houseTaste.house, house)
+//                        .join(generateImage).on(generateImage.house.eq(house))
+//                        .where(
+//                                house.user.id.eq(userId),
+//                                generateImage.id.eq(imageId)
+//                        )
+//                        .fetchOne()
                 queryFactory
-                        .selectFrom(tag)
+                        .select(tag)
+                        .from(tag)
                         .join(tasteTag).on(tasteTag.tag.eq(tag))
-                        .join(tasteTag.taste, taste)
+                        .join(taste).on(tasteTag.taste.eq(taste))
                         .join(houseTaste).on(houseTaste.taste.eq(taste))
                         .join(houseTaste.house, house)
                         .join(generateImage).on(generateImage.house.eq(house))
@@ -39,6 +52,12 @@ public class TagRepositoryImpl implements TagRepositoryCustom {
                                 house.user.id.eq(userId),
                                 generateImage.id.eq(imageId)
                         )
+                        .groupBy(tag.id)
+                        .orderBy(
+                                tasteTag.count().desc(),
+                                tag.priority.asc()
+                        )
+                        .limit(1)
                         .fetchOne()
         );
     }

--- a/src/main/java/or/sopt/houme/domain/taste/repository/tag/TagRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/taste/repository/tag/TagRepositoryImpl.java
@@ -52,7 +52,7 @@ public class TagRepositoryImpl implements TagRepositoryCustom {
                                 house.user.id.eq(userId),
                                 generateImage.id.eq(imageId)
                         )
-                        .groupBy(tag.id)
+                        .groupBy(tag.id, tag.priority)
                         .orderBy(
                                 tasteTag.count().desc(),
                                 tag.priority.asc()
@@ -76,7 +76,7 @@ public class TagRepositoryImpl implements TagRepositoryCustom {
                 .join(taste).on(tasteTag.taste.eq(taste))
                 .join(houseTaste).on(houseTaste.taste.eq(taste))
                 .where(houseTaste.house.id.eq(houseId))
-                .groupBy(tag.id)
+                .groupBy(tag.id, tag.priority)
                 .orderBy(
                         tasteTag.count().desc(),
                         tag.priority.asc()


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #215 

## 📝 Summary

- 이미지 이력 클릭시 결과페이지가 올바르게 조회되지 않는 현상을 수정했습니다.
- 쿼리에서 태그의 우선순위에 맞게 하나의 레코드만 조회되지 않는 쿼리를 수정했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
