### PR TITLE
[REFACTOR] 생성 및 구현 방식 리팩토링, 이미지 상세 반환 로직 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
@@ -8,8 +8,12 @@ import or.sopt.houme.domain.generateImage.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.dto.response.ImageInfoListResponse;
 import or.sopt.houme.domain.generateImage.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.facade.GenerateImageFacade;
+import or.sopt.houme.domain.generateImage.facade.GenerateImageLikeFacade;
+import or.sopt.houme.domain.house.dto.request.IsLikeRequest;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.GenerateImageException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class GenerateImageController {
 
     private final GenerateImageFacade generateImageFacade;
+    private final GenerateImageLikeFacade generateImageLikeFacade;
 
     @Operation(summary = "자바 스프링을 이용한 이미지 생성 API",
             description = "사용자가 요청한 내용을 기반으로 새로운 이미지를 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다.")
@@ -72,5 +77,20 @@ public class GenerateImageController {
         return ResponseEntity.ok(ApiResponse.ok(fallBackImage));
     }
 
+    @Operation(summary = "생성된 이미지 선호 여부 API",
+            description = "생성된 이미지에 대한 선호도를 받습니다.")
+    @PostMapping("/v1/generated-images/{imageId}/preference")
+    public ResponseEntity<ApiResponse<Void>> generateImagePreference(
+            @PathVariable Long imageId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid IsLikeRequest request
+    ){
+        try {
+            generateImageLikeFacade.isLike(userDetails.getUser(), imageId, request);
+        } catch (InterruptedException e) {
+            throw new GenerateImageException(ErrorCode.GENERATE_IMAGE_INTERRUPT_EXCEPTION);
+        }
 
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
@@ -88,6 +88,7 @@ public class GenerateImageController {
         try {
             generateImageLikeFacade.isLike(userDetails.getUser(), imageId, request);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new GenerateImageException(ErrorCode.GENERATE_IMAGE_INTERRUPT_EXCEPTION);
         }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageLikeFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageLikeFacade.java
@@ -1,4 +1,4 @@
-package or.sopt.houme.domain.house;
+package or.sopt.houme.domain.generateImage.facade;
 
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
@@ -6,7 +6,7 @@ import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.house.dto.request.IsLikeRequest;
 import or.sopt.houme.domain.house.entity.House;
-import or.sopt.houme.domain.preference.service.PromptPreferenceService;
+import or.sopt.houme.domain.preference.service.GenerateImagePreferenceService;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.GenerateImageException;
@@ -19,10 +19,10 @@ import static or.sopt.houme.global.util.constant.OptimisticLockConstant.RETRY_DE
 
 @Component
 @RequiredArgsConstructor
-public class HouseLikeFacade {
+public class GenerateImageLikeFacade {
 
     private final GenerateImageService generateImageService;
-    private final PromptPreferenceService promptPreferenceService;
+    private final GenerateImagePreferenceService generateImagePreferenceService;
 
     // 생성된 이미지 선호도
     public void isLike(User user, Long generatedImageId, IsLikeRequest request) throws InterruptedException {
@@ -40,7 +40,7 @@ public class HouseLikeFacade {
 
         while (retryCount < MAX_RETRIES){
             try {
-                promptPreferenceService.togglePromptPreference(house, request.isLike());
+                generateImagePreferenceService.toggleGenerateImagePreference(generateImage, request.isLike());
                 // 성공시 종료
                 return;
             } catch (OptimisticLockException | DataIntegrityViolationException e){
@@ -53,7 +53,7 @@ public class HouseLikeFacade {
         }
 
         // 재시도 횟수 초과 시 예외 처리
-        throw new GenerateImageException(ErrorCode.PROMPT_RETRY_EXCEPTION);
+        throw new GenerateImageException(ErrorCode.GENERATE_IMAGE_RETRY_EXCEPTION);
     }
 
 }

--- a/src/main/java/or/sopt/houme/domain/house/controller/HouseController.java
+++ b/src/main/java/or/sopt/houme/domain/house/controller/HouseController.java
@@ -4,16 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import or.sopt.houme.domain.house.HouseLikeFacade;
 import or.sopt.houme.domain.house.dto.request.HouseSelectRequest;
-import or.sopt.houme.domain.house.dto.request.IsLikeRequest;
 import or.sopt.houme.domain.house.dto.response.HouseIdResponse;
 import or.sopt.houme.domain.house.dto.response.HouseOptionsResponse;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
-import or.sopt.houme.global.api.ErrorCode;
-import or.sopt.houme.global.api.handler.GenerateImageException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 public class HouseController {
 
     private final HouseService houseService;
-    private final HouseLikeFacade houseLikeFacade;
 
     // 집구조 제공 API
     @Operation(summary = "집구조 제공 API",
@@ -46,20 +41,4 @@ public class HouseController {
         return ResponseEntity.ok(ApiResponse.ok(houseId));
     }
 
-    @Operation(summary = "생성된 이미지 선호 여부 API",
-            description = "생성된 프롬프트에 따른 이미지에 대한 선호도를 받습니다.")
-    @PostMapping("/generated-images/{imageId}/preference")
-    public ResponseEntity<ApiResponse<Void>> generateImagePreference(
-            @PathVariable Long imageId,
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid IsLikeRequest request
-    ){
-        try {
-            houseLikeFacade.isLike(userDetails.getUser(), imageId, request);
-        } catch (InterruptedException e) {
-            throw new GenerateImageException(ErrorCode.PROMPT_INTERRUPT_EXCEPTION);
-        }
-
-        return ResponseEntity.ok(ApiResponse.ok(null));
-    }
 }

--- a/src/main/java/or/sopt/houme/domain/preference/entity/GenerateImagePreference.java
+++ b/src/main/java/or/sopt/houme/domain/preference/entity/GenerateImagePreference.java
@@ -1,0 +1,44 @@
+package or.sopt.houme.domain.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.houme.domain.generateImage.entity.GenerateImage;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "generate_image_preference", uniqueConstraints = {
+        // 하나의 이미지에 하나의 선호도만 존재하도록 설정
+        @UniqueConstraint(name = "uk_prompt_pref_generate_image", columnNames = "generate_image_id")
+})
+public class GenerateImagePreference {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "preference_id", unique = true)
+    private Preference preference;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "generate_image_id")
+    private GenerateImage generateImage;
+
+    // 정적 메서드
+    public static GenerateImagePreference generatePreference(Preference preference, GenerateImage generateImage) {
+        return GenerateImagePreference.builder()
+                .preference(preference)
+                .generateImage(generateImage)
+                .build();
+    }
+
+    @Builder
+    public GenerateImagePreference(Preference preference, GenerateImage generateImage) {
+        this.preference = preference;
+        this.generateImage = generateImage;
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/preference/repository/GenerateImagePreferenceRepository.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/GenerateImagePreferenceRepository.java
@@ -1,0 +1,14 @@
+package or.sopt.houme.domain.preference.repository;
+
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GenerateImagePreferenceRepository extends JpaRepository<GenerateImagePreference, Long> {
+
+    // 이미지에 대한 선호도 최신순으로 가져오기
+    Optional<GenerateImagePreference> findFirstByGenerateImageIdOrderByIdDesc(Long generateImageId);
+}

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -22,13 +22,17 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
         QPreference preference = QPreference.preference;
         QGenerateImagePreference generateImagePreference = QGenerateImagePreference.generateImagePreference;
         QGenerateImage generateImage = QGenerateImage.generateImage;
+        QHouse house = QHouse.house;
+        QUser user = QUser.user;
 
         return Optional.ofNullable(queryFactory
                 .selectFrom(preference) // Preference 엔티티 선택
                 .join(generateImagePreference).on(generateImagePreference.preference.eq(preference)).fetchJoin()
                 .join(generateImage).on(generateImagePreference.generateImage.eq(generateImage)).fetchJoin()
+                .join(house).on(generateImage.house.eq(house)).fetchJoin()
+                .join(user).on(house.user.eq(user)).fetchJoin()
                 .where(
-                        generateImage.house.user.id.eq(userId),
+                        user.id.eq(userId),
                         generateImage.id.eq(imageId)
                 )
                 .fetchOne());

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.generateImage.entity.QGenerateImage;
 import or.sopt.houme.domain.house.entity.QHouse;
 import or.sopt.houme.domain.preference.entity.Preference;
+import or.sopt.houme.domain.preference.entity.QGenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.QPreference;
-import or.sopt.houme.domain.preference.entity.QPromptPreference;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -19,15 +19,15 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
     @Override
     public Optional<Preference> findPreferenceByUserIdAndImageId(Long userId, Long imageId) {
         QPreference preference = QPreference.preference;
-        QPromptPreference promptPreference = QPromptPreference.promptPreference;
+        QGenerateImagePreference generateImagePreference = QGenerateImagePreference.generateImagePreference;
         QHouse house = QHouse.house;
         QGenerateImage generateImage = QGenerateImage.generateImage;
 
         return Optional.ofNullable(queryFactory
                 .selectFrom(preference)
-                .join(promptPreference).on(promptPreference.preference.eq(preference))
-                .join(house).on(promptPreference.house.eq(house))
-                .join(generateImage).on(generateImage.house.eq(house))
+                .join(preference).on(generateImagePreference.preference.eq(preference)).fetchJoin()
+                .join(generateImage).on(generateImagePreference.generateImage.eq(generateImage)).fetchJoin()
+                .join(generateImage).on(generateImage.house.eq(house)).fetchJoin()
                 .where(
                         house.user.id.eq(userId),
                         generateImage.id.eq(imageId)

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -26,15 +26,15 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
         QUser user = QUser.user;
 
         return Optional.ofNullable(queryFactory
-                .select(preference) // Preference 엔티티를 선택
+                .select(preference) // Preference 엔티티 선택
                 .from(generateImagePreference) // generateImagePreference에서 시작
-                .join(generateImagePreference.preference, preference).fetchJoin() // Preference 페치 조인
-                .join(generateImagePreference.generateImage, generateImage).fetchJoin() // GenerateImage 페치 조인
-                .join(generateImage.house, house).fetchJoin() // House 페치 조인
-                .join(house.user, user).fetchJoin() // User 페치 조인 (User 정보가 필요하다면)
+                .join(generateImagePreference.preference, preference).fetchJoin()
+                .join(generateImagePreference.generateImage, generateImage).fetchJoin()
+                .join(generateImage.house, house).fetchJoin()
+                .join(house.user, user).fetchJoin()
                 .where(
-                        user.id.eq(userId), // House의 User ID 조건
-                        generateImage.id.eq(imageId) // GenerateImage ID 조건
+                        user.id.eq(userId),
+                        generateImage.id.eq(imageId)
                 )
                 .fetchOne());
     }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -7,6 +7,7 @@ import or.sopt.houme.domain.house.entity.QHouse;
 import or.sopt.houme.domain.preference.entity.Preference;
 import or.sopt.houme.domain.preference.entity.QGenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.QPreference;
+import or.sopt.houme.domain.user.entity.QUser;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -22,15 +23,19 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
         QGenerateImagePreference generateImagePreference = QGenerateImagePreference.generateImagePreference;
         QHouse house = QHouse.house;
         QGenerateImage generateImage = QGenerateImage.generateImage;
+        QUser user = QUser.user;
 
         return Optional.ofNullable(queryFactory
-                .selectFrom(preference)
-                .join(preference).on(generateImagePreference.preference.eq(preference)).fetchJoin()
-                .join(generateImage).on(generateImagePreference.generateImage.eq(generateImage)).fetchJoin()
-                .join(generateImage).on(generateImage.house.eq(house)).fetchJoin()
+                .select(preference) // Preference 엔티티를 선택
+                .from(generateImagePreference) // generateImagePreference에서 시작
+                .join(generateImagePreference.preference, preference).fetchJoin() // Preference 페치 조인
+                .join(generateImagePreference.generateImage, generateImage).fetchJoin() // GenerateImage 페치 조인
+                .join(generateImage.house, house).fetchJoin() // House 페치 조인
+                .join(house.user, user).fetchJoin() // User 페치 조인 (User 정보가 필요하다면)
                 .where(
-                        house.user.id.eq(userId),
-                        generateImage.id.eq(imageId)
-                ).fetchOne());
+                        user.id.eq(userId), // House의 User ID 조건
+                        generateImage.id.eq(imageId) // GenerateImage ID 조건
+                )
+                .fetchOne());
     }
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PreferenceRepositoryImpl.java
@@ -21,19 +21,14 @@ public class PreferenceRepositoryImpl implements PreferenceRepositoryCustom {
     public Optional<Preference> findPreferenceByUserIdAndImageId(Long userId, Long imageId) {
         QPreference preference = QPreference.preference;
         QGenerateImagePreference generateImagePreference = QGenerateImagePreference.generateImagePreference;
-        QHouse house = QHouse.house;
         QGenerateImage generateImage = QGenerateImage.generateImage;
-        QUser user = QUser.user;
 
         return Optional.ofNullable(queryFactory
-                .select(preference) // Preference 엔티티 선택
-                .from(generateImagePreference) // generateImagePreference에서 시작
-                .join(generateImagePreference.preference, preference).fetchJoin()
-                .join(generateImagePreference.generateImage, generateImage).fetchJoin()
-                .join(generateImage.house, house).fetchJoin()
-                .join(house.user, user).fetchJoin()
+                .selectFrom(preference) // Preference 엔티티 선택
+                .join(generateImagePreference).on(generateImagePreference.preference.eq(preference)).fetchJoin()
+                .join(generateImage).on(generateImagePreference.generateImage.eq(generateImage)).fetchJoin()
                 .where(
-                        user.id.eq(userId),
+                        generateImage.house.user.id.eq(userId),
                         generateImage.id.eq(imageId)
                 )
                 .fetchOne());

--- a/src/main/java/or/sopt/houme/domain/preference/service/GenerateImagePreferenceService.java
+++ b/src/main/java/or/sopt/houme/domain/preference/service/GenerateImagePreferenceService.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.preference.service;
+
+import or.sopt.houme.domain.generateImage.entity.GenerateImage;
+
+public interface GenerateImagePreferenceService {
+
+    // 좋아요 or 싫어요
+    void toggleGenerateImagePreference(GenerateImage generateImage, boolean isLike);
+}

--- a/src/main/java/or/sopt/houme/domain/preference/service/GenerateImagePreferenceServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/service/GenerateImagePreferenceServiceImpl.java
@@ -1,9 +1,12 @@
 package or.sopt.houme.domain.preference.service;
 
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.house.entity.House;
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.Preference;
 import or.sopt.houme.domain.preference.entity.PromptPreference;
+import or.sopt.houme.domain.preference.repository.GenerateImagePreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PromptPreferenceRepository;
 import org.springframework.stereotype.Service;
@@ -14,22 +17,22 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PromptPreferenceServiceImpl implements PromptPreferenceService {
+public class GenerateImagePreferenceServiceImpl implements GenerateImagePreferenceService {
 
-    private final PromptPreferenceRepository promptPreferenceRepository;
     private final PreferenceRepository preferenceRepository;
+    private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
 
     // 좋아요 or 싫어요
     @Transactional
     @Override
-    public void togglePromptPreference(House house, boolean isLike) {
-        // house.id로 기존 선호도 데이터를 조회
-        Optional<PromptPreference> promptPreferenceOptional =
-                promptPreferenceRepository.findFirstByHouseIdOrderByIdDesc(house.getId());
+    public void toggleGenerateImagePreference(GenerateImage generateImage, boolean isLike) {
+        // generateImage.id로 기존 선호도 데이터를 조회
+        Optional<GenerateImagePreference> generateImagePreferenceOptional =
+                generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage.getId());
 
-        if (promptPreferenceOptional.isPresent()) {
+        if (generateImagePreferenceOptional.isPresent()) {
             // 이미 좋아요/싫어요 상태가 있는 경우
-            Preference preference = promptPreferenceOptional.get().getPreference();
+            Preference preference = generateImagePreferenceOptional.get().getPreference();
 
             // 기존 상태와 요청 상태가 다를 경우에만 업데이트
             if (preference.isLike() != isLike) {
@@ -42,8 +45,9 @@ public class PromptPreferenceServiceImpl implements PromptPreferenceService {
             Preference newPreference = Preference.of(isLike);
             preferenceRepository.save(newPreference);
 
-            PromptPreference newPromptPreference = PromptPreference.generatePreference(newPreference, house);
-            promptPreferenceRepository.save(newPromptPreference);
+            GenerateImagePreference newPromptPreference =
+                    GenerateImagePreference.generatePreference(newPreference, generateImage);
+            generateImagePreferenceRepository.save(newPromptPreference);
         }
     }
 

--- a/src/main/java/or/sopt/houme/domain/preference/service/PromptPreferenceService.java
+++ b/src/main/java/or/sopt/houme/domain/preference/service/PromptPreferenceService.java
@@ -1,9 +1,0 @@
-package or.sopt.houme.domain.preference.service;
-
-import or.sopt.houme.domain.house.entity.House;
-
-public interface PromptPreferenceService {
-
-    // 좋아요 or 싫어요
-    void togglePromptPreference(House house, boolean isLike);
-}

--- a/src/main/java/or/sopt/houme/domain/user/controller/dto/ImageHistoriesResultPageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/dto/ImageHistoriesResultPageResponse.java
@@ -15,7 +15,7 @@ public record ImageHistoriesResultPageResponse(
             String tasteTag,
             String name,
             String generatedImageUrl,
-            boolean isLike
+            Boolean isLike
     ) {
         public static ImageHistoryResultPageResponse of(
                 String equilibrium,
@@ -23,7 +23,7 @@ public record ImageHistoriesResultPageResponse(
                 String tasteTag,
                 String name,
                 String generatedImageUrl,
-                boolean isLike
+                Boolean isLike
         ) {
             return new ImageHistoryResultPageResponse(
                     equilibrium, houseForm, tasteTag, name, generatedImageUrl, isLike

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -96,8 +96,6 @@ public class UserServiceImpl implements UserService {
         // 1. house, tag 조회
         House house = houseRepository.findHouseByUserIdAndImageId(findUser.getId(), imageId)
                 .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
-        Tag tag = tagRepository.findTagByUserIdAndImageId(findUser.getId(), imageId)
-                .orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
 
         // 2. houseId 에 해당하는 generateImage 리스트 조회 (오름차순 정렬)
         List<GenerateImage> generateImages = generateImageRepository.findGenerateImagesByHouseId(house.getId());
@@ -106,6 +104,7 @@ public class UserServiceImpl implements UserService {
         }
 
         List<Boolean> likes = new ArrayList<>();
+        List<Tag> tags = new ArrayList<>();
 
         // 3. 최신 GenerateImagePreference 조회 (선호 여부)
         for (GenerateImage generateImage : generateImages) {
@@ -117,6 +116,9 @@ public class UserServiceImpl implements UserService {
             } else {
                 likes.add(null);
             }
+
+            tags.add(tagRepository.findTagByUserIdAndImageId(user.getId(), generateImage.getId())
+                    .orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY)));
         }
 
         // 4. GenerateImage 리스트와 likes 리스트를 함께 사용하여 DTO 변환
@@ -125,7 +127,7 @@ public class UserServiceImpl implements UserService {
                         .mapToObj(i -> {
                             GenerateImage generateImage = generateImages.get(i);
                             Boolean isLike = likes.get(i); // likes 리스트에서 해당 인덱스의 값 가져오기
-
+                            Tag tag = tags.get(i);
                             return ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
                                     house.getEquilibrium().getDescription(),
                                     house.getForm().toString(),

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -8,7 +8,9 @@ import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.PromptPreference;
+import or.sopt.houme.domain.preference.repository.GenerateImagePreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PromptPreferenceRepository;
 import or.sopt.houme.domain.taste.entity.Tag;
@@ -29,6 +31,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +44,7 @@ public class UserServiceImpl implements UserService {
     private final CreditRepository creditRepository;
     private final PreferenceRepository preferenceRepository;
     private final PromptPreferenceRepository promptPreferenceRepository;
+    private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -95,37 +99,42 @@ public class UserServiceImpl implements UserService {
         Tag tag = tagRepository.findTagByUserIdAndImageId(findUser.getId(), imageId)
                 .orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
 
-        // 2. houseId 에 해당하는 generateImage 리스트 조회
+        // 2. houseId 에 해당하는 generateImage 리스트 조회 (오름차순 정렬)
         List<GenerateImage> generateImages = generateImageRepository.findGenerateImagesByHouseId(house.getId());
         if (generateImages.isEmpty()) {
             throw new GenerateImageException(ErrorCode.NOT_FOUND_GENERATE_IMAGE_ENTITY);
         }
 
-       // 3. 최신 PromptPreference 조회 (선호 여부)
-        Optional<PromptPreference> optionalPreference =
-                promptPreferenceRepository.findFirstByHouseIdOrderByIdDesc(house.getId());
+        List<Boolean> likes = new ArrayList<>();
 
-        boolean isLike;
-        if (optionalPreference.isEmpty()) {
-            // null이면 true인 로직
-            isLike = true;
-        } else {
-            PromptPreference preference = optionalPreference.get();
-            // 있으면 PromptPreference를 활용
-            isLike = preference.getPreference().isLike();
+        // 3. 최신 GenerateImagePreference 조회 (선호 여부)
+        for (GenerateImage generateImage : generateImages) {
+            Optional<GenerateImagePreference> optionalGenerateImagePreference =
+                    generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage.getId());
+
+            if (optionalGenerateImagePreference.isPresent()){
+                likes.add(optionalGenerateImagePreference.get().getPreference().isLike());
+            } else {
+                likes.add(null);
+            }
         }
 
-        // 4. GenerateImage 리스트 → DTO 리스트 변환
+        // 4. GenerateImage 리스트와 likes 리스트를 함께 사용하여 DTO 변환
         List<ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse> histories =
-                generateImages.stream()
-                        .map(generateImage -> ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
-                                house.getEquilibrium().getDescription(),
-                                house.getForm().toString(),
-                                tag.getTagNameKr(),
-                                findUser.getName(),
-                                generateImage.getUrl(),
-                                isLike
-                        ))
+                IntStream.range(0, generateImages.size()) // 인덱스를 활용하여 스트림 생성
+                        .mapToObj(i -> {
+                            GenerateImage generateImage = generateImages.get(i);
+                            Boolean isLike = likes.get(i); // likes 리스트에서 해당 인덱스의 값 가져오기
+
+                            return ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
+                                    house.getEquilibrium().getDescription(),
+                                    house.getForm().toString(),
+                                    tag.getTagNameKr(),
+                                    findUser.getName(),
+                                    generateImage.getUrl(),
+                                    isLike
+                            );
+                        })
                         .toList();
 
         // 5. 응답 DTO 생성

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -162,9 +162,9 @@ public enum ErrorCode {
     // DB 관련
     DATA_INTEGRITY_VIOLATION(HttpStatus.INTERNAL_SERVER_ERROR,50015, "데이터 무결성 제약 조건을 위반했습니다. 서버 관리자에게 문의해주세요"),
 
-    // Prompt 좋아요 | 생성된 이미지 관련 예외
-    PROMPT_RETRY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50016,"생성된 이미지 좋아요,싫어요 시도 중 동시성 예외가 발생하였습니다, 서버 개발자에게 문의해주세요"),
-    PROMPT_INTERRUPT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50017,"이미지 API 실행 중, INTERRUPT_EXCEPTION 가 발생하였습니다. 서버 개발자에게 문의해주세요"),
+    // GenerateImage 좋아요 | 생성된 이미지 관련 예외
+    GENERATE_IMAGE_RETRY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50016,"생성된 이미지 좋아요,싫어요 시도 중 동시성 예외가 발생하였습니다, 서버 개발자에게 문의해주세요"),
+    GENERATE_IMAGE_INTERRUPT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50017,"이미지 API 실행 중, INTERRUPT_EXCEPTION 가 발생하였습니다. 서버 개발자에게 문의해주세요"),
 
     // DB 제약조건 위반 에러
     DB_CONSTRAINT_VIOLATION(HttpStatus.INTERNAL_SERVER_ERROR, 50018, "DB 제약조건 문제 발생, 서버 개발자에게 문의해주세요"),

--- a/src/test/java/or/sopt/houme/domain/house/controller/HouseControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/controller/HouseControllerTest.java
@@ -1,6 +1,5 @@
 package or.sopt.houme.domain.house.controller;
 
-import or.sopt.houme.domain.generateImage.facade.HouseLikeFacade;
 import or.sopt.houme.domain.house.dto.HouseOptionDTO;
 import or.sopt.houme.domain.house.dto.response.HouseOptionsResponse;
 import or.sopt.houme.domain.house.service.HouseService;
@@ -38,9 +37,6 @@ class HouseControllerTest {
 
     @MockBean
     private HouseService houseService;
-
-    @MockBean
-    private HouseLikeFacade houseLikeFacade;
 
     @Test
     @WithMockUser   // 인증된 사용자로 요청

--- a/src/test/java/or/sopt/houme/domain/house/controller/HouseControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/controller/HouseControllerTest.java
@@ -1,6 +1,6 @@
 package or.sopt.houme.domain.house.controller;
 
-import or.sopt.houme.domain.house.HouseLikeFacade;
+import or.sopt.houme.domain.generateImage.facade.HouseLikeFacade;
 import or.sopt.houme.domain.house.dto.HouseOptionDTO;
 import or.sopt.houme.domain.house.dto.response.HouseOptionsResponse;
 import or.sopt.houme.domain.house.service.HouseService;

--- a/src/test/java/or/sopt/houme/domain/preference/service/PromptPreferenceServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/preference/service/PromptPreferenceServiceImplTest.java
@@ -1,14 +1,16 @@
 package or.sopt.houme.domain.preference.service;
 
+import or.sopt.houme.domain.generateImage.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.entity.enums.Form;
 import or.sopt.houme.domain.house.entity.enums.Structure;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.Preference;
-import or.sopt.houme.domain.preference.entity.PromptPreference;
+import or.sopt.houme.domain.preference.repository.GenerateImagePreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PreferenceRepository;
-import or.sopt.houme.domain.preference.repository.PromptPreferenceRepository;
 import or.sopt.houme.domain.user.entity.*;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -30,10 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PromptPreferenceServiceImplTest {
 
     @Autowired
-    PromptPreferenceService promptPreferenceService;
-
-    @Autowired
-    PromptPreferenceRepository promptPreferenceRepository;
+    GenerateImagePreferenceRepository generateImagePreferenceRepository;
 
     @Autowired
     PreferenceRepository preferenceRepository;
@@ -43,6 +42,11 @@ class PromptPreferenceServiceImplTest {
 
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    GenerateImagePreferenceService generateImagePreferenceService;
+
+    @Autowired
+    GenerateImageRepository generateImageRepository;
 
     @Test
     @DisplayName("집 도면 좋아요를 생성 할 수 있다.")
@@ -73,13 +77,22 @@ class PromptPreferenceServiceImplTest {
                 .build();
         House saveHouse = houseRepository.save(house);
 
+        GenerateImage generateImage = GenerateImage.builder()
+                .house(saveHouse)
+                .url("https://www.example.com")
+                .fileExtension("JPG")
+                .originalFilename("image.jpg")
+                .filename("image.jpg")
+                .build();
+        GenerateImage saveImage = generateImageRepository.save(generateImage);
+
         // When
-        promptPreferenceService.togglePromptPreference(saveHouse, preference.isLike());
+        generateImagePreferenceService.toggleGenerateImagePreference(saveImage, preference.isLike());
 
         // Then
-        List<PromptPreference> all = promptPreferenceRepository.findAll();
+        List<GenerateImagePreference> all = generateImagePreferenceRepository.findAll();
         assertThat(all.size()).isEqualTo(1);
-        assertThat(all.get(0).getHouse()).isEqualTo(house);
+        assertThat(all.get(0).getGenerateImage()).isEqualTo(saveImage);
         assertThat(all.get(0).getPreference().isLike()).isEqualTo(preference.isLike());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -169,13 +169,14 @@ class UserServiceImplTest {
         // given
         Long userId = 1L;
         Long imageId = 10L;
-
+        Long houseId = 20L;
         User user = User.builder()
                 .id(userId)
                 .name("테스트유저")
                 .build();
 
         House house = House.builder()
+                .id(houseId)
                 .form(Form.OFFICETEL)
                 .equilibrium(Equilibrium.UNDER_5)
                 .build();
@@ -185,30 +186,43 @@ class UserServiceImplTest {
                 .build();
 
         GenerateImage generateImage1 = GenerateImage.builder()
+                .id(1L)
                 .url("https://example.com/image1.png")
+                .house(house)
                 .build();
 
         GenerateImage generateImage2 = GenerateImage.builder()
+                .id(2L)
                 .url("https://example.com/image2.png")
+                .house(house)
                 .build();
 
-        Preference preference = Preference.builder()
-                .isLike(true)
-                .build();
-
-        GenerateImagePreference generateImagePreference = GenerateImagePreference.builder()
-                .preference(preference)
+        GenerateImagePreference generateImagePreference1 = GenerateImagePreference.builder()
+                .preference(Preference.builder().isLike(true).build())
                 .generateImage(generateImage1)
+                .build();
+
+        GenerateImagePreference generateImagePreference2 = GenerateImagePreference.builder()
+                .preference(Preference.builder().isLike(true).build())
+                .generateImage(generateImage2)
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(houseRepository.findHouseByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(house));
-        given(tagRepository.findTagByUserIdAndImageId(userId, imageId)).willReturn(Optional.of(tag));
+
         // generateImages 리스트 2개 반환
         given(generateImageRepository.findGenerateImagesByHouseId(house.getId()))
                 .willReturn(List.of(generateImage1, generateImage2));
+
         given(generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage1.getId()))
-                .willReturn(Optional.of(generateImagePreference));
+                .willReturn(Optional.of(generateImagePreference1));
+        given(generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage2.getId()))
+                .willReturn(Optional.of(generateImagePreference2));
+
+        given(tagRepository.findTagByUserIdAndImageId(userId, generateImage1.getId()))
+                .willReturn(Optional.of(tag));
+        given(tagRepository.findTagByUserIdAndImageId(userId, generateImage2.getId()))
+                .willReturn(Optional.of(tag));
 
         // when
         ImageHistoriesResultPageResponse response = userService.getImageHistoryResultPage(user, imageId);
@@ -255,6 +269,8 @@ class UserServiceImplTest {
                 .willReturn(Optional.of(house));
         given(tagRepository.findTagByUserIdAndImageId(user.getId(), generateImage.getId()))
                 .willReturn(Optional.empty());
+        given(generateImageRepository.findGenerateImagesByHouseId(house.getId()))
+                .willReturn(List.of(generateImage));
 
         // when & then
         assertThatThrownBy(() -> userService.getImageHistoryResultPage(user, generateImage.getId()))

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -8,8 +8,10 @@ import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.entity.enums.Form;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.entity.Preference;
 import or.sopt.houme.domain.preference.entity.PromptPreference;
+import or.sopt.houme.domain.preference.repository.GenerateImagePreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.preference.repository.PromptPreferenceRepository;
 import or.sopt.houme.domain.taste.entity.Tag;
@@ -43,6 +45,7 @@ class UserServiceImplTest {
     private final CreditRepository creditRepository = mock(CreditRepository.class);
     private final PreferenceRepository preferenceRepository = mock(PreferenceRepository.class);
     private final PromptPreferenceRepository  promptPreferenceRepository = mock(PromptPreferenceRepository.class);
+    private final GenerateImagePreferenceRepository generateImagePreferenceRepository = mock(GenerateImagePreferenceRepository.class);
 
     private final UserServiceImpl userService = new UserServiceImpl(
             userRepository,
@@ -51,7 +54,9 @@ class UserServiceImplTest {
             generateImageRepository,
             creditRepository,
             preferenceRepository,
-            promptPreferenceRepository);
+            promptPreferenceRepository,
+            generateImagePreferenceRepository
+            );
 
     private User user;
     private House house;
@@ -191,9 +196,9 @@ class UserServiceImplTest {
                 .isLike(true)
                 .build();
 
-        PromptPreference promptPreference = PromptPreference.builder()
+        GenerateImagePreference generateImagePreference = GenerateImagePreference.builder()
                 .preference(preference)
-                .house(house)
+                .generateImage(generateImage1)
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -202,8 +207,8 @@ class UserServiceImplTest {
         // generateImages 리스트 2개 반환
         given(generateImageRepository.findGenerateImagesByHouseId(house.getId()))
                 .willReturn(List.of(generateImage1, generateImage2));
-        given(promptPreferenceRepository.findFirstByHouseIdOrderByIdDesc(house.getId()))
-                .willReturn(Optional.of(promptPreference));
+        given(generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage1.getId()))
+                .willReturn(Optional.of(generateImagePreference));
 
         // when
         ImageHistoriesResultPageResponse response = userService.getImageHistoryResultPage(user, imageId);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #273 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 생성 및 구현 방식 리팩토링
- 이미지 상세 반환 로직 수정

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
1. 이미지 생성 히스토리 내역 제공같은 경우에는 imageId별로 뿌려주고 있는데, 기획의 변경으로 A안에서는 하나의 요청에 2장의 이미지가 생성되는 결과도 있습니다. 이렇게 된다면 그 두 장의 이미지도 요청이 분리된 것처럼 내려주게 되는 문제가 발생합니다.

2. 그리고 이미지 상세 반환에서는 imageId를 받고, houseId를 찾아서 생성된 이미지를 전부 다 내려줍니다. 그러면 houseId를 받아서 내려주는게 좋아질 것 같습니다.

위의 내용들은 스레드 생성 후 자세히 달겠습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
