### PR TITLE
[CHORE] 회원탈퇴 시, 찜 연관관계 삭제 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface JjymRepository extends JpaRepository<Jjym, Long>, JjymRepositoryCustom {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
@@ -16,6 +16,7 @@ import or.sopt.houme.domain.preference.repository.*;
 import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.credit.repository.PaymentBtnClickLogRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureRecommendBtnClickLogRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.house.repository.InvalidHouseRequestRepository;
 import or.sopt.houme.domain.address.repository.AddressRepository;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
@@ -49,6 +50,7 @@ public class UserDeletionService {
     private final FurnitureRecommendBtnClickLogRepository furnitureRecommendBtnClickLogRepository;
     private final InvalidHouseRequestRepository invalidHouseRequestRepository;
     private final CreditRepository creditRepository;
+    private final JjymRepository jjymRepository;
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistTokenRepository blacklistTokenRepository;
@@ -142,6 +144,8 @@ public class UserDeletionService {
         }
 
         // 3. 유저 직접 참조 로그/데이터 삭제
+        // 3-0. 찜 데이터(jjyms) 선삭제로 FK 제약 해소
+        jjymRepository.deleteByUserId(userId);
         imageGenerationLogRepository.deleteByUserId(userId);
         invalidHouseRequestRepository.deleteByUserId(userId);
         addressRepository.deleteByUserId(userId);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #343 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 회원 탈퇴 api가 호출될때, 찜 관련 데이터가 함께 삭제되도록 수정하였습니다

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 따로 없습니다~!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
