### PR TITLE
[CHORE] 가구 영단어 교집합 비교를 object365_word에서 furniture_name_eng로 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/FurnitureController.java
@@ -55,7 +55,20 @@ public class FurnitureController {
     }
 
     @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
-            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다.")
+            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다." +
+                    "- 가구 영단어\n" +
+                    "- 침대(모든 종류) : SINGLE\n" +
+                    "- 업무용 책상 : OFFICE_DESK\n" +
+                    "- 옷장 : CLOSET\n" +
+                    "- 식탁 : DINING_TABLE\n" +
+                    "- 1인용 : SINGLE_SOFA\n" +
+                    "- 수납장 : DRAWER\n" +
+                    "- 이동식 TV : MOVABLE_TV\n" +
+                    "- 좌식 테이블 : SITTING_TABLE\n" +
+                    "- 전신 거울 : MIRROR\n" +
+                    "- 책 선반 : WHITE_BOOKSHELF\n" +
+                    "- 장식장 : DISPLAY_CABINET\n" +
+                    "- 2인용 : TWO_SEATER_SOFA")
     @GetMapping("/generated-images/{imageId}/curations/products/{categoryId}")
     public ResponseEntity<ApiResponse<FurnitureProductsInfoResponse>> getFurnitureProductInfoFromNaverApi(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @PathVariable Long categoryId) {
         FurnitureProductsInfoResponse response = furnitureFacade.getFurnitureProductInfoFromNaverApi(userDetails.getUser(), imageId, categoryId);

--- a/src/main/java/or/sopt/houme/domain/furniture/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/controller/FurnitureController.java
@@ -46,16 +46,7 @@ public class FurnitureController {
 
     @Operation(summary = "생성된 이미지에서 가구 카테고리 조회 API",
             description = "생성된 이미지에서 소파, 침대, 스탠드, 러그와 같은 카테고리를 제공합니다.\n" +
-                    "각 가구 카테고리의 순서는 스타일에 따라 다릅니다.")
-    @GetMapping("/generated-images/{imageId}/curations/categories")
-    public ResponseEntity<ApiResponse<FurnitureCategoriesResponse>> getFurnitureCategories(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @RequestParam List<String> detectedObjects) {
-        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyle(userDetails.getUser(), imageId, detectedObjects);
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
-    }
-
-    @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
-            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다." +
+                    "각 가구 카테고리의 순서는 스타일에 따라 다릅니다.\n" +
                     "- 가구 영단어\n" +
                     "- 침대(모든 종류) : SINGLE\n" +
                     "- 업무용 책상 : OFFICE_DESK\n" +
@@ -69,6 +60,15 @@ public class FurnitureController {
                     "- 책 선반 : WHITE_BOOKSHELF\n" +
                     "- 장식장 : DISPLAY_CABINET\n" +
                     "- 2인용 : TWO_SEATER_SOFA")
+    @GetMapping("/generated-images/{imageId}/curations/categories")
+    public ResponseEntity<ApiResponse<FurnitureCategoriesResponse>> getFurnitureCategories(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @RequestParam List<String> detectedObjects) {
+        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyle(userDetails.getUser(), imageId, detectedObjects);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
+            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다.")
     @GetMapping("/generated-images/{imageId}/curations/products/{categoryId}")
     public ResponseEntity<ApiResponse<FurnitureProductsInfoResponse>> getFurnitureProductInfoFromNaverApi(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @PathVariable Long categoryId) {
         FurnitureProductsInfoResponse response = furnitureFacade.getFurnitureProductInfoFromNaverApi(userDetails.getUser(), imageId, categoryId);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -101,14 +101,14 @@ public class FurnitureServiceImpl implements FurnitureService {
         House house = houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId).orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
         List<Furniture> selectedFurnitures = furnitureRepository.findAllByHouseId(house.getId());
 
-        // 3. 2번 과정에서 생성된 selectedFurnitures의 'object365Word' 필드와 FurnitureCategoriesRequest의 furnitureNames를 비교하여 교집합 산출
+        // 3. 2번 과정에서 생성된 selectedFurnitures의 'furniture_name_eng' 필드와 FurnitureCategoriesRequest의 furnitureNames를 비교하여 교집합 산출
         Set<String> requestedObjects = detectedObjects.stream()
                 .map(String::toLowerCase) // 소문자로 변환
                 .collect(Collectors.toSet());
 
         List<Furniture> intersectedFurnitures = selectedFurnitures.stream()
-                .filter(f -> f.getObject365Word() != null
-                        && requestedObjects.contains(f.getObject365Word().toLowerCase()))  // 소문자로 비교하기
+                .filter(f -> f.getFurnitureNameEng() != null
+                        && requestedObjects.contains(f.getFurnitureNameEng().toLowerCase()))  // 소문자로 비교하기
                 .toList();
 
         // 4. 교집합으로 산출된 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -163,25 +163,25 @@ class FurnitureServiceImplTest {
         Furniture bed = Furniture.builder()
                 .id(1L)
                 .furnitureNameKr("침대")
-                .object365Word("Bed")
+                .furnitureNameEng("Bed")
                 .build();
 
         Furniture chair = Furniture.builder()
                 .id(2L)
                 .furnitureNameKr("의자")
-                .object365Word("Chair")
+                .furnitureNameEng("Chair")
                 .build();
 
         Furniture tv = Furniture.builder()
                 .id(3L)
                 .furnitureNameKr("TV")
-                .object365Word("Monitor/TV")
+                .furnitureNameEng("Monitor/TV")
                 .build();
 
         Furniture dining = Furniture.builder()
                 .id(4L)
                 .furnitureNameKr("식탁")
-                .object365Word("Dining Table")
+                .furnitureNameEng("Dining Table")
                 .build();
 
         // 레포지토리 Stubbing


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #330 

## 📝 Summary

- 가구 교집합을 위해 클라이언트에게 받은 영단어를 furniture_name_eng와 비교하도록 수정했습니다.
- furnitures 테이블의 가구 영단어를 통일화하였고 중복을 없앴습니다.
- 수정된 가구 영단어를 스웨거 설명란에 정리하여 추가했습니다.
<img width="411" height="429" alt="image" src="https://github.com/user-attachments/assets/d7ae7960-b4b2-4359-aac6-c8e0162df6cc" />


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
