### PR TITLE
[CHORE] 침대 영단어 요청을 종류 상관없이 받도록 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -95,49 +95,28 @@ public class FurnitureServiceImpl implements FurnitureService {
     public FurnitureCategoriesResponse getFurnitureCategoriesByStyle(User user, Long imageId, List<String> detectedObjects) {
 
         // 1. userId와 imageId로 해당하는 스타일 태그 조회
-        Tag tag = tagRepository.findTagByUserIdAndImageId(user.getId(), imageId).orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
+        Tag tag = findTag(user, imageId);
 
         // 2. userId와 imageId로 이미지 생성시 선택했던 가구들을 조회
-        House house = houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId).orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
-        List<Furniture> selectedFurnitures = furnitureRepository.findAllByHouseId(house.getId());
+        List<Furniture> selectedFurnitures = findSelectedFurnitures(user, imageId);
 
-        // 3. 2번 과정에서 생성된 selectedFurnitures의 'furniture_name_eng' 필드와 FurnitureCategoriesRequest의 furnitureNames를 비교하여 교집합 산출
-        Set<String> requestedObjects = detectedObjects.stream()
-                .map(String::toLowerCase) // 소문자로 변환
-                .collect(Collectors.toSet());
+        // 3. alias map 정의, 침대의 키워드의 확장
+        Set<String> expandedRequestedObjects = expandKeywords(detectedObjects);
 
-        // alias map 정의 (확장 키워드 처리)
-        Map<String, List<String>> keywordAliasMap = Map.of(
-                "single", List.of("single", "super_single", "double", "queen_over")
-        );
+        // 4. selectedFurnitures와 expandedRequestedObjects의 교집합 산출
+        List<Furniture> intersectedFurnitures = filterIntersectedFurnitures(selectedFurnitures, expandedRequestedObjects);
 
-        // 확장된 요청 키워드 집합 만들기
-        Set<String> expandedRequestedObjects = requestedObjects.stream()
-                .flatMap(req -> keywordAliasMap.getOrDefault(req, List.of(req)).stream())
-                .map(String::toLowerCase)
-                .collect(Collectors.toSet());
+        // 5. 교집합으로 산출된 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회
+        List<FurnitureTag> matchedTags = furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), intersectedFurnitures);
 
-        // 교집합 가구 추출
-        List<Furniture> intersectedFurnitures = selectedFurnitures.stream()
-                .filter(f -> f.getFurnitureNameEng() != null
-                        && expandedRequestedObjects.contains(f.getFurnitureNameEng().toLowerCase()))  // 소문자로 비교하기
+        // 6. priority 기준 오름차순 정렬 → 응답 DTO 변환
+        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> categoryResponses = matchedTags.stream()
+                .sorted(Comparator.comparingInt(FurnitureTag::getPriority))
+                .map(ft -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
+                        ft.getFurniture().getId(),
+                        ft.getFurniture().getFurnitureNameKr()
+                ))
                 .toList();
-
-        // 4. 교집합으로 산출된 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회
-        List<FurnitureTag> styleMappedFurnitureTags = furnitureTagRepository.findAllByTagIdAndFurnitureIn(
-                tag.getId(),
-                intersectedFurnitures
-        );
-
-        // 5. priority 기준 오름차순 정렬 → 응답 DTO 변환
-        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> categoryResponses =
-                styleMappedFurnitureTags.stream()
-                        .sorted(Comparator.comparingInt(FurnitureTag::getPriority))
-                        .map(ft -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
-                                ft.getFurniture().getId(),
-                                ft.getFurniture().getFurnitureNameKr()
-                        ))
-                        .toList();
 
         return FurnitureCategoriesResponse.of(categoryResponses);
     }
@@ -180,5 +159,42 @@ public class FurnitureServiceImpl implements FurnitureService {
 
         // 3. tagId와 categoryId(=furnitureId)로 furnitureTag 매핑 객체 조회
         return furnitureTagRepository.findByFurnitureAndTag(furniture, tag).orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE_TAG));
