### PR TITLE
[FIX] factor 변수 수정, factor 요인 중복 가능성 제거

### DIFF
--- a/src/main/java/or/sopt/houme/domain/preference/entity/PreferenceFactor.java
+++ b/src/main/java/or/sopt/houme/domain/preference/entity/PreferenceFactor.java
@@ -31,7 +31,11 @@ public class PreferenceFactor {
                 .build();
     }
 
-    // Factor 업데이트
+    /**
+     * PreferenceFactor의 factor를 업데이트합니다.
+     * 주로 중복 factor 제거 시 기존 엔티티를 재사용할 때 사용됩니다.
+     * @param factor 새로운 Factor (null 불가)
+     */
     public void updateFactor(Factor factor) {
         this.factor = factor;
     }

--- a/src/main/java/or/sopt/houme/domain/preference/entity/PreferenceFactor.java
+++ b/src/main/java/or/sopt/houme/domain/preference/entity/PreferenceFactor.java
@@ -30,4 +30,9 @@ public class PreferenceFactor {
                 .factor(factor)
                 .build();
     }
+
+    // Factor 업데이트
+    public void updateFactor(Factor factor) {
+        this.factor = factor;
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/preference/service/FactorServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/preference/service/FactorServiceImpl.java
@@ -52,12 +52,19 @@ public class FactorServiceImpl implements FactorService {
         }
 
         // preferenceFactor 존재 여부 확인
-        Optional<PreferenceFactor> existing = preferenceFactorRepository.findByPreferenceAndFactor(preference, factor);
+        Optional<PreferenceFactor> byPreference = preferenceFactorRepository.findByPreference(preference);
 
         // 매핑 객체를 토글링합니다.
-        if (existing.isPresent()) {
-            // 이미 있으면 삭제 (toggle off)
-            preferenceFactorRepository.delete(existing.get());
+        if (byPreference.isPresent()) {
+            PreferenceFactor preferenceFactor = byPreference.get();
+
+            // 이미 같은값이 있으면 삭제 (toggle off)
+            if (preferenceFactor.getFactor().getId().equals(factor.getId())) {
+                preferenceFactorRepository.delete(preferenceFactor);
+            } else {
+                // 다른 값이라면 업데이트
+                preferenceFactor.updateFactor(factor);
+            }
         } else {
             // 없으면 새로 저장 (toggle on)
             PreferenceFactor preferenceFactor = PreferenceFactor.of(preference, factor);

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -8,8 +8,14 @@ import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.repository.HouseRepository;
-import or.sopt.houme.domain.preference.entity.*;
-import or.sopt.houme.domain.preference.repository.*;
+import or.sopt.houme.domain.preference.entity.Factor;
+import or.sopt.houme.domain.preference.entity.GenerateImagePreference;
+import or.sopt.houme.domain.preference.entity.Preference;
+import or.sopt.houme.domain.preference.entity.PreferenceFactor;
+import or.sopt.houme.domain.preference.repository.FactorRepository;
+import or.sopt.houme.domain.preference.repository.GenerateImagePreferenceRepository;
+import or.sopt.houme.domain.preference.repository.PreferenceFactorRepository;
+import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.taste.entity.Tag;
 import or.sopt.houme.domain.taste.repository.tag.TagRepository;
 import or.sopt.houme.domain.user.controller.dto.ImageHistoriesResultPageResponse;
@@ -27,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -95,7 +100,6 @@ public class UserServiceImpl implements UserService {
         // 1. house, tag 조회
         House house = houseRepository.findHouseByUserIdAndImageId(findUser.getId(), imageId)
                 .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
-        Optional<Preference> preferenceByUserIdAndImageId = preferenceRepository.findPreferenceByUserIdAndImageId(findUser.getId(), imageId);
 
         // 2. houseId 에 해당하는 generateImage 리스트 조회
         List<GenerateImage> generateImages = generateImageRepository.findGenerateImagesByHouseId(house.getId());
@@ -130,7 +134,7 @@ public class UserServiceImpl implements UserService {
 
             // Factor 관련
             if (preference.isPresent()){
-                PreferenceFactor preferenceFactor = preferenceFactorRepository.findByPreference(preferenceByUserIdAndImageId.get())
+                PreferenceFactor preferenceFactor = preferenceFactorRepository.findByPreference(preference.get())
                         .orElse(null);
 
                 if (preferenceFactor != null){

--- a/src/test/java/or/sopt/houme/domain/factor/service/FactorServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/factor/service/FactorServiceImplTest.java
@@ -115,7 +115,7 @@ public class FactorServiceImplTest {
 
         when(preferenceRepository.findPreferenceByUserIdAndImageId(1L, 100L)).thenReturn(Optional.of(preference));
         when(factorRepository.findById(factorId)).thenReturn(Optional.of(factor));
-        when(preferenceFactorRepository.findByPreferenceAndFactor(preference, factor)).thenReturn(Optional.of(existing));
+        when(preferenceFactorRepository.findByPreference(preference)).thenReturn(Optional.of(existing));
 
         // when
         factorService.toggleFactorLog(user, 100L, factorId);
@@ -135,7 +135,7 @@ public class FactorServiceImplTest {
 
         when(preferenceRepository.findPreferenceByUserIdAndImageId(1L, 100L)).thenReturn(Optional.of(preference));
         when(factorRepository.findById(factorId)).thenReturn(Optional.of(factor));
-        when(preferenceFactorRepository.findByPreferenceAndFactor(preference, factor)).thenReturn(Optional.empty());
+        when(preferenceFactorRepository.findByPreference(preference)).thenReturn(Optional.empty());
 
         // when
         factorService.toggleFactorLog(user, 100L, factorId);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #292 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
Factor 변수 오타 수정
Factor 요인 생성 API 중복 가능성 제거

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
기존 요인 선택은
클라이언트에게 받은 `factorId`로 `Factor`를 찾아서 처리했습니다.
하지만, 이 과정에서 해당 `GenerateImage`에 `Factor`가 없으면 새로 추가가 되는 구조로 "중복"이 가능했습니다.

그래서 새로운 `factorId`로 `Factor`를 찾고 `GenerateImage`에 `Factor`가 있고 값이 다르다면, `update` 값이 같으면 `delete`로 흘러가게 수정했습니다. `Factor`가 없는 경우에는 새로 생성하는 흐름입니다!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
