### PR TITLE
[FEATURE] 동일 IP 중복접근 방지 필터구현

### DIFF
--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.global.jwt.JWTFilter;
 import or.sopt.houme.global.filter.IPFilter;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -34,7 +35,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JWTFilter jwtFilter;
-    private final IPFilter ipFilter;
+    private final ObjectProvider<IPFilter> ipFilterProvider;
     private final OAuthService oAuthService;
 
     @Bean
@@ -116,8 +117,11 @@ public class SecurityConfig {
 
         http.logout(AbstractHttpConfigurer::disable);
 
-        // IP 요청 제한 필터를 JWT 처리 이전에 적용
-        http.addFilterBefore(ipFilter, UsernamePasswordAuthenticationFilter.class);
+        // IP 요청 제한 필터를 JWT 처리 이전에 적용 (빈이 존재할 때만)
+        IPFilter ipFilter = ipFilterProvider.getIfAvailable();
+        if (ipFilter != null) {
+            http.addFilterBefore(ipFilter, UsernamePasswordAuthenticationFilter.class);
+        }
         // JWT 인증 필터
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.global.jwt.JWTFilter;
+import or.sopt.houme.global.filter.IPFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -33,6 +34,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JWTFilter jwtFilter;
+    private final IPFilter ipFilter;
     private final OAuthService oAuthService;
 
     @Bean
@@ -114,6 +116,9 @@ public class SecurityConfig {
 
         http.logout(AbstractHttpConfigurer::disable);
 
+        // IP 요청 제한 필터를 JWT 처리 이전에 적용
+        http.addFilterBefore(ipFilter, UsernamePasswordAuthenticationFilter.class);
+        // JWT 인증 필터
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/or/sopt/houme/global/filter/IPFilter.java
+++ b/src/main/java/or/sopt/houme/global/filter/IPFilter.java
@@ -1,0 +1,120 @@
+package or.sopt.houme.global.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.global.api.ApiResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 동일한 IP에서 1분 내 2번 이상 요청이 들어오면 차단하는 필터입니다.
+ * - 첫 요청은 허용하고, Redis에 60초 TTL 키를 저장합니다.
+ * - 같은 IP로 TTL이 남아있는 동안 재요청 시 429로 응답하고 체인을 중단합니다.
+ *
+ * 참고 사항:
+ * - CORS Preflight(OPTIONS)는 필터링하지 않습니다.
+ * - 테스트 환경(`test` 프로파일)에서는 비활성화하여 테스트에 영향이 없도록 합니다.
+ */
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class IPFilter extends OncePerRequestFilter {
+
+    private static final String RATE_KEY_PREFIX = "ip:rate:";
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+
+        // Preflight 및 공통 인프라 엔드포인트는 제외
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) return true;
+
+        String uri = request.getRequestURI();
+        if (uri == null) return false;
+
+        // 모니터링/도구용 actuator, swagger 엔드포인트는 제외
+        if (uri.startsWith("/actuator")) return true;
+        if (uri.startsWith("/v3/api-docs")) return true;
+        if (uri.startsWith("/swagger-ui")) return true;
+        if ("/swagger-ui.html".equals(uri)) return true;
+
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String clientIp = resolveClientIp(request);
+        String key = RATE_KEY_PREFIX + clientIp;
+
+        try {
+            Boolean exists = redisTemplate.hasKey(key);
+
+            if (Boolean.TRUE.equals(exists)) {
+                // 같은 IP로 1분 내 재요청 발생 → 차단
+                writeTooManyRequests(response);
+                return;
+            }
+
+            // 첫 요청: 짧은 TTL(1분) 키 저장
+            redisTemplate.opsForValue().set(key, 1, WINDOW);
+        } catch (Exception e) {
+            // Fail-open 전략: Redis 에러 시 서비스 중단 방지 위해 통과
+            log.warn("IPFilter encountered an error; allowing request. ip={}, err={}", clientIp, e.toString());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+    /**
+     * 예외를 필터단에서 직접 조작하여 반환하는 메서드
+     * */
+    private void writeTooManyRequests(HttpServletResponse response) throws IOException {
+        ErrorCode error = ErrorCode.RETRY_GET_IMAGE;
+        ApiResponse<Void> body = ApiResponse.fail(error.getCode(), error.getMsg());
+        String json = objectMapper.writeValueAsString(body);
+
+        response.setStatus(error.getStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(json);
+        response.getWriter().flush();
+    }
+
+
+    /**
+     * 클라이언트의 IP를 파싱하는 메서드
+     * */
+    private String resolveClientIp(HttpServletRequest request) {
+
+        // 프록시 환경 고려: X-Forwarded-For의 첫 IP → X-Real-IP → remoteAddr 순으로 사용
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            String first = xff.split(",")[0].trim();
+            if (!first.isBlank()) return first;
+        }
+        String xri = request.getHeader("X-Real-IP");
+        return Optional.ofNullable(xri).filter(ip -> !ip.isBlank()).orElse(request.getRemoteAddr());
+    }
+}

--- a/src/main/java/or/sopt/houme/global/filter/IPFilter.java
+++ b/src/main/java/or/sopt/houme/global/filter/IPFilter.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpMethod;
@@ -33,6 +34,7 @@ import java.util.Optional;
 @Slf4j
 @Component
 @Profile("!test")
+@ConditionalOnBean(StringRedisTemplate.class)
 @RequiredArgsConstructor
 public class IPFilter extends OncePerRequestFilter {
 

--- a/src/main/java/or/sopt/houme/global/filter/IPFilter.java
+++ b/src/main/java/or/sopt/houme/global/filter/IPFilter.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -22,9 +22,9 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * 동일한 IP에서 1분 내 2번 이상 요청이 들어오면 차단하는 필터입니다.
- * - 첫 요청은 허용하고, Redis에 60초 TTL 키를 저장합니다.
- * - 같은 IP로 TTL이 남아있는 동안 재요청 시 429로 응답하고 체인을 중단합니다.
+ * 동일한 IP에서 1분 내 요청이 20회를 초과하면 차단하는 필터입니다.
+ * - 매 요청마다 Redis 카운터를 1 증가시키고, 첫 증가 시 60초 TTL을 설정합니다.
+ * - 1분 동안 누적 요청 수가 21번째가 되면 429로 응답하고 체인을 중단합니다.
  *
  * 참고 사항:
  * - CORS Preflight(OPTIONS)는 필터링하지 않습니다.
@@ -38,8 +38,9 @@ public class IPFilter extends OncePerRequestFilter {
 
     private static final String RATE_KEY_PREFIX = "ip:rate:";
     private static final Duration WINDOW = Duration.ofMinutes(1);
+    private static final long LIMIT = 20L; // 1분당 허용 횟수
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
@@ -68,16 +69,17 @@ public class IPFilter extends OncePerRequestFilter {
         String key = RATE_KEY_PREFIX + clientIp;
 
         try {
-            Boolean exists = redisTemplate.hasKey(key);
+            Long count = redisTemplate.opsForValue().increment(key);
+            if (count != null && count == 1L) {
+                // 첫 요청: 키에 TTL(1분) 설정
+                redisTemplate.expire(key, WINDOW);
+            }
 
-            if (Boolean.TRUE.equals(exists)) {
-                // 같은 IP로 1분 내 재요청 발생 → 차단
+            if (count != null && count > LIMIT) {
+                // 1분 내 요청 횟수 초과 → 차단 (21번째부터 차단)
                 writeTooManyRequests(response);
                 return;
             }
-
-            // 첫 요청: 짧은 TTL(1분) 키 저장
-            redisTemplate.opsForValue().set(key, 1, WINDOW);
         } catch (Exception e) {
             // Fail-open 전략: Redis 에러 시 서비스 중단 방지 위해 통과
             log.warn("IPFilter encountered an error; allowing request. ip={}, err={}", clientIp, e.toString());

--- a/src/main/java/or/sopt/houme/global/filter/IPFilter.java
+++ b/src/main/java/or/sopt/houme/global/filter/IPFilter.java
@@ -82,7 +82,7 @@ public class IPFilter extends OncePerRequestFilter {
             }
         } catch (Exception e) {
             // Fail-open 전략: Redis 에러 시 서비스 중단 방지 위해 통과
-            log.warn("IPFilter encountered an error; allowing request. ip={}, err={}", clientIp, e.toString());
+            log.warn("IPFilter 처리 중 오류 발생, 요청을 허용합니다. IP={}, 오류={}", clientIp, e.toString());
         }
 
         filterChain.doFilter(request, response);


### PR DESCRIPTION
 ## 📣 Related Issue

  - close #339 

  ## 📝 Summary

  - 기능: 동일 IP 기준 1분당 20회까지 허용, 21번째 요청부터 429로 차단하는 IPFilter 추가
  - 구현
      - OncePerRequestFilter + StringRedisTemplate 기반
      - 요청마다 ip:rate:{ip} 카운터를 INCR로 증가, 첫 증가 시 TTL 60초 설정
      - 1분 내 > 20이면 차단, ErrorCode.RETRY_GET_IMAGE로 표준 응답 반환
      - 예외 경로: OPTIONS, /actuator/**, /v3/api-docs/**, /swagger-ui/**, /swagger-ui.html
      - test 프로파일에서는 비활성화
      - 필터 순서: UsernamePasswordAuthenticationFilter 이전, JWTFilter보다 먼저 등록
      - 장애 내성: Redis 오류 시 경고 로그 남기고 통과(Fail-open)
     
  - 배경(AWS WAF와의 2중 필터링)
      - 인프라 레벨에서 AWS WAF 사용 중이나, 적용 지연(약 30ms)으로 극단적인 순간 버스트가 일부 통과하는 문제가 있었습니다.
      - 애플리케이션 레벨에서 즉시성 높은 제한을 추가하여 WAF를 보완하고, 누락 가능성을 최소화하기 위해 이중 필터링을 적용하였습니ㅏㄷ.
      - 결과적으로 엣지(WAF) + 앱(필터) 조합으로 방어 심도를 강화하고, 백엔드 부하 급증을 완화하였습니다.
      - 정리해보자면,
      
```
      1. 10,000 개의 악의적인 요청이 20ms 의 delay로 들어왔다고 가정
      2. WAF 정책으로 인해서 300개 정도의 요청만 인스턴스로 들어옴
      3. 300개의 요청 중 20개의 요청만 서블릿으로 들어와서 로직이 실행됨

```

```
{
    "code": 42900,
    "msg": "너무 많은 요청이 들어왔습니다. 잠시 후에 재요청하세요."
}

```

## 🙏 Question & PR point

1. 그러면 AWS WAF는 왜 필요한가요?
WAF가 없으면 10,000 개의 요청이 모두 인스턴스로 들어와 필터단에서 로직을 수행하게 됩니다. 그러면 결국 10,000 개의 요청을 처리하기 위해 필터단에서 부하가 발생하고 이는 곧 인스턴스의 부하 -> 서버가 터져버릴 수 있겠죠.
그래서 1차적으로 인스턴스에 들어오기 전에 WAF에서 요청을 필터링하고, 해당 요청들에 한해서 필터에서 2차적으로 요청을 처리하는 것이에요.

2. @ConditionalOnBean(StringRedisTemplate.class)
@ConditionalOnBean 은 Spring Boot의 조건부 빈 등록입니다. 이렇게 선언하면, StringRedisTemplate 이 이미 스프링 컨텍스트에 등록되어 있을 때만 IPFilter 클래스가 활성화됩니다.
도입 이유는 테스트 단에서는 레디스 관련 빈들을 등록하지 않기 때문에 필터단에서 모든 테스트를 위한 요청이 실패해버리는 문제를 해결하기 위함이었습니다.


  ## 📬 Postman

<img width="1003" height="608" alt="image" src="https://github.com/user-attachments/assets/ad7ea6c2-a4e5-486b-b52e-b147ddac4843" />

  - 시나리오: 동일 IP로 보호 경로에 60초 내 100회 요청
      - 1~20회: 200 OK
      - 21회: 429 Too Many Requests