### PR TITLE
[FEAT] 찜 기능 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.dto.response.JjymListResponse;
 import or.sopt.houme.domain.furniture.dto.response.JjymToggleResponse;
+import or.sopt.houme.domain.furniture.facade.JjymOptimisticLockFacade;
 import or.sopt.houme.domain.furniture.service.JjymService;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
@@ -20,6 +21,7 @@ public class JjymController {
 
 
     private final JjymService jjymService;
+    private final JjymOptimisticLockFacade jjymOptimisticLockFacade;
 
 
     @Operation(summary = "추천 가구 찜 토글 API", description = "이미 찜이면 해제, 아니면 찜으로 저장합니다")
@@ -28,7 +30,13 @@ public class JjymController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long recommendFurnitureId
     ) {
-        jjymService.jjymToggle(userDetails.getUser().getId(), recommendFurnitureId);
+        try {
+            jjymOptimisticLockFacade.toggle(userDetails.getUser(), recommendFurnitureId);
+        } catch (InterruptedException e) {
+            // 인터럽트 발생 시 런타임으로 전파하여 글로벌 핸들러에서 처리
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Jjym toggle interrupted", e);
+        }
         return ResponseEntity.ok(ApiResponse.ok(new JjymToggleResponse()));
     }
 

--- a/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
@@ -1,0 +1,41 @@
+package or.sopt.houme.domain.furniture.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.Table;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.dto.response.JjymToggleResponse;
+import or.sopt.houme.domain.furniture.service.JjymService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.service.JjymService;
+import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "찜 관련 API")
+public class JjymController {
+
+    private final JjymService jjymService;
+
+    @Operation(summary = "추천 가구 찜 토글 API", description = "이미 찜이면 해제, 아니면 찜으로 저장합니다")
+    @PostMapping("/recommend-furnitures/{recommendFurnitureId}/jjym")
+    public ResponseEntity<ApiResponse<JjymToggleResponse>> toggleJjym(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long recommendFurnitureId
+    ) {
+        jjymService.jjymToggle(userDetails.getUser().getId(), recommendFurnitureId);
+        return ResponseEntity.ok(ApiResponse.ok(
+                new JjymToggleResponse()
+        ));
+    }
+
+
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
@@ -30,14 +30,8 @@ public class JjymController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long recommendFurnitureId
     ) {
-        try {
-            jjymOptimisticLockFacade.toggle(userDetails.getUser(), recommendFurnitureId);
-        } catch (InterruptedException e) {
-            // 인터럽트 발생 시 런타임으로 전파하여 글로벌 핸들러에서 처리
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Jjym toggle interrupted", e);
-        }
-        return ResponseEntity.ok(ApiResponse.ok(new JjymToggleResponse()));
+        boolean favorited = jjymOptimisticLockFacade.toggle(userDetails.getUser(), recommendFurnitureId);
+        return ResponseEntity.ok(ApiResponse.ok(new JjymToggleResponse(favorited)));
     }
 
 

--- a/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/JjymController.java
@@ -1,15 +1,10 @@
 package or.sopt.houme.domain.furniture.controller;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.persistence.Table;
-import lombok.RequiredArgsConstructor;
-import or.sopt.houme.domain.furniture.dto.response.JjymToggleResponse;
-import or.sopt.houme.domain.furniture.service.JjymService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.dto.response.JjymListResponse;
+import or.sopt.houme.domain.furniture.dto.response.JjymToggleResponse;
 import or.sopt.houme.domain.furniture.service.JjymService;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