+    }
+
+    /**
+     * 보조 메서드 (비즈니스 로직 가독성을 위해 분리했습니다.)
+     */
+    private Tag findTag(User user, Long imageId) {
+        return tagRepository.findTagByUserIdAndImageId(user.getId(), imageId)
+                .orElseThrow(() -> new TagException(ErrorCode.NOT_FOUND_TAG_ENTITY));
+    }
+
+    private List<Furniture> findSelectedFurnitures(User user, Long imageId) {
+        House house = houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId)
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_HOUSE_ENTITY));
+        return furnitureRepository.findAllByHouseId(house.getId());
+    }
+
+    // single 침대 키워드를 현재는 구분하지 않고 있기 때문에, 다른 침대 종류와도 확장 매핑합니다.
+    private Set<String> expandKeywords(List<String> detectedObjects) {
+        Set<String> requestedObjects = detectedObjects.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+
+        Map<String, List<String>> keywordAliasMap = Map.of(
+                "single", List.of("single", "super_single", "double", "queen_over")
+        );
+
+        return requestedObjects.stream()
+                .flatMap(req -> keywordAliasMap.getOrDefault(req, List.of(req)).stream())
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+    }
+
+    private List<Furniture> filterIntersectedFurnitures(List<Furniture> furnitures, Set<String> keywords) {
+        return furnitures.stream()
+                .filter(f -> f.getFurnitureNameEng() != null
+                        && keywords.contains(f.getFurnitureNameEng().toLowerCase()))
+                .toList();
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -106,9 +106,21 @@ public class FurnitureServiceImpl implements FurnitureService {
                 .map(String::toLowerCase) // 소문자로 변환
                 .collect(Collectors.toSet());
 
+        // alias map 정의 (확장 키워드 처리)
+        Map<String, List<String>> keywordAliasMap = Map.of(
+                "single", List.of("single", "super_single", "double", "queen_over")
+        );
+
+        // 확장된 요청 키워드 집합 만들기
+        Set<String> expandedRequestedObjects = requestedObjects.stream()
+                .flatMap(req -> keywordAliasMap.getOrDefault(req, List.of(req)).stream())
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+
+        // 교집합 가구 추출
         List<Furniture> intersectedFurnitures = selectedFurnitures.stream()
                 .filter(f -> f.getFurnitureNameEng() != null
-                        && requestedObjects.contains(f.getFurnitureNameEng().toLowerCase()))  // 소문자로 비교하기
+                        && expandedRequestedObjects.contains(f.getFurnitureNameEng().toLowerCase()))  // 소문자로 비교하기
                 .toList();
 
         // 4. 교집합으로 산출된 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -149,7 +149,7 @@ class FurnitureServiceImplTest {
     void categories_intersection_sorted() {
         // Given
         Long imageId = 10L;
-        List<String> detectedObjects = List.of("Bed", "Desk", "Bed", "Desk", "Chair", "Box", "Dining Table");
+        List<String> detectedObjects = List.of("SINGLE", "OFFICE_DESK", "Bed", "CLOSET", "DINING_TABLE", "BOX", "WHITE_BOOKSHELF");
 
         Tag tag = Tag.builder()
                 .id(100L)
@@ -159,17 +159,17 @@ class FurnitureServiceImplTest {
                 .id(200L)
                 .build();
 
-        // 이미지 생성 과정에서 사용자가 선택한 가구: Bed, Chair, TV, Dining Table
+        // 이미지 생성 과정에서 사용자가 선택한 가구
         Furniture bed = Furniture.builder()
                 .id(1L)
                 .furnitureNameKr("침대")
-                .furnitureNameEng("Bed")
+                .furnitureNameEng("DOUBLE")
                 .build();
 
         Furniture chair = Furniture.builder()
                 .id(2L)
                 .furnitureNameKr("의자")
-                .furnitureNameEng("Chair")
+                .furnitureNameEng("OFFICE_DESK")
                 .build();
 
         Furniture tv = Furniture.builder()
@@ -181,7 +181,7 @@ class FurnitureServiceImplTest {
         Furniture dining = Furniture.builder()
                 .id(4L)
                 .furnitureNameKr("식탁")
-                .furnitureNameEng("Dining Table")
+                .furnitureNameEng("DINING_TABLE")
                 .build();
 
         // 레포지토리 Stubbing


### PR DESCRIPTION
## 📣 Related Issue

- 조금 헷갈릴 수 있는 이슈라서 이슈의 '문제 원인' 작성 부분 확인 부탁드립니다!!

- close #333 

## 📝 Summary

- 아래 스웨거 사진의 API에 약간의 결함이 있었습니다.
- 이 API는 생성된 이미지에서 AI로 인식된 가구 영단어 리스트를 API의 요청 바디로 받습니다. 여기서 클라이언트에서는 AI가 침대의 사이즈로 종류를 구분할 수 없기 때문에 모든 침대를 통칭하여 'SINGLE'이라는 영단어로만 요청할 수 있습니다.
- 하지만 지금 상황을 살펴보면, DB에서는 침대를 'SINGLE', 'SUPER_SINGLE', 'DOUBLE', 'QUEEN_OVER'로 종류를 나누어 갖고 있고, 사용자도 침대의 종류를 나누어 입력하고 있습니다.
- 이 상황에서 만약, 서버는 '사용자가 'DOUBLE'이라는 가구를 선택했구나!' 라고 알고 있는데, 클라의 요청 바디에 'SINGLE'을 담아 요청을 보내면, 서버는 '아하 'DOUBLE'이라는 가구가 생성된 이미지에는 없나보네?'라고 생각하여 응답에 침대를 반환하지 않게 됩니다.
- 하지만, 저희끼리는 SINGLE로 보내더라도 종류 상관없이 모두 (SINGLE)침대로 응답하기로 통일했기 때문에, 메서드에서 '침대 종류 상관없이 매핑해라' 라는 로직을 추가하여 해결했습니다.

<img width="875" height="303" alt="image" src="https://github.com/user-attachments/assets/a1df666d-3b04-4d68-9a84-d5bf7e8c6594" />


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
