### PR TITLE
[FEATURE] 이미지 이력 결과 페이지 제공 API에 좋아요 여부 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepository.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepository.java
@@ -3,5 +3,5 @@ package or.sopt.houme.domain.preference.repository;
 import or.sopt.houme.domain.preference.entity.Preference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PreferenceRepository extends JpaRepository<Preference, Long> {
+public interface PreferenceRepository extends JpaRepository<Preference, Long>,PreferenceRepositoryCustom {
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryCustom.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.domain.preference.repository;
+
+import or.sopt.houme.domain.preference.entity.Preference;
+
+public interface PreferenceRepositoryCustom {
+    Preference findPreferenceByUserIdAndImageId(Long userId, Long imageId);
+}

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryCustom.java
@@ -2,6 +2,8 @@ package or.sopt.houme.domain.preference.repository;
 
 import or.sopt.houme.domain.preference.entity.Preference;
 
+import java.util.Optional;
+
 public interface PreferenceRepositoryCustom {
-    Preference findPreferenceByUserIdAndImageId(Long userId, Long imageId);
+    Optional<Preference> findPreferenceByUserIdAndImageId(Long userId, Long imageId);
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -1,0 +1,34 @@
+package or.sopt.houme.domain.preference.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.generateImage.entity.QGenerateImage;
+import or.sopt.houme.domain.house.entity.QHouse;
+import or.sopt.houme.domain.preference.entity.Preference;
+import or.sopt.houme.domain.preference.entity.QPreference;
+import or.sopt.houme.domain.preference.entity.QPromptPreference;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Preference findPreferenceByUserIdAndImageId(Long userId, Long imageId) {
+        QPreference preference = QPreference.preference;
+        QPromptPreference promptPreference = QPromptPreference.promptPreference;
+        QHouse house = QHouse.house;
+        QGenerateImage generateImage = QGenerateImage.generateImage;
+
+        return queryFactory
+                .selectFrom(preference)
+                .join(promptPreference).on(promptPreference.preference.eq(preference))
+                .join(house).on(promptPreference.house.eq(house))
+                .join(generateImage).on(generateImage.house.eq(house))
+                .where(
+                        house.user.id.eq(userId),
+                        generateImage.id.eq(imageId)
+                ).fetchOne();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -9,19 +9,21 @@ import or.sopt.houme.domain.preference.entity.QPreference;
 import or.sopt.houme.domain.preference.entity.QPromptPreference;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Preference findPreferenceByUserIdAndImageId(Long userId, Long imageId) {
+    public Optional<Preference> findPreferenceByUserIdAndImageId(Long userId, Long imageId) {
         QPreference preference = QPreference.preference;
         QPromptPreference promptPreference = QPromptPreference.promptPreference;
         QHouse house = QHouse.house;
         QGenerateImage generateImage = QGenerateImage.generateImage;
 
-        return queryFactory
+        return Optional.ofNullable(queryFactory
                 .selectFrom(preference)
                 .join(promptPreference).on(promptPreference.preference.eq(preference))
                 .join(house).on(promptPreference.house.eq(house))
@@ -29,6 +31,6 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
                 .where(
                         house.user.id.eq(userId),
                         generateImage.id.eq(imageId)
-                ).fetchOne();
+                ).fetchOne());
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/controller/dto/ImageHistoryResultPageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/dto/ImageHistoryResultPageResponse.java
@@ -5,15 +5,17 @@ public record ImageHistoryResultPageResponse(
         String houseForm,
         String tasteTag,
         String name,
-        String generatedImageUrl
+        String generatedImageUrl,
+        boolean isLike
 ) {
     public static ImageHistoryResultPageResponse of(
             String equilibrium,
             String houseForm,
             String tasteTag,
             String name,
-            String generatedImageUrl
+            String generatedImageUrl,
+            boolean isLike
     ) {
-        return new ImageHistoryResultPageResponse(equilibrium, houseForm, tasteTag, name, generatedImageUrl);
+        return new ImageHistoryResultPageResponse(equilibrium, houseForm, tasteTag, name, generatedImageUrl, isLike);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -8,6 +8,8 @@ import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.preference.entity.Preference;
+import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.taste.entity.Tag;
 import or.sopt.houme.domain.taste.repository.tag.TagRepository;
 import or.sopt.houme.domain.user.controller.dto.*;
@@ -33,6 +35,7 @@ public class UserServiceImpl implements UserService {
     private final TagRepository tagRepository;
     private final GenerateImageRepository generateImageRepository;
     private final CreditRepository creditRepository;
+    private final PreferenceRepository preferenceRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -83,8 +86,9 @@ public class UserServiceImpl implements UserService {
         House house = houseRepository.findHouseByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
         Tag tag = tagRepository.findTagByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
         GenerateImage generateImage = generateImageRepository.findGenerateImageByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new GenerateImageException(ErrorCode.NOT_FOUND_GENERATE_IMAGE_ENTITY));
+        Preference preference = preferenceRepository.findPreferenceByUserIdAndImageId(findUser.getId(), imageId);
 
-        return ImageHistoryResultPageResponse.of(house.getEquilibrium().getDescription(), house.getForm().toString(), tag.getTagNameKr(), findUser.getName(), generateImage.getUrl());
+        return ImageHistoryResultPageResponse.of(house.getEquilibrium().getDescription(), house.getForm().toString(), tag.getTagNameKr(), findUser.getName(), generateImage.getUrl(), preference.isLike());
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -86,9 +86,9 @@ public class UserServiceImpl implements UserService {
         House house = houseRepository.findHouseByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
         Tag tag = tagRepository.findTagByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
         GenerateImage generateImage = generateImageRepository.findGenerateImageByUserIdAndImageId(findUser.getId(), imageId).orElseThrow(() -> new GenerateImageException(ErrorCode.NOT_FOUND_GENERATE_IMAGE_ENTITY));
-        Preference preference = preferenceRepository.findPreferenceByUserIdAndImageId(findUser.getId(), imageId);
+        Optional<Preference> preference = preferenceRepository.findPreferenceByUserIdAndImageId(findUser.getId(), imageId);
 
-        return ImageHistoryResultPageResponse.of(house.getEquilibrium().getDescription(), house.getForm().toString(), tag.getTagNameKr(), findUser.getName(), generateImage.getUrl(), preference.isLike());
+        return ImageHistoryResultPageResponse.of(house.getEquilibrium().getDescription(), house.getForm().toString(), tag.getTagNameKr(), findUser.getName(), generateImage.getUrl(), preference.get().isLike());
     }
 
     @Override

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -174,7 +174,7 @@ class UserServiceImplTest {
         given(houseRepository.findHouseByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(house));
         given(tagRepository.findTagByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(tag));
         given(generateImageRepository.findGenerateImageByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(generateImage));
-        given(preferenceRepository.findPreferenceByUserIdAndImageId(userId, imageId)).willReturn(preference);
+        given(preferenceRepository.findPreferenceByUserIdAndImageId(userId, imageId)).willReturn(Optional.ofNullable(preference));
 
         // when
         ImageHistoryResultPageResponse response = userService.getImageHistoryResultPage(user, imageId);

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -8,6 +8,8 @@ import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.entity.enums.Form;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.preference.entity.Preference;
+import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.taste.entity.Tag;
 import or.sopt.houme.domain.taste.repository.tag.TagRepository;
 import or.sopt.houme.domain.user.controller.dto.*;
@@ -17,6 +19,7 @@ import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.*;
 
+import org.assertj.core.api.PredicateAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,13 +39,15 @@ class UserServiceImplTest {
     private final TagRepository tagRepository = mock(TagRepository.class);
     private final GenerateImageRepository generateImageRepository = mock(GenerateImageRepository.class);
     private final CreditRepository creditRepository = mock(CreditRepository.class);
+    private final PreferenceRepository preferenceRepository = mock(PreferenceRepository.class);
 
     private final UserServiceImpl userService = new UserServiceImpl(
             userRepository,
             houseRepository,
             tagRepository,
             generateImageRepository,
-            creditRepository);
+            creditRepository,
+            preferenceRepository);
 
     private User user;
     private House house;
@@ -161,10 +166,15 @@ class UserServiceImplTest {
                 .url("https://example.com/image.png")
                 .build();
 
+        Preference preference = Preference.builder()
+                .isLike(true)
+                .build();
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(houseRepository.findHouseByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(house));
         given(tagRepository.findTagByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(tag));
         given(generateImageRepository.findGenerateImageByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(generateImage));
+        given(preferenceRepository.findPreferenceByUserIdAndImageId(userId, imageId)).willReturn(preference);
 
         // when
         ImageHistoryResultPageResponse response = userService.getImageHistoryResultPage(user, imageId);
@@ -175,6 +185,7 @@ class UserServiceImplTest {
         assertThat(response.tasteTag()).isEqualTo("모던");
         assertThat(response.name()).isEqualTo("테스트유저");
         assertThat(response.generatedImageUrl()).isEqualTo("https://example.com/image.png");
+        assertThat(response.isLike()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #217 

## 📝 Summary

- 클라에서 마이페이지를 통한 이미지 이력 결과 페이지 이동시, 좋아요 유무가 선택되어 있지 않아 어색한 문제 발견
- 결과 페이지 응답시 좋아요 유무도 함께 반환하도록 수정

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
