### PR TITLE
[REFACTOR] B안 이미지(1장) 생성 트랜잭션 분리

### DIFF
--- a/src/main/java/or/sopt/houme/domain/credit/service/CreditService.java
+++ b/src/main/java/or/sopt/houme/domain/credit/service/CreditService.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.credit.service;
 
 import or.sopt.houme.domain.credit.entity.Credit;
 import or.sopt.houme.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CreditService {
 
@@ -9,6 +10,7 @@ public interface CreditService {
     void decreaseCreditAtomically(User user);
 
     // 락 획득 및 크레딧 상태 PENDING 으로 변경
+    @Transactional
     Credit tryLockAndGetCredit(User user);
 
     // 크레딧 최종 삭제 (이미지 생성 성공 시)

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
@@ -18,7 +18,6 @@ public interface FurnitureService {
     // 가구 중 침대 ID 조회
     Optional<Long> findBedId(List<Long> furnitureIds);
 
-
     FurnitureTag findFurnitureTag(User user, Long imageId, Long categoryId);
 
     FurnitureTag findFurnitureTagForPlan(Long tagId, Long furnitureId);

--- a/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacade.java
@@ -166,86 +166,68 @@ public class GenerateImageFacade {
         }
     }
 
-
-    @Transactional
     public ImageInfoResponse generateImageByFastApi(User user, GenerateImageRequest generateImageRequest) {
 
         /**
-         * redis 저장 (user랑 상태값)
-         * 재요청시 user 조회 (상태값은 이미지 받았는지 판단)
-         * 상태값이 요청 후 받았다( -> 재요청 가능 )
+         * [짧은 트랜잭션이 일어나는 부분] (하나의 로직으로 처리)
+         * - house 주요 활동 업데이트
+         * - house furniture 저장
+         * - house 무드보드들 저장
+         * - house prompt 저장
+         * - 이미지 생성 여부 업데이트
+         * - 이미지 저장
+         * - 크레딧 차감 확정
+         * =====================
+         * [본 로직에서 일어나는 부분]
+         * 로그 처리 (이것도 하나의 로직 => 트랜잭션 처리됨)
+         * 크레딧 락 획득 및 상태 변경
          */
 
-        // 크레딧 감소
-        creditService.decreaseCreditAtomically(user);
-
-        // Enum 타입의 유효성 검증
-        Activity activity = enumValueOf(Activity.class, generateImageRequest.activity());
-        Equilibrium equilibrium = enumValueOf(Equilibrium.class, generateImageRequest.equilibrium());
-
-        // 주요 활동 업데이트
-        House house = houseService.updateHouseActivity(generateImageRequest.houseId(), activity);
-
-        // house_floor_plan 생성 및 저장
-        houseService.saveHouseFloorPlan(house, generateImageRequest.floorPlan().floorPlanId());
-
-        // 침대 ID 찾기
-        Optional<Long> bedId = furnitureService.findBedId(generateImageRequest.selectiveIds());
-
-        // 복층이 아닌 경우 침대 추가
-        if (!house.getStructure().equals(Structure.DUPLEX) && bedId.isPresent()) {
-            log.info("복층이 아닌 경우 침대 추가");
-            generateImageRequest.selectiveIds().add(bedId.get());
+        // 이미 생성된 이미지가 존재하는 houseId면 fall api로 요청하라고 넘기기
+        try{
+            GenerateImage generateImageByHouseId = generateImageService.findGenerateImageByHouseId(generateImageRequest.houseId());
+            if (generateImageByHouseId != null) {
+                log.info("houseId: {}로 생성된 이미지 존재함", generateImageRequest.houseId());
+                // 이미지 생성 중 오류가 발생하면 재요청하라는 예외 반환
+                throw new GeneralException(ErrorCode.RETRY_GET_IMAGE);
+            }
+        } catch (GenerateImageException e) {
+            // 이미지 생성 진행
+            log.info("houseId: {}로 생성된 이미지 없음", generateImageRequest.houseId());
         }
 
-        // house furniture 저장
-        houseService.saveHouseFurniture(house, generateImageRequest.selectiveIds());
-
-        // 가구 식별자 ID
-        PromptFurnitureListDTO promptFurnitureListDTO = PromptFurnitureListDTO.of(generateImageRequest.selectiveIds());
-
-        // House와 무드보드들 저장
-        houseService.saveHouseTaste(house, generateImageRequest.moodBoardIds());
-
-        // 최고 순위 찾기
-        Tag tag = tasteTagService.getPriorityId(generateImageRequest.moodBoardIds());
-
-        PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(generateImageRequest.floorPlan().floorPlanId(),
-                tag.getId(), equilibrium, promptFurnitureListDTO);
-
+        Credit lockedCredit = null;
+        // 크레딧 감소
         try {
+
+            // 크레딧 락 획득 및 상태 변경 (짧은 트랜잭션)
+            lockedCredit = creditService.tryLockAndGetCredit(user);
+
+            // Enum 타입의 유효성 검증
+            Activity activity = enumValueOf(Activity.class, generateImageRequest.activity());
+            Equilibrium equilibrium = enumValueOf(Equilibrium.class, generateImageRequest.equilibrium());
+
+            // 가구 식별자 ID
+            PromptFurnitureListDTO promptFurnitureListDTO = PromptFurnitureListDTO.of(generateImageRequest.selectiveIds());
+
+            // 최고 순위 찾기
+            Tag priorityTag = tasteTagService.getPriorityId(generateImageRequest.moodBoardIds());
+
+            PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(generateImageRequest.floorPlan().floorPlanId(),
+                    priorityTag.getId(), equilibrium, promptFurnitureListDTO);
 
             // OpenAI로 image 생성
             ImageUploadResponseDTO imageUploadResponseDTO = openAiFacade.makeImageByFastApi(promptRequestDTO);
 
-            // house에 프롬프트 저장
-            houseService.saveHousePrompt(house, imageUploadResponseDTO.getPullPrompt());
-
-            GenerateImage generateImage;
-
-            try {
-                // 도면 이미지 생성
-                generateImage = generateImageService.createGenerateImage(imageUploadResponseDTO, house);
-
-            } catch (Exception e) {
-
-                // 이미지 생성 중 오류가 발생하면 재요청하라는 예외 반환
-                throw new GeneralException(ErrorCode.RETRY_GET_IMAGE);
-            }
-
-            // 이미지 반환 ImageInfoResponse 생성
-            ImageInfoResponse imageInfoResponse = ImageInfoResponse.of(generateImage.getId(), generateImage.getUrl(),
-                    generateImageRequest.floorPlan().isMirror(), house.getEquilibrium().getDescription(),
-                    house.getForm().getDescription(), tag.getTagNameKr(), user.getName());
+            ImageInfoResponse imageInfoResponse = generateImageTransactionService.saveAllDataAndConfirmCredit(
+                    user, lockedCredit, generateImageRequest, imageUploadResponseDTO, priorityTag, activity
+            );
 
             // 만약 Fallback 이미지라면, 예외처리
-            if (generateImage.getUrl().equals(S3Constant.FALL_BACK_IMAGE)) {
+            if (imageInfoResponse.imageUrl().equals(S3Constant.FALL_BACK_IMAGE)) {
                 log.error("폴백 이미지가 생성되었습니다.");
                 throw new ImageFallbackException(ErrorCode.GENERATED_IMAGE_EXCEPTION, imageInfoResponse);
             }
-
-            // 이미지 생성 여부 업데이트
-            userService.updateHasGeneratedImage(user);
 
             /*
              * 사용자 로그 저장 사용자, 무드보드 객체들, 이미지, 스타일 태그 객체들
@@ -257,12 +239,26 @@ public class GenerateImageFacade {
         } catch (ValidException validException) {
             // 유효값 검증 실패시
             log.error("유효값 검증 실패: {}", validException.getMessage(), validException);
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
             throw new ValidException(ErrorCode.NOT_VALID_EXCEPTION);
         } catch (GenerateImageException e) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
             throw e;
         } catch (Exception e) {
             log.info("Image 생성 중 오류 발생 {}", e.getMessage());
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
             throw new GenerateImageException(ErrorCode.GENERATED_IMAGE_EXCEPTION);
+        } finally {
+            // 어떤 경우든 락 최종 해제
+            if (lockedCredit != null) {
+                creditService.releaseLock(user);
+            }
         }
     }
 
@@ -402,6 +398,9 @@ public class GenerateImageFacade {
         } catch (ValidException validException) {
             // 유효값 검증 실패시
             log.error("유효값 검증 실패: {}", validException.getMessage(), validException);
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
             throw new ValidException(ErrorCode.NOT_VALID_EXCEPTION);
         } catch (GenerateImageException | ImageFallbackException | CreditException e) {
             // 이미지 생성 중 어떤 예외라도 발생하면 크레딧 상태 복구

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageService.java
@@ -3,10 +3,12 @@ package or.sopt.houme.domain.generateImage.service;
 import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface GenerateImageService {
 
     // 이미지 생성
+    @Transactional
     GenerateImage createGenerateImage(ImageUploadResponseDTO request, House house);
 
     // 이미지 ID로 조회

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -7,12 +7,15 @@ import or.sopt.houme.domain.generateImage.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.house.entity.House;
+import or.sopt.houme.domain.house.entity.enums.Activity;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.taste.dto.response.TagDTO;
+import or.sopt.houme.domain.taste.entity.Tag;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -60,5 +63,44 @@ public class GenerateImageTransactionService {
             );
         }
         return imageInfoResponses;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 확실하게 분리된 트랜잭션 보장
+    public ImageInfoResponse saveAllDataAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            GenerateImageRequest request,
+            ImageUploadResponseDTO imageResponse,
+            Tag priorityTag,
+            Activity activity
+    ) {
+        // 1. House 정보 업데이트
+        House house = houseService.updateHouseActivity(request.houseId(), activity);
+
+        // 2. 가구 및 무드보드, 프롬프트 저장
+        houseService.saveHouseFloorPlan(house, request.floorPlan().floorPlanId());
+        houseService.saveHouseFurniture(house, request.selectiveIds());
+        houseService.saveHouseTaste(house, request.moodBoardIds());
+        houseService.saveHousePrompt(house, imageResponse.getPullPrompt());
+
+        // 3. 이미지 엔티티 생성 및 저장
+        GenerateImage generateImage = generateImageService.createGenerateImage(imageResponse, house);
+
+        // 4. 크레딧 차감 확정 (PENDING -> DELETE)
+        creditService.commitCreditDeletion(lockedCredit);
+
+        // 5. 유저 상태 업데이트
+        userService.updateHasGeneratedImage(user);
+
+        // 6. 응답 DTO 생성
+        return ImageInfoResponse.of(
+                generateImage.getId(),
+                generateImage.getUrl(),
+                request.floorPlan().isMirror(),
+                house.getEquilibrium().getDescription(),
+                house.getForm().getDescription(),
+                priorityTag.getTagNameKr(),
+                user.getName()
+        );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
@@ -7,6 +7,7 @@ import or.sopt.houme.domain.house.dto.response.HouseOptionsResponse;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.entity.enums.Activity;
 import or.sopt.houme.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ public interface HouseService {
     LatestHouseConditionDTO findLatestHouse(User user);
 
     // house에 주요활동 저장하기
+    @Transactional
     House updateHouseActivity(Long houseId, Activity activity);
 
     // 생성된 이미지 가져오기 (가장 최신 1개)

--- a/src/main/java/or/sopt/houme/domain/user/service/UserService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.user.controller.dto.MyPageInfoResponse;
 import or.sopt.houme.domain.user.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.entity.Gender;
 import or.sopt.houme.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
@@ -18,6 +19,7 @@ public interface UserService {
     String updateUser(User user, String name, Gender gender, LocalDate birthday);
 
     // 사용자 이미지 생성 여부 저장
+    @Transactional
     void updateHasGeneratedImage(User user);
 
 }

--- a/src/test/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacadeTest.java
@@ -1,11 +1,13 @@
 package or.sopt.houme.domain.generateImage.facade;
 
+import or.sopt.houme.domain.credit.entity.Credit;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.generateImage.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
+import or.sopt.houme.domain.generateImage.service.GenerateImageTransactionService;
 import or.sopt.houme.domain.generateImage.service.imageGenerationLog.ImageGenerationLogService;
 import or.sopt.houme.domain.generateImage.service.imageGenerationLog.ImageGenerationTransactionService;
 import or.sopt.houme.domain.house.entity.House;
@@ -76,6 +78,9 @@ class GenerateImageFacadeTest {
 
     @Mock
     ImageGenerationTransactionService imageGenerationTransactionService;
+
+    @Mock
+    GenerateImageTransactionService generateImageTransactionService;
 
     @Mock
     TagService tagService;
@@ -212,6 +217,8 @@ class GenerateImageFacadeTest {
                 List.of(1L, 2L), "READING", List.of(1L)
         );
 
+        Credit lockedCredit = null;
+
         Tag tag = Tag.builder()
                 .id(1L)
                 .priority(1)
@@ -219,11 +226,6 @@ class GenerateImageFacadeTest {
                 .tagNameKr("모던")
                 .tagPrompt("취향 프롬프트")
                 .build();
-
-        when(houseService.updateHouseActivity(generateImageRequest.houseId(), Activity.valueOf(generateImageRequest.activity()))).thenReturn(house);
-
-        // 침대 Id 찾기
-        when(furnitureService.findBedId(generateImageRequest.selectiveIds())).thenReturn(Optional.empty());
 
         when(tasteTagService.getPriorityId(generateImageRequest.moodBoardIds()))
                 .thenReturn(tag);
@@ -238,6 +240,10 @@ class GenerateImageFacadeTest {
         String imageLink = "image_link";
         String contentType = "content_type";
         String pullPrompt = "pull_prompt";
+
+        ImageInfoResponse tempImageInfoResponse = new ImageInfoResponse(
+                1L, imageLink, false, house.getEquilibrium().getDescription(), house.getForm().getDescription(), tag.getTagNameKr(), user.getName()
+                );
 
         ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
                 filename, originalFilename, imageLink, contentType
@@ -260,11 +266,11 @@ class GenerateImageFacadeTest {
         List<Taste> tasteList = List.of(taste1, taste2);
         List<Tag> tagList = List.of(tag);
 
-        when(generateImageService.createGenerateImage(imageUploadResponseDTO, house)).thenReturn(generateImage);
         when(tasteService.getTasteList(moodBoardIds)).thenReturn(tasteList);
         when(tagService.findTagByTasteId(moodBoardIds.get(0))).thenReturn(tag);
         when(tagService.findTagByTasteId(moodBoardIds.get(1))).thenReturn(tag);
         when(tasteTagService.findDistinctTagsByTasteIds(moodBoardIds)).thenReturn(tagList);
+        when(generateImageTransactionService.saveAllDataAndConfirmCredit(user, lockedCredit, generateImageRequest, imageUploadResponseDTO, tag, Activity.valueOf(generateImageRequest.activity()))).thenReturn(tempImageInfoResponse);
 
         // When
         ImageInfoResponse imageInfoResponse = generateImageFacade.generateImageByFastApi(user, generateImageRequest);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #341 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
B안 이미지(1장) 생성 트랜잭션 분리
보상 트랜잭션을 만드는 형식보다는, 이미지 생성 이후에 커밋하는 방식으로 수정했습니다.
이미지 생성 B안의 트랜잭션은 총 4개가 있습니다.
1. 크레딧 차감 대기
2. 이미지 외 여러개 저장
3. 로그 생성
4. 크레딧 차감

기존 로직이 트랜잭션이 너무 길어 2번의 경우를 사용해서 분리했습니다.
`REQUIRES_NEW` 옵션을 사용해서 확실하게 분리된 트랜잭션을 보장하도록 설계하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
기존에 없던 로직도 추가했습니다. `houseId` 기준으로 생성되어 있는 이미지가 존재하면 `Fallback API`로 요청하라는 과정을 초반에 넣었습니다.
`Fallback API`는 `houseId` 기준으로 생성되어있는 이미지를 불러오는 API입니다. 
이 부분이 문제상황이 있을까요? 저는 없을것이라고 생각하긴 했습니다만, 의견을 듣고 싶습니다!!

## 📬 Postman

### 성공
<img width="907" height="224" alt="image" src="https://github.com/user-attachments/assets/5ac0cc57-b0aa-4df9-a397-c6e554269432" />


### 실패 (Fallback으로 보내달라는 예외 code: 42900)
<img width="544" height="272" alt="image" src="https://github.com/user-attachments/assets/b92269b5-4bf9-4cee-8eca-b1252bf65a0e" />

<!-- postman 스크린샷을 첨부해주세요 -->
