### PR TITLE
[FEAT] 임시 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/address/repository/AddressRepository.java
+++ b/src/main/java/or/sopt/houme/domain/address/repository/AddressRepository.java
@@ -4,5 +4,5 @@ import or.sopt.houme.domain.address.entity.Address;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AddressRepository extends CrudRepository<Address, Long> {
-
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/credit/repository/CreditRepository.java
+++ b/src/main/java/or/sopt/houme/domain/credit/repository/CreditRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CreditRepository extends JpaRepository<Credit, Long>, CreditCustomRepository {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/credit/repository/PaymentBtnClickLogRepository.java
+++ b/src/main/java/or/sopt/houme/domain/credit/repository/PaymentBtnClickLogRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PaymentBtnClickLogRepository extends JpaRepository<PaymentBtnClickLog, Long> {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureRecommendBtnClickLogRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureRecommendBtnClickLogRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FurnitureRecommendBtnClickLogRepository extends JpaRepository<FurnitureRecommendBtnClickLog, Long> {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepository.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GenerateImageRepository extends JpaRepository<GenerateImage, Long>, GenerateImageRepositoryCustom {
+    void deleteByHouseId(Long houseId);
+    void flush();
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/ImageGenerationLogRepository.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/ImageGenerationLogRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageGenerationLogRepository extends JpaRepository<ImageGenerationLog, Long> {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFloorPlanRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFloorPlanRepository.java
@@ -13,4 +13,6 @@ public interface HouseFloorPlanRepository extends JpaRepository<HouseFloorPlan, 
 
     @Query("SELECT hfp FROM HouseFloorPlan hfp WHERE hfp.house.id = :houseId")
     Optional<HouseFloorPlan> findHouseFloorPlanByHouseId(@Param("houseId") Long houseId);
+
+    void deleteByHouseId(Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HouseFurnitureRepository extends JpaRepository<HouseFurniture, Long> {
+    void deleteByHouseId(Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HouseRepository extends JpaRepository<House, Long>, HouseCustomRepository {
-
+    java.util.List<House> findByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseTasteRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseTasteRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HouseTasteRepository extends JpaRepository<HouseTaste, Long> {
+    void deleteByHouseId(Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/InvalidHouseRequestRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/InvalidHouseRequestRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InvalidHouseRequestRepository extends JpaRepository<InvalidHouseRequest, Long> {
-
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/CarouselPreferenceRepository.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/CarouselPreferenceRepository.java
@@ -14,4 +14,7 @@ public interface CarouselPreferenceRepository extends JpaRepository<CarouselPref
 
     @Query("SELECT cp FROM CarouselPreference cp JOIN FETCH cp.preference")
     List<CarouselPreference> findAllWithPreference();
+
+    List<CarouselPreference> findByUserId(Long userId);
+
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/GenerateImagePreferenceRepository.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/GenerateImagePreferenceRepository.java
@@ -5,10 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface GenerateImagePreferenceRepository extends JpaRepository<GenerateImagePreference, Long> {
 
     // 이미지에 대한 선호도 최신순으로 가져오기
     Optional<GenerateImagePreference> findFirstByGenerateImageIdOrderByIdDesc(Long generateImageId);
+
+    // 이미지에 대한 모든 선호도 가져오기 (과거 데이터 정리 목적)
+    List<GenerateImagePreference> findAllByGenerateImageId(Long generateImageId);
+
+    long countByGenerateImageId(Long generateImageId);
 }

--- a/src/main/java/or/sopt/houme/domain/preference/repository/PromptPreferenceRepository.java
+++ b/src/main/java/or/sopt/houme/domain/preference/repository/PromptPreferenceRepository.java
@@ -4,9 +4,11 @@ import or.sopt.houme.domain.preference.entity.PromptPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface PromptPreferenceRepository extends JpaRepository<PromptPreference, Long> {
 
     Optional<PromptPreference> findFirstByHouseIdOrderByIdDesc(Long houseId);
 
+    List<PromptPreference> findAllByHouseId(Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.controller.dto.*;
 import or.sopt.houme.domain.user.entity.Gender;
+import or.sopt.houme.domain.user.service.UserDeletionService;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
@@ -21,7 +22,9 @@ import java.time.LocalDate;
 @RequestMapping("/api/v1")
 @Tag(name = "회원 관련 api")
 public class UserController {
+
     private final UserService userService;
+    private final UserDeletionService userDeletionService;
 
     @GetMapping(value = "/mypage/user")  // 유저의 이름, 사용가능한 크레딧 개수 조회
     @Operation(summary = "마이페이지 기본 정보 제공 API")
@@ -75,7 +78,7 @@ public class UserController {
             "정책 상, 한 번 삭제된 회원은 **절대 되돌릴 수 없으니** 주의해주세요.")
     public ResponseEntity<ApiResponse<String>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        userService.delete(userDetails.getUser().getId());
+        userDeletionService.delete(userDetails.getUser().getId());
 
         return ResponseEntity.ok(ApiResponse.ok("회원이 정상적으로 삭제되었습니다."));
     }

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
@@ -68,4 +68,15 @@ public class UserController {
 
         return ResponseEntity.ok(ApiResponse.ok(username));
     }
+
+    @DeleteMapping("/user")
+    @Operation(summary = "회원 탈퇴 API",
+    description = "회원을 삭제합니다. <br><br>" +
+            "정책 상, 한 번 삭제된 회원은 **절대 되돌릴 수 없으니** 주의해주세요.")
+    public ResponseEntity<ApiResponse<String>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        userService.delete(userDetails.getUser().getId());
+
+        return ResponseEntity.ok(ApiResponse.ok("회원이 정상적으로 삭제되었습니다."));
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
@@ -1,0 +1,156 @@
+package or.sopt.houme.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import or.sopt.houme.domain.house.entity.House;
+import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
+import or.sopt.houme.domain.house.repository.HouseTasteRepository;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
+import or.sopt.houme.domain.generateImage.repository.ImageGenerationLogRepository;
+import or.sopt.houme.domain.preference.repository.*;
+import or.sopt.houme.domain.credit.repository.CreditRepository;
+import or.sopt.houme.domain.credit.repository.PaymentBtnClickLogRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRecommendBtnClickLogRepository;
+import or.sopt.houme.domain.house.repository.InvalidHouseRequestRepository;
+import or.sopt.houme.domain.address.repository.AddressRepository;
+import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.global.config.JWTConfig;
+import or.sopt.houme.global.jwt.JWTUtil;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserDeletionService {
+
+    private final UserRepository userRepository;
+    private final HouseRepository houseRepository;
+    private final HouseFloorPlanRepository houseFloorPlanRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
+    private final HouseTasteRepository houseTasteRepository;
+
+    private final GenerateImageRepository generateImageRepository;
+    private final ImageGenerationLogRepository imageGenerationLogRepository;
+
+    private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
+    private final PromptPreferenceRepository promptPreferenceRepository;
+    private final FactorRepository factorRepository;
+    private final PreferenceRepository preferenceRepository;
+
+    private final CarouselPreferenceRepository carouselPreferenceRepository;
+    private final AddressRepository addressRepository;
+    private final PaymentBtnClickLogRepository paymentBtnClickLogRepository;
+    private final FurnitureRecommendBtnClickLogRepository furnitureRecommendBtnClickLogRepository;
+    private final InvalidHouseRequestRepository invalidHouseRequestRepository;
+    private final CreditRepository creditRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistTokenRepository blacklistTokenRepository;
+    private final JWTUtil jwtUtil;
+    private final JWTConfig jwtConfig;
+
+    public void delete(Long userId) {
+        // 0. 현재 액세스 토큰 블랙리스트 처리 + 리프레시 토큰 제거 (best-effort)
+        try {
+            var attr = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attr != null) {
+                var request = attr.getRequest();
+                String authHeader = request.getHeader(jwtConfig.getHeader());
+                if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                    String accessToken = authHeader.substring(7).trim();
+                    String jti = jwtUtil.getJti(accessToken);
+                    long ttl = jwtUtil.getRemainingExpiration(accessToken);
+                    if (jti != null && ttl > 0) {
+                        blacklistTokenRepository.save(jti, ttl);
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+
+        // 리프레시 토큰 제거
+        try { refreshTokenRepository.deleteById(userId); } catch (Exception ignored) {}
+
+        // 1. 캐러셀 선호도 및 연결된 Preference 삭제
+        var carouselPrefs = carouselPreferenceRepository.findByUserId(userId);
+        if (!carouselPrefs.isEmpty()) {
+            var prefIds = carouselPrefs.stream().map(cp -> cp.getPreference().getId()).toList();
+            carouselPreferenceRepository.deleteAllInBatch(carouselPrefs);
+            prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+            preferenceRepository.deleteAllById(prefIds);
+        }
+
+        // 2. 하우스 관련 데이터 정리 (이미지, 매핑 등)
+        var houses = houseRepository.findByUserId(userId);
+        for (House house : houses) {
+            // 이미지별 선호도/요인/Preference 삭제
+            var images = generateImageRepository.findGenerateImagesByHouseId(house.getId());
+            images.forEach(image -> {
+                var gpList = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
+                if (!gpList.isEmpty()) {
+                    var prefIds = gpList.stream().map(gp -> gp.getPreference().getId()).toList();
+                    generateImagePreferenceRepository.deleteAll(gpList);
+                    generateImagePreferenceRepository.flush();
+                    prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+                    preferenceRepository.deleteAllById(prefIds);
+                    preferenceRepository.flush();
+                }
+                long remain = generateImagePreferenceRepository.countByGenerateImageId(image.getId());
+                if (remain > 0) {
+                    var left = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
+                    generateImagePreferenceRepository.deleteAll(left);
+                    generateImagePreferenceRepository.flush();
+                }
+            });
+            if (!images.isEmpty()) {
+                generateImageRepository.deleteAll(images);
+                generateImageRepository.deleteByHouseId(house.getId());
+                generateImageRepository.flush();
+            }
+
+            // 하우스에 연결된 PromptPreference(집 단위 선호도) 정리
+            var ppList = promptPreferenceRepository.findAllByHouseId(house.getId());
+            if (!ppList.isEmpty()) {
+                var prefIds = ppList.stream().map(pp -> pp.getPreference().getId()).toList();
+                promptPreferenceRepository.deleteAll(ppList);
+                promptPreferenceRepository.flush();
+                prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+                preferenceRepository.deleteAllById(prefIds);
+                preferenceRepository.flush();
+            }
+
+            // 하우스 맵핑 데이터 삭제
+            houseFloorPlanRepository.deleteByHouseId(house.getId());
+            houseFloorPlanRepository.flush();
+            houseFurnitureRepository.deleteByHouseId(house.getId());
+            houseFurnitureRepository.flush();
+            houseTasteRepository.deleteByHouseId(house.getId());
+            houseTasteRepository.flush();
+        }
+        if (!houses.isEmpty()) {
+            generateImageRepository.flush();
+            promptPreferenceRepository.flush();
+            houseFloorPlanRepository.flush();
+            houseFurnitureRepository.flush();
+            houseTasteRepository.flush();
+            houseRepository.deleteAllInBatch(houses);
+        }
+
+        // 3. 유저 직접 참조 로그/데이터 삭제
+        imageGenerationLogRepository.deleteByUserId(userId);
+        invalidHouseRequestRepository.deleteByUserId(userId);
+        addressRepository.deleteByUserId(userId);
+        paymentBtnClickLogRepository.deleteByUserId(userId);
+        furnitureRecommendBtnClickLogRepository.deleteByUserId(userId);
+        creditRepository.deleteByUserId(userId);
+
+        // 4. 마지막으로 유저 삭제
+        userRepository.deleteById(userId);
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/user/service/UserService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserService.java
@@ -20,5 +20,4 @@ public interface UserService {
     // 사용자 이미지 생성 여부 저장
     void updateHasGeneratedImage(User user);
 
-    void delete(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserService.java
@@ -19,4 +19,6 @@ public interface UserService {
 
     // 사용자 이미지 생성 여부 저장
     void updateHasGeneratedImage(User user);
+
+    void delete(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -1,13 +1,19 @@
 package or.sopt.houme.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import or.sopt.houme.domain.credit.entity.Credit;
 import or.sopt.houme.domain.credit.entity.CreditStatus;
 import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
+import or.sopt.houme.domain.generateImage.repository.ImageGenerationLogRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.repository.HouseRepository;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
+import or.sopt.houme.domain.house.repository.HouseTasteRepository;
 import or.sopt.houme.domain.preference.entity.*;
 import or.sopt.houme.domain.preference.repository.*;
 import or.sopt.houme.domain.taste.entity.Tag;
@@ -19,15 +25,23 @@ import or.sopt.houme.domain.user.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.entity.Gender;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
+import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.domain.address.repository.AddressRepository;
+import or.sopt.houme.domain.preference.repository.CarouselPreferenceRepository;
+import or.sopt.houme.domain.credit.repository.PaymentBtnClickLogRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRecommendBtnClickLogRepository;
+import or.sopt.houme.domain.house.repository.InvalidHouseRequestRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.*;
+import or.sopt.houme.global.config.JWTConfig;
+import or.sopt.houme.global.jwt.JWTUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -37,13 +51,28 @@ import java.util.stream.IntStream;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
+    private final HouseFloorPlanRepository houseFloorPlanRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
+    private final HouseTasteRepository houseTasteRepository;
     private final TagRepository tagRepository;
     private final GenerateImageRepository generateImageRepository;
+    private final ImageGenerationLogRepository imageGenerationLogRepository;
     private final CreditRepository creditRepository;
     private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
+    private final PromptPreferenceRepository promptPreferenceRepository;
     private final FactorRepository factorRepository;
     private final PreferenceRepository preferenceRepository;
     private final PreferenceFactorRepository preferenceFactorRepository;
+    private final AddressRepository addressRepository;
+    private final CarouselPreferenceRepository carouselPreferenceRepository;
+    private final PaymentBtnClickLogRepository paymentBtnClickLogRepository;
+    private final FurnitureRecommendBtnClickLogRepository furnitureRecommendBtnClickLogRepository;
+    private final InvalidHouseRequestRepository invalidHouseRequestRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistTokenRepository blacklistTokenRepository;
+    private final JWTUtil jwtUtil;
+    private final JWTConfig jwtConfig;
 
     @Override
     @Transactional(readOnly = true)
@@ -199,7 +228,117 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
     }
 
+    @Override
+    public void delete(Long userId){
+        // 0. 현재 액세스 토큰 블랙리스트 처리 + 리프레시 토큰 제거 (best-effort)
+        try {
+            var attr = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attr != null) {
+                var request = attr.getRequest();
+                String authHeader = request.getHeader(jwtConfig.getHeader());
+                if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                    String accessToken = authHeader.substring(7).trim();
+                    String jti = jwtUtil.getJti(accessToken);
+                    long ttl = jwtUtil.getRemainingExpiration(accessToken);
+                    if (jti != null && ttl > 0) {
+                        blacklistTokenRepository.save(jti, ttl);
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+
+        // 리프레시 토큰 제거
+        try { refreshTokenRepository.deleteById(userId); } catch (Exception ignored) {}
+
+        // 1. 캐러셀 선호도 및 연결된 Preference 삭제
+        var carouselPrefs = carouselPreferenceRepository.findByUserId(userId);
+        if (!carouselPrefs.isEmpty()) {
+            var prefIds = carouselPrefs.stream()
+                    .map(cp -> cp.getPreference().getId())
+                    .toList();
+            carouselPreferenceRepository.deleteAllInBatch(carouselPrefs);
+            prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+            preferenceRepository.deleteAllById(prefIds);
+        }
+
+        // 2. 하우스 관련 데이터 정리 (이미지, 매핑 등)
+        var houses = houseRepository.findByUserId(userId);
+        for (House house : houses) {
+            // 이미지별 선호도/요인/Preference 삭제
+            var images = generateImageRepository.findGenerateImagesByHouseId(house.getId());
+            images.forEach(image -> {
+                var gpList = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
+                if (!gpList.isEmpty()) {
+                    var prefIds = gpList.stream().map(gp -> gp.getPreference().getId()).toList();
+                    // 매핑을 개별 삭제(배치 삭제로 인한 flush 순서 이슈 회피)
+                    generateImagePreferenceRepository.deleteAll(gpList);
+                    generateImagePreferenceRepository.flush();
+                    // 요인/선호 삭제
+                    prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+                    preferenceRepository.deleteAllById(prefIds);
+                    preferenceRepository.flush();
+                }
+
+                // 안전장치: 남아있는 매핑이 있다면 한 번 더 제거 시도
+                long remain = generateImagePreferenceRepository.countByGenerateImageId(image.getId());
+                if (remain > 0) {
+                    var left = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
+                    generateImagePreferenceRepository.deleteAll(left);
+                    generateImagePreferenceRepository.flush();
+                }
+            });
+            if (!images.isEmpty()) {
+                // 배치 삭제 대신 순차 삭제로 FK 안정성 확보
+                generateImageRepository.deleteAll(images);
+                // 혹시 남아있을 수 있는 이미지 일괄 삭제 (안전망)
+                generateImageRepository.deleteByHouseId(house.getId());
+                generateImageRepository.flush();
+            }
+
+            // 하우스에 연결된 PromptPreference(집 단위 선호도) 정리
+            var ppList = promptPreferenceRepository.findAllByHouseId(house.getId());
+            if (!ppList.isEmpty()) {
+                var prefIds = ppList.stream().map(pp -> pp.getPreference().getId()).toList();
+                promptPreferenceRepository.deleteAll(ppList);
+                promptPreferenceRepository.flush();
+                prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
+                preferenceRepository.deleteAllById(prefIds);
+                preferenceRepository.flush();
+            }
+
+            // 하우스 맵핑 데이터 삭제
+            houseFloorPlanRepository.deleteByHouseId(house.getId());
+            houseFloorPlanRepository.flush();
+            houseFurnitureRepository.deleteByHouseId(house.getId());
+            houseFurnitureRepository.flush();
+            houseTasteRepository.deleteByHouseId(house.getId());
+            houseTasteRepository.flush();
+        }
+        if (!houses.isEmpty()) {
+            // 이미지 삭제가 DB에 반영된 이후 하우스 삭제
+            // 매핑/이미지 삭제가 확실히 반영되도록 마지막 플러시
+            generateImageRepository.flush();
+            promptPreferenceRepository.flush();
+            houseFloorPlanRepository.flush();
+            houseFurnitureRepository.flush();
+            houseTasteRepository.flush();
+            houseRepository.deleteAllInBatch(houses);
+        }
+
+        // 3. 유저 직접 참조 로그/데이터 삭제
+        imageGenerationLogRepository.deleteByUserId(userId);
+        invalidHouseRequestRepository.deleteByUserId(userId);
+        addressRepository.deleteByUserId(userId);
+        paymentBtnClickLogRepository.deleteByUserId(userId);
+        furnitureRecommendBtnClickLogRepository.deleteByUserId(userId);
+        creditRepository.deleteByUserId(userId);
+
+        // 4. 마지막으로 유저 삭제
+        userRepository.deleteById(userId);
+    }
+
     private User findUser(User user) {
         return userRepository.findById(user.getId()).orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
     }
+
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -1,19 +1,13 @@
 package or.sopt.houme.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import or.sopt.houme.domain.credit.entity.Credit;
 import or.sopt.houme.domain.credit.entity.CreditStatus;
 import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
-import or.sopt.houme.domain.generateImage.repository.ImageGenerationLogRepository;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.repository.HouseRepository;
-import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
-import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
-import or.sopt.houme.domain.house.repository.HouseTasteRepository;
 import or.sopt.houme.domain.preference.entity.*;
 import or.sopt.houme.domain.preference.repository.*;
 import or.sopt.houme.domain.taste.entity.Tag;
@@ -25,17 +19,8 @@ import or.sopt.houme.domain.user.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.entity.Gender;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.repository.UserRepository;
-import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
-import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
-import or.sopt.houme.domain.address.repository.AddressRepository;
-import or.sopt.houme.domain.preference.repository.CarouselPreferenceRepository;
-import or.sopt.houme.domain.credit.repository.PaymentBtnClickLogRepository;
-import or.sopt.houme.domain.furniture.repository.FurnitureRecommendBtnClickLogRepository;
-import or.sopt.houme.domain.house.repository.InvalidHouseRequestRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.*;
-import or.sopt.houme.global.config.JWTConfig;
-import or.sopt.houme.global.jwt.JWTUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,30 +34,16 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 @Transactional
 public class UserServiceImpl implements UserService {
+
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
-    private final HouseFloorPlanRepository houseFloorPlanRepository;
-    private final HouseFurnitureRepository houseFurnitureRepository;
-    private final HouseTasteRepository houseTasteRepository;
     private final TagRepository tagRepository;
     private final GenerateImageRepository generateImageRepository;
-    private final ImageGenerationLogRepository imageGenerationLogRepository;
     private final CreditRepository creditRepository;
     private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
-    private final PromptPreferenceRepository promptPreferenceRepository;
     private final FactorRepository factorRepository;
     private final PreferenceRepository preferenceRepository;
     private final PreferenceFactorRepository preferenceFactorRepository;
-    private final AddressRepository addressRepository;
-    private final CarouselPreferenceRepository carouselPreferenceRepository;
-    private final PaymentBtnClickLogRepository paymentBtnClickLogRepository;
-    private final FurnitureRecommendBtnClickLogRepository furnitureRecommendBtnClickLogRepository;
-    private final InvalidHouseRequestRepository invalidHouseRequestRepository;
-
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final BlacklistTokenRepository blacklistTokenRepository;
-    private final JWTUtil jwtUtil;
-    private final JWTConfig jwtConfig;
 
     @Override
     @Transactional(readOnly = true)
@@ -226,115 +197,6 @@ public class UserServiceImpl implements UserService {
         user.updateHasGeneratedImage();
 
         userRepository.save(user);
-    }
-
-    @Override
-    public void delete(Long userId){
-        // 0. 현재 액세스 토큰 블랙리스트 처리 + 리프레시 토큰 제거 (best-effort)
-        try {
-            var attr = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            if (attr != null) {
-                var request = attr.getRequest();
-                String authHeader = request.getHeader(jwtConfig.getHeader());
-                if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                    String accessToken = authHeader.substring(7).trim();
-                    String jti = jwtUtil.getJti(accessToken);
-                    long ttl = jwtUtil.getRemainingExpiration(accessToken);
-                    if (jti != null && ttl > 0) {
-                        blacklistTokenRepository.save(jti, ttl);
-                    }
-                }
-            }
-        } catch (Exception ignored) {}
-
-        // 리프레시 토큰 제거
-        try { refreshTokenRepository.deleteById(userId); } catch (Exception ignored) {}
-
-        // 1. 캐러셀 선호도 및 연결된 Preference 삭제
-        var carouselPrefs = carouselPreferenceRepository.findByUserId(userId);
-        if (!carouselPrefs.isEmpty()) {
-            var prefIds = carouselPrefs.stream()
-                    .map(cp -> cp.getPreference().getId())
-                    .toList();
-            carouselPreferenceRepository.deleteAllInBatch(carouselPrefs);
-            prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
-            preferenceRepository.deleteAllById(prefIds);
-        }
-
-        // 2. 하우스 관련 데이터 정리 (이미지, 매핑 등)
-        var houses = houseRepository.findByUserId(userId);
-        for (House house : houses) {
-            // 이미지별 선호도/요인/Preference 삭제
-            var images = generateImageRepository.findGenerateImagesByHouseId(house.getId());
-            images.forEach(image -> {
-                var gpList = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
-                if (!gpList.isEmpty()) {
-                    var prefIds = gpList.stream().map(gp -> gp.getPreference().getId()).toList();
-                    // 매핑을 개별 삭제(배치 삭제로 인한 flush 순서 이슈 회피)
-                    generateImagePreferenceRepository.deleteAll(gpList);
-                    generateImagePreferenceRepository.flush();
-                    // 요인/선호 삭제
-                    prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
-                    preferenceRepository.deleteAllById(prefIds);
-                    preferenceRepository.flush();
-                }
-
-                // 안전장치: 남아있는 매핑이 있다면 한 번 더 제거 시도
-                long remain = generateImagePreferenceRepository.countByGenerateImageId(image.getId());
-                if (remain > 0) {
-                    var left = generateImagePreferenceRepository.findAllByGenerateImageId(image.getId());
-                    generateImagePreferenceRepository.deleteAll(left);
-                    generateImagePreferenceRepository.flush();
-                }
-            });
-            if (!images.isEmpty()) {
-                // 배치 삭제 대신 순차 삭제로 FK 안정성 확보
-                generateImageRepository.deleteAll(images);
-                // 혹시 남아있을 수 있는 이미지 일괄 삭제 (안전망)
-                generateImageRepository.deleteByHouseId(house.getId());
-                generateImageRepository.flush();
-            }
-
-            // 하우스에 연결된 PromptPreference(집 단위 선호도) 정리
-            var ppList = promptPreferenceRepository.findAllByHouseId(house.getId());
-            if (!ppList.isEmpty()) {
-                var prefIds = ppList.stream().map(pp -> pp.getPreference().getId()).toList();
-                promptPreferenceRepository.deleteAll(ppList);
-                promptPreferenceRepository.flush();
-                prefIds.forEach(factorRepository::findPreferenceFactorAndDeleteByPreferenceId);
-                preferenceRepository.deleteAllById(prefIds);
-                preferenceRepository.flush();
-            }
-
-            // 하우스 맵핑 데이터 삭제
-            houseFloorPlanRepository.deleteByHouseId(house.getId());
-            houseFloorPlanRepository.flush();
-            houseFurnitureRepository.deleteByHouseId(house.getId());
-            houseFurnitureRepository.flush();
-            houseTasteRepository.deleteByHouseId(house.getId());
-            houseTasteRepository.flush();
-        }
-        if (!houses.isEmpty()) {
-            // 이미지 삭제가 DB에 반영된 이후 하우스 삭제
-            // 매핑/이미지 삭제가 확실히 반영되도록 마지막 플러시
-            generateImageRepository.flush();
-            promptPreferenceRepository.flush();
-            houseFloorPlanRepository.flush();
-            houseFurnitureRepository.flush();
-            houseTasteRepository.flush();
-            houseRepository.deleteAllInBatch(houses);
-        }
-
-        // 3. 유저 직접 참조 로그/데이터 삭제
-        imageGenerationLogRepository.deleteByUserId(userId);
-        invalidHouseRequestRepository.deleteByUserId(userId);
-        addressRepository.deleteByUserId(userId);
-        paymentBtnClickLogRepository.deleteByUserId(userId);
-        furnitureRecommendBtnClickLogRepository.deleteByUserId(userId);
-        creditRepository.deleteByUserId(userId);
-
-        // 4. 마지막으로 유저 삭제
-        userRepository.deleteById(userId);
     }
 
     private User findUser(User user) {

--- a/src/test/java/or/sopt/houme/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.user.controller.dto.CustomUserDetailsService;
 import or.sopt.houme.domain.user.controller.dto.MyPageInfoResponse;
 import or.sopt.houme.domain.user.entity.*;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
+import or.sopt.houme.domain.user.service.UserDeletionService;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.config.JWTConfig;
 import or.sopt.houme.global.jwt.JWTUtil;
@@ -47,6 +48,9 @@ class UserControllerTest {
 
     @MockBean
     private UserService userService;
+
+    @MockBean
+    private UserDeletionService userDeletionService;
 
     @MockBean
     private JWTConfig jwtConfig;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #264 

## 📝 Summary

회원 탈퇴 API를 임시로 구현하였습니다.
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

기획 의도에 맞추어 HARD DELETE로 구현하였습니다. cascade로 삭제를 전파시키는게 가장 이상적인 방법이지만, 설계초반 거기까지 고려하지 못해버린 이슈가 있습니다. (너무나 치명적;)

출시가 얼마 남지 않은 시점에서 cascade를 설정하고 적용하는 데에는 조금 리스크가 있을 것이라고 생각되어 모든 연관관계를 수동으로 삭제 후 회원을 삭제하는 로직을 구현하였습니다.
그에따라 너무 의존관계가 꼬여버려서 클래스도 분리했어요.

+) 데이터베이스 dump 파일을 만들어서 로컬에 붙이는 스크립트를 저번 피처 구현하면서 만들었는데, 혹시 필요하신 분 있으면 공유하겠습니다.

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

