### PR TITLE
[FIX] 마이페이지의 이미지 생성 이력 조회시 500에러

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -37,7 +37,8 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
         return Optional.ofNullable(queryFactory
                 .selectFrom(generateImage)
                 .where(generateImage.house.id.eq(houseId))
-                .fetchOne());
+                .orderBy(generateImage.createdAt.asc())
+                .fetchFirst());
     }
 
     // 가장 최근 생성된 GenerateImage 1개 가져오기 (생성시간 내림차순, Id 내림차순)

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -110,8 +110,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("유저의 이미지 생성 이력 조회 성공")
-    void getUserImageHistoryList_Success() {
+    @DisplayName("유저의 이미지 생성 이력 조회 성공 - 동일한 houseId에 여러 이미지가 있을 때 첫 번째 것만 반환")
+    void getUserImageHistoryList_MultipleGenerateImages_ReturnsFirst() {
         // given
         Long userId = user.getId();
 
@@ -122,9 +122,22 @@ class UserServiceImplTest {
         given(houseRepository.findValidHouseByUserId(userId))
                 .willReturn(List.of(house));
 
-        // 2. 각 house의 이미지 반환
+        // 2. 동일한 houseId에 여러 이미지가 있다고 가정
+        GenerateImage firstImage = GenerateImage.builder()
+                .id(100L)
+                .url("https://cdn.com/image1.png")
+                .house(house)
+                .build();
+
+        GenerateImage secondImage = GenerateImage.builder()
+                .id(200L)
+                .url("https://cdn.com/image2.png")
+                .house(house)
+                .build();
+
+        // Repository는 결국 fetchFirst() 결과만 반환하므로 "첫 번째 이미지"만 리턴되도록 설정
         given(generateImageRepository.findByHouseId(house.getId()))
-                .willReturn(Optional.ofNullable(generateImage));
+                .willReturn(Optional.of(firstImage));
 
         // 3. 대표 태그 반환
         given(tagRepository.findMostFrequentTagByHouseId(house.getId()))
@@ -138,8 +151,8 @@ class UserServiceImplTest {
         assertThat(response.histories()).hasSize(1);
 
         UserImageHistoryDTO dto = response.histories().get(0);
-        assertThat(dto.imageId()).isEqualTo(100L);
-        assertThat(dto.generatedImageUrl()).isEqualTo("https://cdn.com/image.png");
+        assertThat(dto.imageId()).isEqualTo(100L); // 첫번째 이미지가 선택됨
+        assertThat(dto.generatedImageUrl()).isEqualTo("https://cdn.com/image1.png");
         assertThat(dto.tasteTag()).isEqualTo("모던");
         assertThat(dto.equilibrium()).isEqualTo("5평 이하");
         assertThat(dto.houseForm()).isEqualTo("아파트");


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #252

## 📝 Summary

하나의 houseId, 즉 한번의 이미지 생성 요청시 여러개의 이미지 생성이 된 이력은 마이페이지에서 이미지 생성이력 조회 시도시 'NonUniqueResultException' 예외가 터지고 있었습니다. fetchOne -> fetchFirst로 수정하여 해결했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