@@ -23,7 +18,9 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "찜 관련 API")
 public class JjymController {
 
+
     private final JjymService jjymService;
+
 
     @Operation(summary = "추천 가구 찜 토글 API", description = "이미 찜이면 해제, 아니면 찜으로 저장합니다")
     @PostMapping("/recommend-furnitures/{recommendFurnitureId}/jjym")
@@ -32,10 +29,17 @@ public class JjymController {
             @PathVariable Long recommendFurnitureId
     ) {
         jjymService.jjymToggle(userDetails.getUser().getId(), recommendFurnitureId);
-        return ResponseEntity.ok(ApiResponse.ok(
-                new JjymToggleResponse()
-        ));
+        return ResponseEntity.ok(ApiResponse.ok(new JjymToggleResponse()));
     }
 
 
+    @Operation(summary = "내가 찜한 가구 목록 조회 API",
+            description = "찜한 가구의 이미지, 이름, 가구 식별자를 반환합니다.")
+    @GetMapping("/jjyms")
+    public ResponseEntity<ApiResponse<JjymListResponse>> getMyJjyms(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        JjymListResponse response = jjymService.getMyJjyms(userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/external/naverShop/NaverFurnitureProductDto.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/external/naverShop/NaverFurnitureProductDto.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.furniture.dto.external.naverShop;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 
@@ -9,11 +10,22 @@ import java.util.Objects;
 import static or.sopt.houme.global.util.HtmlTextCleaner.clean;
 
 public record NaverFurnitureProductDto(
+
+        @Schema(description = "추천 가구 이미지 url")
         String furnitureProductImageUrl,
+
+        @Schema(description = "추천 가구 구매 사이트 url")
         String furnitureProductSiteUrl,
+
+        @Schema(description = "추천 가구명")
         String furnitureProductName,
+
+        @Schema(description = "추천 가구 판매 회사")
         String furnitureProductMallName,
+
+        @Schema(description = "추천 가구 식별자")
         Long furnitureProductId
+
 ) {
     public static NaverFurnitureProductDto from(Map<String, Object> it) {
         return new NaverFurnitureProductDto(

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymItemResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymItemResponse.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.domain.furniture.dto.response;
+
+import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+
+public record JjymItemResponse(
+        String furnitureProductImageUrl,
+        String furnitureProductName,
+        Long furnitureProductId
+) {
+    public static JjymItemResponse from(RecommendFurniture rf) {
+        return new JjymItemResponse(
+                rf.getFurnitureProductImageUrl(),
+                rf.getFurnitureProductName(),
+                rf.getFurnitureProductId()
+        );
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymItemResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymItemResponse.java
@@ -3,12 +3,14 @@ package or.sopt.houme.domain.furniture.dto.response;
 import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
 
 public record JjymItemResponse(
+        Long id,
         String furnitureProductImageUrl,
         String furnitureProductName,
         Long furnitureProductId
 ) {
     public static JjymItemResponse from(RecommendFurniture rf) {
         return new JjymItemResponse(
+                rf.getId(),
                 rf.getFurnitureProductImageUrl(),
                 rf.getFurnitureProductName(),
                 rf.getFurnitureProductId()

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymListResponse.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.furniture.dto.response;
+
+import java.util.List;
+
+public record JjymListResponse(List<JjymItemResponse> items) {
+    public static JjymListResponse of(List<JjymItemResponse> items) {
+        return new JjymListResponse(items);
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymToggleResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymToggleResponse.java
@@ -1,13 +1,3 @@
 package or.sopt.houme.domain.furniture.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-
-public record JjymToggleResponse() {
-
-
-}
-
+public record JjymToggleResponse(boolean favorited) { }

--- a/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymToggleResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/dto/response/JjymToggleResponse.java
@@ -1,0 +1,13 @@
+package or.sopt.houme.domain.furniture.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+public record JjymToggleResponse() {
+
+
+}
+

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/Jjym.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/Jjym.java
@@ -40,4 +40,7 @@ public class Jjym extends BaseEntity {
                 .recommendFurniture(recommendFurniture)
                 .build();
     }
+
+    @Version
+    private Long version;
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/Jjym.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/Jjym.java
@@ -1,0 +1,43 @@
+package or.sopt.houme.domain.furniture.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.global.entity.BaseEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(
+        name = "jjyms",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_recommend_furniture", columnNames = {"user_id", "recommend_furniture_id"})
+        },
+        indexes = {
+                @Index(name = "idx_jjym_user_id", columnList = "user_id"),
+                @Index(name = "idx_jjym_recommend_furniture_id", columnList = "recommend_furniture_id")
+        }
+)
+public class Jjym extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "recommend_furniture_id", nullable = false)
+    private RecommendFurniture recommendFurniture;
+
+    public static Jjym of(User user, RecommendFurniture recommendFurniture) {
+        return Jjym.builder()
+                .user(user)
+                .recommendFurniture(recommendFurniture)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
@@ -1,0 +1,40 @@
+package or.sopt.houme.domain.furniture.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(name = "recommend_furnitures", indexes = {
+        @Index(name = "idx_furniture_product_id", columnList = "furniture_product_id")
+})
+public class RecommendFurniture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "furniture_product_url")
+    @Comment("추천 가구 이미지 url")
+    private String furnitureProductImageUrl;
+
+    @Column(name = "furniture_product_site_url")
+    @Comment("추천 가구 구매 사이트 url")
+    private String furnitureProductSiteUrl;
+
+    @Column(name = "furniture_product_name")
+    @Comment("추천 가구명")
+    private String furnitureProductName;
+
+    @Column(name = "furniture_product_mall_name")
+    @Comment("추천 가구 판매 회사")
+    private String furnitureProductMallName;
+
+    @Column(name = "furniture_product_id", nullable = false)
+    @Comment("추천 가구 식별자")
+    private Long furnitureProductId;
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
@@ -9,9 +9,18 @@ import org.hibernate.annotations.Comment;
 @Getter
 @Builder
 @Entity
-@Table(name = "recommend_furnitures", indexes = {
-        @Index(name = "idx_furniture_product_id", columnList = "furniture_product_id")
-})
+@Table(
+        name = "recommend_furnitures",
+        indexes = {
+                @Index(name = "idx_furniture_product_id", columnList = "furniture_product_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_furniture_product_id",
+                        columnNames = {"furniture_product_id"}
+                )
+        }
+)
 public class RecommendFurniture {
 
     @Id
@@ -37,4 +46,22 @@ public class RecommendFurniture {
     @Column(name = "furniture_product_id", nullable = false)
     @Comment("추천 가구 식별자")
     private Long furnitureProductId;
+
+
+
+    public RecommendFurniture from(
+            String furnitureProductImageUrl,
+            String furnitureProductSiteUrl,
+            String furnitureProductName,
+            String furnitureProductMallName,
+            Long furnitureProductId
+    ){
+        return RecommendFurniture.builder()
+                .furnitureProductImageUrl(furnitureProductImageUrl)
+                .furnitureProductSiteUrl(furnitureProductSiteUrl)
+                .furnitureProductName(furnitureProductName)
+                .furnitureProductMallName(furnitureProductMallName)
+                .furnitureProductId(furnitureProductId)
+                .build();
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/RecommendFurniture.java
@@ -49,7 +49,7 @@ public class RecommendFurniture {
 
 
 
-    public RecommendFurniture from(
+    public static RecommendFurniture from(
             String furnitureProductImageUrl,
             String furnitureProductSiteUrl,
             String furnitureProductName,

--- a/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
@@ -8,6 +8,7 @@ import or.sopt.houme.domain.furniture.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.furniture.service.ImageHashService;
 import or.sopt.houme.domain.furniture.service.NaverShopService;
+import or.sopt.houme.domain.furniture.service.RecommendFurnitureService;
 import or.sopt.houme.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
@@ -16,9 +17,11 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class FurnitureFacadeImpl implements FurnitureFacade {
+
     private final NaverShopService naverShopService;
     private final ImageHashService imageHashService;
     private final FurnitureService furnitureService;
+    private final RecommendFurnitureService recommendFurnitureService;
 
     @Override
     public FurnitureProductsInfoResponse getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId) {
@@ -32,6 +35,9 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         // 3. FastAPI 호출 → 유사도 기반 상위 상품 리스트만 반환
         List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos =
                 imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), products, 5);
+
+        // 3-1. 최종반환된 리스트를 기반으로 추천가구 엔티티 저장
+        recommendFurnitureService.saveRecommendFurniture(infos);
 
         // 4. 최종 응답 조립 (Facade 책임)
         return FurnitureProductsInfoResponse.of(user.getName(), infos);

--- a/src/main/java/or/sopt/houme/domain/furniture/facade/JjymOptimisticLockFacade.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/facade/JjymOptimisticLockFacade.java
@@ -1,0 +1,36 @@
+package or.sopt.houme.domain.furniture.facade;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.service.JjymServiceImpl;
+import or.sopt.houme.domain.user.entity.User;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import static or.sopt.houme.global.util.constant.OptimisticLockConstant.MAX_RETRIES;
+import static or.sopt.houme.global.util.constant.OptimisticLockConstant.RETRY_DELAY_MS;
+
+@Component
+@RequiredArgsConstructor
+public class JjymOptimisticLockFacade {
+
+    private final JjymServiceImpl jjymService;
+
+    public void toggle(User user, Long recommendFurnitureId) throws InterruptedException {
+        int retryCount = 0;
+        while (retryCount < MAX_RETRIES) {
+            try {
+                jjymService.jjymToggle(user.getId(), recommendFurnitureId);
+                return;
+            } catch (OptimisticLockException | DataIntegrityViolationException e) {
+                long backoffTime = (long) Math.pow(2, retryCount) * RETRY_DELAY_MS;
+                Thread.sleep(backoffTime);
+                retryCount++;
+            }
+        }
+
+        // 마지막까지 실패 시 런타임 예외 전파 (글로벌 핸들러에서 처리)
+        throw new DataIntegrityViolationException("찜 시도가 정해진 횟수를 초과하였습니다");
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/furniture/facade/JjymOptimisticLockFacade.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/facade/JjymOptimisticLockFacade.java
@@ -16,15 +16,19 @@ public class JjymOptimisticLockFacade {
 
     private final JjymServiceImpl jjymService;
 
-    public void toggle(User user, Long recommendFurnitureId) throws InterruptedException {
+    public boolean toggle(User user, Long recommendFurnitureId) {
         int retryCount = 0;
         while (retryCount < MAX_RETRIES) {
             try {
-                jjymService.jjymToggle(user.getId(), recommendFurnitureId);
-                return;
+                return jjymService.jjymToggle(user.getId(), recommendFurnitureId);
             } catch (OptimisticLockException | DataIntegrityViolationException e) {
                 long backoffTime = (long) Math.pow(2, retryCount) * RETRY_DELAY_MS;
-                Thread.sleep(backoffTime);
+                try {
+                    Thread.sleep(backoffTime);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new DataIntegrityViolationException("찜 토글 처리 중 인터럽트가 발생했습니다", ie);
+                }
                 retryCount++;
             }
         }
@@ -33,4 +37,3 @@ public class JjymOptimisticLockFacade {
         throw new DataIntegrityViolationException("찜 시도가 정해진 횟수를 초과하였습니다");
     }
 }
-

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.entity.Jjym;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JjymRepository extends JpaRepository<Jjym, Long> {
+
+    boolean existsByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
+
+    Optional<Jjym> findByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
+
+    void deleteByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
@@ -3,19 +3,6 @@ package or.sopt.houme.domain.furniture.repository;
 import or.sopt.houme.domain.furniture.entity.Jjym;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface JjymRepository extends JpaRepository<Jjym, Long> {
-
-    boolean existsByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
-
-    Optional<Jjym> findByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
-
-    void deleteByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
-
-    @Query("select j from Jjym j join fetch j.recommendFurniture rf where j.user.id = :userId order by j.createdAt desc")
-    List<Jjym> findAllByUserIdWithFurnitureOrderByCreatedAtDesc(@Param("userId") Long userId);
+public interface JjymRepository extends JpaRepository<Jjym, Long>, JjymRepositoryCustom {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
@@ -3,7 +3,10 @@ package or.sopt.houme.domain.furniture.repository;
 import or.sopt.houme.domain.furniture.entity.Jjym;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JjymRepository extends JpaRepository<Jjym, Long> {
 
@@ -12,4 +15,7 @@ public interface JjymRepository extends JpaRepository<Jjym, Long> {
     Optional<Jjym> findByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
 
     void deleteByUser_IdAndRecommendFurniture_Id(Long userId, Long recommendFurnitureId);
+
+    @Query("select j from Jjym j join fetch j.recommendFurniture rf where j.user.id = :userId order by j.createdAt desc")
+    List<Jjym> findAllByUserIdWithFurnitureOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepositoryCustom.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.entity.Jjym;
+
+import java.util.List;
+
+public interface JjymRepositoryCustom {
+
+    List<Jjym> findAllByUserIdWithFurnitureOrderByCreatedAtDesc(Long userId);
+
+    java.util.Optional<Jjym> findByUserIdAndRecommendFurnitureId(Long userId, Long recommendFurnitureId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepositoryImpl.java
@@ -1,0 +1,46 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.entity.Jjym;
+import or.sopt.houme.domain.furniture.entity.QJjym;
+import or.sopt.houme.domain.furniture.entity.QRecommendFurniture;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class JjymRepositoryImpl implements JjymRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Jjym> findAllByUserIdWithFurnitureOrderByCreatedAtDesc(Long userId) {
+        QJjym jjym = QJjym.jjym;
+        QRecommendFurniture rf = QRecommendFurniture.recommendFurniture;
+
+        return queryFactory
+                .selectFrom(jjym)
+                .join(jjym.recommendFurniture, rf).fetchJoin()
+                .where(jjym.user.id.eq(userId))
+                .orderBy(jjym.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public java.util.Optional<Jjym> findByUserIdAndRecommendFurnitureId(Long userId, Long recommendFurnitureId) {
+        QJjym jjym = QJjym.jjym;
+        QRecommendFurniture rf = QRecommendFurniture.recommendFurniture;
+
+        Jjym result = queryFactory
+                .selectFrom(jjym)
+                .join(jjym.recommendFurniture, rf).fetchJoin()
+                .where(
+                        jjym.user.id.eq(userId),
+                        jjym.recommendFurniture.id.eq(recommendFurnitureId)
+                )
+                .fetchOne();
+        return java.util.Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/RecommendFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/RecommendFurnitureRepository.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendFurnitureRepository extends JpaRepository<RecommendFurniture,Long> {
+
+    boolean existsByFurnitureProductId(Long furnitureProductId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
@@ -3,7 +3,7 @@ package or.sopt.houme.domain.furniture.service;
 import or.sopt.houme.domain.furniture.dto.response.JjymListResponse;
 
 public interface JjymService {
-    void jjymToggle(Long userId, Long recommendFurnitureId);
+    boolean jjymToggle(Long userId, Long recommendFurnitureId);
 
     JjymListResponse getMyJjyms(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
@@ -1,0 +1,5 @@
+package or.sopt.houme.domain.furniture.service;
+
+public interface JjymService {
+    void jjymToggle(Long userId, Long recommendFurnitureId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymService.java
@@ -1,5 +1,9 @@
 package or.sopt.houme.domain.furniture.service;
 
+import or.sopt.houme.domain.furniture.dto.response.JjymListResponse;
+
 public interface JjymService {
     void jjymToggle(Long userId, Long recommendFurnitureId);
+
+    JjymListResponse getMyJjyms(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
@@ -37,7 +37,7 @@ public class JjymServiceImpl implements JjymService {
         RecommendFurniture furniture = recommendFurnitureRepository.findById(recommendFurnitureId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE));
 
-        Optional<Jjym> existing = jjymRepository.findByUser_IdAndRecommendFurniture_Id(user.getId(), furniture.getId());
+        Optional<Jjym> existing = jjymRepository.findByUserIdAndRecommendFurnitureId(user.getId(), furniture.getId());
 
         if (existing.isPresent()) {
             // 이미 찜되어 있으면 찜을 해제합니다

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
@@ -3,6 +3,8 @@ package or.sopt.houme.domain.furniture.service;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.entity.Jjym;
 import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.dto.response.JjymItemResponse;
+import or.sopt.houme.domain.furniture.dto.response.JjymListResponse;
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.user.entity.User;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -44,6 +48,20 @@ public class JjymServiceImpl implements JjymService {
             jjymRepository.save(jjym);
         }
 
+
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public JjymListResponse getMyJjyms(Long userId) {
+
+        List<Jjym> jjyms = jjymRepository.findAllByUserIdWithFurnitureOrderByCreatedAtDesc(userId);
+
+        List<JjymItemResponse> items = jjyms.stream()
+                .map(j -> JjymItemResponse.from(j.getRecommendFurniture()))
+                .collect(Collectors.toList());
+
+        return JjymListResponse.of(items);
 
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
@@ -1,0 +1,49 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.entity.Jjym;
+import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import or.sopt.houme.domain.user.entity.User;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JjymServiceImpl implements JjymService {
+
+    private final JjymRepository jjymRepository;
+    private final UserRepository userRepository;
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+
+    @Override
+    public void jjymToggle(Long userId, Long recommendFurnitureId) {
+
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+        RecommendFurniture furniture = recommendFurnitureRepository.findById(recommendFurnitureId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE));
+
+        Optional<Jjym> existing = jjymRepository.findByUser_IdAndRecommendFurniture_Id(user.getId(), furniture.getId());
+
+        if (existing.isPresent()) {
+            // 이미 찜되어 있으면 찜을 해제합니다
+            jjymRepository.delete(existing.get());
+        } else {
+            // 찜이 되어 있지 않으면 찜을 해제합니다
+            Jjym jjym = Jjym.of(user, furniture);
+            jjymRepository.save(jjym);
+        }
+
+
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/JjymServiceImpl.java
@@ -28,9 +28,7 @@ public class JjymServiceImpl implements JjymService {
     private final RecommendFurnitureRepository recommendFurnitureRepository;
 
     @Override
-    public void jjymToggle(Long userId, Long recommendFurnitureId) {
-
-
+    public boolean jjymToggle(Long userId, Long recommendFurnitureId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
@@ -40,15 +38,13 @@ public class JjymServiceImpl implements JjymService {
         Optional<Jjym> existing = jjymRepository.findByUserIdAndRecommendFurnitureId(user.getId(), furniture.getId());
 
         if (existing.isPresent()) {
-            // 이미 찜되어 있으면 찜을 해제합니다
             jjymRepository.delete(existing.get());
+            return false;
         } else {
-            // 찜이 되어 있지 않으면 찜을 해제합니다
             Jjym jjym = Jjym.of(user, furniture);
             jjymRepository.save(jjym);
+            return true;
         }
-
-
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/or/sopt/houme/domain/furniture/service/NaverShopService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/NaverShopService.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.furniture.service;
 
 import feign.FeignException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.client.NaverShopApiClient;
 import or.sopt.houme.domain.furniture.dto.external.naverShop.NaverFurnitureProductDto;
@@ -45,7 +46,7 @@ public class NaverShopService {
             }
 
             // mallName이 "롯데ON"인 상품만 필터링
-            return response.items().stream()
+            List<NaverFurnitureProductDto> responseLists = response.items().stream()
                     // (임시) mallName 필터링 제거
 //                    .filter(item -> {
 //                        Object mallName = item.get("mallName");
@@ -54,6 +55,10 @@ public class NaverShopService {
 //                    })
                     .map(NaverFurnitureProductDto::from)
                     .toList();
+
+
+
+            return responseLists;
 
         } catch (FeignException e) {
             int status = e.status();

--- a/src/main/java/or/sopt/houme/domain/furniture/service/RecommendFurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/RecommendFurnitureService.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.furniture.service;
+
+import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsInfoResponse;
+
+import java.util.List;
+
+public interface RecommendFurnitureService {
+    void saveRecommendFurniture(List<FurnitureProductsInfoResponse.FurnitureProductInfo> requestDto);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/RecommendFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/RecommendFurnitureServiceImpl.java
@@ -1,0 +1,55 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsInfoResponse;
+import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecommendFurnitureServiceImpl implements RecommendFurnitureService {
+
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+
+
+    @Override
+    public void saveRecommendFurniture(List<FurnitureProductsInfoResponse.FurnitureProductInfo> requestDto) {
+
+        saveSingleRecommendFurniture(requestDto);
+    }
+
+
+    /**
+     * 단일 추천 가구를 저장하는 헬퍼 메서드입니다.
+     *
+     * 리스트 형식으로 input을 받아 가구들을 저장합니다
+     * */
+    private void saveSingleRecommendFurniture(List<FurnitureProductsInfoResponse.FurnitureProductInfo> requestDto) {
+
+        for (FurnitureProductsInfoResponse.FurnitureProductInfo furnitureProductInfo : requestDto) {
+
+            boolean existsByFurnitureProductId = recommendFurnitureRepository.existsByFurnitureProductId(furnitureProductInfo.furnitureProductId());
+
+            if (existsByFurnitureProductId) {
+                continue;
+            }
+
+            RecommendFurniture from = RecommendFurniture.from(
+                    furnitureProductInfo.furnitureProductImageUrl(),
+                    furnitureProductInfo.furnitureProductSiteUrl(),
+                    furnitureProductInfo.furnitureProductName(),
+                    furnitureProductInfo.furnitureProductMallName(),
+                    furnitureProductInfo.furnitureProductId()
+            );
+
+            recommendFurnitureRepository.save(from);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #263 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

가구 찜 기능을 구현하였습니다.

동시에 추천 가구를 저장할 수 있는 테이블을 만들고, 찜을 할 수 있는 토글 API를 구현하였습니다.
마이페이지에서 본인이 찜한 가구들을 조회 할 수 있는 API를 구현하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

```
        uniqueConstraints = {
                @UniqueConstraint(name = "uk_user_recommend_furniture", columnNames = {"user_id", "recommend_furniture_id"})
        }
```

찜 엔티티에 userId와 추천 가구 식별자를 복합 유니크 키로 지정하여 같은 값이 중복적으로 저장 할 수 없도록 하였고 동시에,

```
@Component
@RequiredArgsConstructor
public class JjymOptimisticLockFacade {

    private final JjymServiceImpl jjymService;

    public boolean toggle(User user, Long recommendFurnitureId) {
        int retryCount = 0;
        while (retryCount < MAX_RETRIES) {
            try {
                return jjymService.jjymToggle(user.getId(), recommendFurnitureId);
            } catch (OptimisticLockException | DataIntegrityViolationException e) {
                long backoffTime = (long) Math.pow(2, retryCount) * RETRY_DELAY_MS;
                try {
                    Thread.sleep(backoffTime);
                } catch (InterruptedException ie) {
                    Thread.currentThread().interrupt();
                    throw new DataIntegrityViolationException("찜 토글 처리 중 인터럽트가 발생했습니다", ie);
                }
                retryCount++;
            }
        }

        // 마지막까지 실패 시 런타임 예외 전파 (글로벌 핸들러에서 처리)
        throw new DataIntegrityViolationException("찜 시도가 정해진 횟수를 초과하였습니다");
    }
}
```

낙관적 락을 이용하여 동시성 이슈를 해결하고자 하였습니다.
캐러셀 좋아요 토글과 기본 기조가 같습니다.


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

곧 테스트 코드 작성하겠습니다 ㅇㅇ...
