### PR TITLE
[FEAT] 가구 등록 시, 영어이름 정규화 로직 구현 및 테스트 코드 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/entity/Furniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/Furniture.java
@@ -53,12 +53,24 @@ public class Furniture {
     public static Furniture createByAdminFurnitureRequestDTO(AdminFurnitureRequestDTO dto, FurnitureType furnitureType){
         return Furniture.builder()
                 .furnitureNameKr(dto.furnitureNameKr())
-                .furnitureNameEng(dto.furnitureNameEng())
+                .furnitureNameEng(normalizeEngName(dto.furnitureNameEng()))
                 .furnitureType(furnitureType)
                 .build();
     }
 
     public void updateFurnitureNameEng(String furnitureNameEng) {
-        this.furnitureNameEng = furnitureNameEng;
+        this.furnitureNameEng = normalizeEngName(furnitureNameEng);
+    }
+
+
+    /**
+     * 가구의 이름을 후처리합니다.
+     *
+     * 1. 소문자인 경우, 대문자로 저장합니다
+     * 2. 띄어쓰기가 있는 경우 언더바로 대체합니다
+     * */
+    private static String normalizeEngName(String name) {
+        if (name == null) return null;
+        return name.trim().replace(' ', '_').toUpperCase();
     }
 }

--- a/src/test/java/or/sopt/houme/domain/admin/service/AdminFurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/admin/service/AdminFurnitureServiceImplTest.java
@@ -231,8 +231,27 @@ class AdminFurnitureServiceImplTest {
         adminFurnitureService.updateFurniture(requestDTO, null);
 
         // then
-        assertThat(furniture.getFurnitureNameEng()).isEqualTo("new bed eng");
+        assertThat(furniture.getFurnitureNameEng()).isEqualTo("NEW_BED_ENG");
         assertThat(furnitureTag.getFurniturePrompt()).isEqualTo("new prompt");
+    }
+
+
+    @Test
+    @DisplayName("registerFurniture()는 영어명을 대문자+언더스코어로 정규화하여 저장한다")
+    void registerFurniture_normalizesEnglishName() {
+        // given
+        AdminFurnitureRequestDTO requestDTO = new AdminFurnitureRequestDTO("정규화 테스트", "test furniture", 1L);
+        when(furnitureRepository.findByFurnitureNameKr("정규화 테스트")).thenReturn(Optional.empty());
+        when(furnitureTypeRepository.findById(1L)).thenReturn(Optional.of(bedType));
+
+        // when
+        adminFurnitureService.registerFurniture(requestDTO);
+
+        // then
+        org.mockito.ArgumentCaptor<Furniture> captor = org.mockito.ArgumentCaptor.forClass(Furniture.class);
+        verify(furnitureRepository, times(1)).save(captor.capture());
+        Furniture saved = captor.getValue();
+        assertThat(saved.getFurnitureNameEng()).isEqualTo("TEST_FURNITURE");
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/furniture/entity/FurnitureEntityTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/entity/FurnitureEntityTest.java
@@ -1,0 +1,38 @@
+package or.sopt.houme.domain.furniture.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import or.sopt.houme.domain.admin.controller.dto.furniture.AdminFurnitureRequestDTO;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FurnitureEntityTest {
+
+    @Test
+    @DisplayName("createByAdminFurnitureRequestDTO는 영어명을 대문자+언더스코어로 정규화한다")
+    void create_normalizesEnglishName() {
+        // given
+        FurnitureType type = FurnitureType.builder().id(1L).nameKr("의자").nameEng("CHAIR").build();
+        AdminFurnitureRequestDTO dto = new AdminFurnitureRequestDTO("의자", " test chair ", 1L);
+
+        // when
+        Furniture furniture = Furniture.createByAdminFurnitureRequestDTO(dto, type);
+
+        // then
+        assertThat(furniture.getFurnitureNameEng()).isEqualTo("TEST_CHAIR");
+    }
+
+    @Test
+    @DisplayName("updateFurnitureNameEng는 영어명을 대문자+언더스코어로 정규화한다")
+    void update_normalizesEnglishName() {
+        // given
+        Furniture furniture = Furniture.builder().furnitureNameKr("테이블").build();
+
+        // when
+        furniture.updateFurnitureNameEng("new table name");
+
+        // then
+        assertThat(furniture.getFurnitureNameEng()).isEqualTo("NEW_TABLE_NAME");
+    }
+}
+


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #329 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

가구 등록시, 영어name을 정규화하는 메서드를 구현하였습니다.

```

    /**
     * 가구의 이름을 후처리합니다.
     *
     * 1. 소문자인 경우, 대문자로 저장합니다
     * 2. 띄어쓰기가 있는 경우 언더바로 대체합니다
     * */
    private static String normalizeEngName(String name) {
        if (name == null) return null;
        return name.trim().replace(' ', '_').toUpperCase();
    }


```

관련 테스트 코드 수정 및 추가하였습니다.



<br>

<img width="1108" height="466" alt="image" src="https://github.com/user-attachments/assets/7052a9e3-1a62-42cd-bc63-ae1f86309690" />

우선순위 관련 수정의 경우, 우선순위의 정확한 사용처를 파악하는데에 시간이 걸리기도 하고 비즈니스 로직에 영향이 갈 것이 우려되어, 급하게 수정하지 않았습니다.
추후 같은 이슈를 통해 우선순위도 함께 수정하겠습니다.


<br>


+) DB에 같은 매핑테이블을 가진 가구가 두 개 존재하여 기획 파트의 요청으로 삭제하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
