### PR TITLE
[CHORE] fast-api 로직 스프링으로 이전

### DIFF
--- a/src/main/java/or/sopt/houme/ai/image/LocalFastApiImageClient.java
+++ b/src/main/java/or/sopt/houme/ai/image/LocalFastApiImageClient.java
@@ -1,0 +1,50 @@
+package or.sopt.houme.ai.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import or.sopt.houme.domain.openai.client.FastApiImageClient;
+import or.sopt.houme.domain.openai.service.OpenAiService;
+import or.sopt.houme.domain.prompt.dto.PromptRequestDTO;
+import or.sopt.houme.domain.prompt.service.PromptService;
+import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+
+/**
+ * FastAPI 의존 제거를 위한 로컬 어댑터 구현체입니다.
+ *
+ * 기존 FastAPI 연동 인터페이스(FastApiImageClient)를 구현하여
+ * 외부 HTTP 호출 없이 Spring 내부 로직으로 이미지 생성을 수행합니다.
+ *
+ * 동작 흐름
+ * 1) PromptService.makePrompt(...)로 최종 프롬프트 생성
+ * 2) OpenAiService.createImage(prompt) 호출로 OpenAI 이미지 생성 및 S3 업로드
+ * 3) ImageUploadResponseDTO 반환 (clipScore는 제거)
+ */
+@Component
+@Primary
+@RequiredArgsConstructor
+public class LocalFastApiImageClient implements FastApiImageClient {
+
+    private final PromptService promptService;
+    private final OpenAiService openAiService;
+
+    /**
+     * FastAPI의 /images 엔드포인트 대체 구현.
+     *
+     * @param request 프롬프트 구성에 필요한 식별자/옵션 DTO
+     * @return S3 업로드 메타데이터가 포함된 응답 DTO
+     */
+    @Override
+    public ImageUploadResponseDTO generateImage(PromptRequestDTO request) {
+        // 1) 프롬프트 합성
+        String prompt = promptService.makePrompt(request);
+
+        // 2) 이미지 생성 + S3 업로드 (내부 서비스 활용)
+        ImageUploadResponseDTO response = openAiService.createImage(prompt);
+
+        // pullPrompt 정보 보강 (기존 FastAPI 응답 정합성 유지)
+        response.setPullPrompt(prompt);
+        return response;
+    }
+}
+

--- a/src/main/java/or/sopt/houme/ai/imagehash/LocalFastApiImageHashClient.java
+++ b/src/main/java/or/sopt/houme/ai/imagehash/LocalFastApiImageHashClient.java
@@ -1,0 +1,313 @@
+package or.sopt.houme.ai.imagehash;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import or.sopt.houme.domain.furniture.client.FastApiImageHashClient;
+import or.sopt.houme.domain.furniture.dto.external.fastApiImagehash.ImageHashRequest;
+import or.sopt.houme.domain.furniture.dto.external.fastApiImagehash.SimilarityResponse;
+import or.sopt.houme.domain.furniture.dto.external.fastApiImagehash.forPlan.ImageHashRequestForPlan;
+import or.sopt.houme.domain.furniture.dto.external.fastApiImagehash.forPlan.SimilarityResponseForPlan;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * FastAPI 이미지 해시 유사도 API 대체 구현.
+ *
+ * - pHash(형태) 70% + colorHash(색상) 30% 가중치 기반 유사도 계산
+ * - Top-5 상품 반환
+ * - for-plan 변형은 외부 가중치 비율을 정규화하여 반영
+ *
+ * 구현 세부
+ * - pHash: 32x32 그레이스케일 → 2D DCT → 상위 8x8 블록의 중앙값 기반 64비트 해시
+ * - colorHash: HSV Hue 64-bin 히스토그램 → 평균 이상인 bin을 1로 표기한 64비트 해시
+ * - 유사도: 1 - (해밍거리 / 64)
+ */
+@Component
+@Primary
+@RequiredArgsConstructor
+public class LocalFastApiImageHashClient implements FastApiImageHashClient {
+
+    private static final double PHASH_WEIGHT = 0.7;
+    private static final double COLOR_HASH_WEIGHT = 0.3;
+    private static final int TOP_K = 5;
+    private static final int PHASH_SIZE = 32; // DCT 입력 크기
+    private static final int PHASH_REDUCED_SIZE = 8; // 상위 블록 크기
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    /**
+     * 기본 가중치(0.7/0.3) 기반 유사도 상위 5개 상품을 반환합니다.
+     */
+    @Override
+    public SimilarityResponse getTopKSimilarImages(ImageHashRequest request) {
+        try {
+            BufferedImage base = fetchImage(request.baseImageUrl());
+            long baseP = computePHash(base);
+            long baseC = computeColorHash(base);
+
+            List<SimilarityResponse.RankedProduct> ranked = new ArrayList<>();
+            for (ImageHashRequest.Product p : request.products()) {
+                try {
+                    BufferedImage img = fetchImage(p.imageUrl());
+                    long pP = computePHash(img);
+                    long pC = computeColorHash(img);
+
+                    double sim = weightedSimilarity(baseP, baseC, pP, pC, PHASH_WEIGHT, COLOR_HASH_WEIGHT);
+                    ranked.add(SimilarityResponse.RankedProduct.of(p.productId(), p.imageUrl(), round4(sim)));
+                } catch (Exception e) {
+                    // 개별 실패는 0점 처리 후 계속 진행
+                    ranked.add(SimilarityResponse.RankedProduct.of(p.productId(), p.imageUrl(), 0.0));
+                }
+            }
+
+            List<SimilarityResponse.RankedProduct> top = ranked.stream()
+                    .sorted(Comparator.comparingDouble(SimilarityResponse.RankedProduct::similarity).reversed())
+                    .limit(TOP_K)
+                    .collect(Collectors.toList());
+
+            return SimilarityResponse.of(top);
+        } catch (Exception e) {
+            // 전체 실패 시 빈 결과 반환 (서비스 계층에서 예외 처리)
+            return SimilarityResponse.of(List.of());
+        }
+    }
+
+    /**
+     * 외부 가중치 pHash/colorHash(0~100)를 정규화하여 유사도 계산을 수행합니다.
+     */
+    @Override
+    public SimilarityResponseForPlan getTopKSimilarImagesForPlan(ImageHashRequestForPlan request) {
+        try {
+            BufferedImage base = fetchImage(request.baseImageUrl());
+            long baseP = computePHash(base);
+            long baseC = computeColorHash(base);
+
+            int p = Math.max(0, request.pHash());
+            int c = Math.max(0, request.colorHash());
+            int total = p + c;
+            double pRatio, cRatio;
+            if (total <= 0) {
+                pRatio = PHASH_WEIGHT;
+                cRatio = COLOR_HASH_WEIGHT;
+            } else {
+                pRatio = Math.min(1.0, (double) p / total);
+                cRatio = Math.min(1.0, (double) c / total);
+            }
+
+            List<SimilarityResponseForPlan.RankedProduct> ranked = new ArrayList<>();
+            for (ImageHashRequestForPlan.Product prod : request.products()) {
+                try {
+                    BufferedImage img = fetchImage(prod.imageUrl());
+                    long pP = computePHash(img);
+                    long pC = computeColorHash(img);
+
+                    double sim = weightedSimilarity(baseP, baseC, pP, pC, pRatio, cRatio);
+                    ranked.add(new SimilarityResponseForPlan.RankedProduct(prod.productId(), prod.imageUrl(), round4(sim)));
+                } catch (Exception e) {
+                    ranked.add(new SimilarityResponseForPlan.RankedProduct(prod.productId(), prod.imageUrl(), 0.0));
+                }
+            }
+
+            List<SimilarityResponseForPlan.RankedProduct> top = ranked.stream()
+                    .sorted(Comparator.comparingDouble(SimilarityResponseForPlan.RankedProduct::similarity).reversed())
+                    .limit(TOP_K)
+                    .collect(Collectors.toList());
+
+            return SimilarityResponseForPlan.of(top);
+        } catch (Exception e) {
+            return SimilarityResponseForPlan.of(List.of());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 내부 유틸 구현부
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * 이미지 다운로드 유틸 (타임아웃/에러 처리 포함)
+     */
+    private BufferedImage fetchImage(String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(10))
+                .GET()
+                .header("User-Agent", "Houme-ImageHash/1.0")
+                .build();
+
+        HttpResponse<byte[]> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        if (resp.statusCode() < 200 || resp.statusCode() >= 300) {
+            throw new IOException("Image fetch failed: status=" + resp.statusCode() + ", url=" + url);
+        }
+        try (ByteArrayInputStream in = new ByteArrayInputStream(resp.body())) {
+            BufferedImage img = ImageIO.read(in);
+            if (img == null) {
+                throw new IOException("Unsupported image format: " + url);
+            }
+            return ensureRgb(img);
+        }
+    }
+
+    private BufferedImage ensureRgb(BufferedImage src) {
+        if (src.getType() == BufferedImage.TYPE_INT_RGB) return src;
+        BufferedImage rgb = new BufferedImage(src.getWidth(), src.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = rgb.createGraphics();
+        g.drawImage(src, 0, 0, null);
+        g.dispose();
+        return rgb;
+    }
+
+    /**
+     * pHash 계산: 32x32 그레이스케일 → 2D DCT → 8x8 상위 블록 중앙값 기준 64-bit 해시
+     */
+    private long computePHash(BufferedImage image) {
+        double[][] gray = toGrayscaleMatrix(resize(image, PHASH_SIZE, PHASH_SIZE));
+        double[][] dct = dct2D(gray);
+
+        // 상위 8x8 블록만 사용
+        double[] vals = new double[PHASH_REDUCED_SIZE * PHASH_REDUCED_SIZE];
+        int idx = 0;
+        for (int u = 0; u < PHASH_REDUCED_SIZE; u++) {
+            for (int v = 0; v < PHASH_REDUCED_SIZE; v++) {
+                vals[idx++] = dct[u][v];
+            }
+        }
+        double median = median(vals);
+
+        // 64비트 해시 구성 (상위비트부터 채움)
+        long hash = 0L;
+        for (double v : vals) {
+            hash <<= 1;
+            if (v > median) hash |= 1L;
+        }
+        return hash;
+    }
+
+    /**
+     * colorHash 계산: HSV Hue 64-bin 히스토그램 기반 64-bit 해시
+     */
+    private long computeColorHash(BufferedImage image) {
+        BufferedImage small = resize(image, 64, 64);
+        int width = small.getWidth();
+        int height = small.getHeight();
+        int[] hist = new int[64];
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int rgb = small.getRGB(x, y);
+                int r = (rgb >> 16) & 0xFF;
+                int g = (rgb >> 8) & 0xFF;
+                int b = rgb & 0xFF;
+                float[] hsb = Color.RGBtoHSB(r, g, b, null);
+                // Hue ∈ [0,1) → 64개 bin
+                int bin = (int) Math.floor(hsb[0] * 64.0f);
+                if (bin < 0) bin = 0; if (bin > 63) bin = 63;
+                hist[bin]++;
+            }
+        }
+
+        double avg = 0.0;
+        for (int v : hist) avg += v;
+        avg /= hist.length;
+
+        long hash = 0L;
+        for (int v : hist) {
+            hash <<= 1;
+            if (v >= avg) hash |= 1L;
+        }
+        return hash;
+    }
+
+    private double weightedSimilarity(long baseP, long baseC, long pP, long pC, double wP, double wC) {
+        double sP = hashSimilarity(baseP, pP);
+        double sC = hashSimilarity(baseC, pC);
+        return wP * sP + wC * sC;
+    }
+
+    /** 64비트 해시 간 유사도 (1 - 해밍거리/64) */
+    private double hashSimilarity(long h1, long h2) {
+        int dist = Long.bitCount(h1 ^ h2);
+        return 1.0 - (dist / 64.0);
+    }
+
+    private double[][] toGrayscaleMatrix(BufferedImage img) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        double[][] m = new double[w][h];
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int rgb = img.getRGB(x, y);
+                int r = (rgb >> 16) & 0xFF;
+                int g = (rgb >> 8) & 0xFF;
+                int b = rgb & 0xFF;
+                // 표준 가중치 그레이스케일 변환
+                m[x][y] = 0.299 * r + 0.587 * g + 0.114 * b;
+            }
+        }
+        return m;
+    }
+
+    private BufferedImage resize(BufferedImage src, int w, int h) {
+        BufferedImage dst = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = dst.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(src, 0, 0, w, h, null);
+        g.dispose();
+        return dst;
+    }
+
+    /** 간단한 2D DCT 구현 */
+    private double[][] dct2D(double[][] input) {
+        int N = input.length; // 가정: 정사각형
+        double[][] output = new double[N][N];
+
+        double c0 = 1.0 / Math.sqrt(N);
+        double c = Math.sqrt(2.0) / Math.sqrt(N);
+
+        for (int u = 0; u < N; u++) {
+            for (int v = 0; v < N; v++) {
+                double sum = 0.0;
+                for (int x = 0; x < N; x++) {
+                    for (int y = 0; y < N; y++) {
+                        sum += input[x][y]
+                                * Math.cos(((2 * x + 1) * u * Math.PI) / (2.0 * N))
+                                * Math.cos(((2 * y + 1) * v * Math.PI) / (2.0 * N));
+                    }
+                }
+                double au = (u == 0) ? c0 : c;
+                double av = (v == 0) ? c0 : c;
+                output[u][v] = au * av * sum;
+            }
+        }
+        return output;
+    }
+
+    private double median(double[] arr) {
+        double[] copy = arr.clone();
+        java.util.Arrays.sort(copy);
+        int n = copy.length;
+        if (n % 2 == 1) return copy[n / 2];
+        return (copy[n / 2 - 1] + copy[n / 2]) / 2.0;
+    }
+
+    private double round4(double v) {
+        return Math.round(v * 10000.0) / 10000.0;
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/furniture/client/FastApiImageHashClient.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/client/FastApiImageHashClient.java
@@ -11,7 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
         name = "imageHashClient",
-        url = "${external.image-api.base-url}"
+        url = "${external.image-api.base-url}",
+        primary = false
 )
 public interface FastApiImageHashClient {
 

--- a/src/main/java/or/sopt/houme/domain/openai/client/FastApiImageClient.java
+++ b/src/main/java/or/sopt/houme/domain/openai/client/FastApiImageClient.java
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
         name = "imageClient",
-        url = "${external.image-api.base-url}"
+        url = "${external.image-api.base-url}",
+        primary = false
 )
 public interface FastApiImageClient {
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #350 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

기존의 복잡하게 꼬여있던 RAG 파이프라인과 벡터 DB 관련 로직을 삭제하고 필수 로직만 Spring으로 구현해두었습니다.
Feign으로 추상화되어있던 로직을 바로 open ai로 호출 할 수 있도록 구현체를 구현하고 구현체를 우선 주입하도록 @Primary를 통해 강제하였습니다.

속도는 22s로 확실히 개선되었습니다.

hash 로직은 인공지능의 도움을 많이 받았습니다 ㅎㅎ...


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 일단 제가 주요로직을 돌려보았을때의 문제점은 발견되지는 않았습니다만, 실제 배포환경에서 테스트가 되어봐야 할 것 같습니다.
- 무섭네요

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1071" height="356" alt="image" src="https://github.com/user-attachments/assets/c85e3088-38e1-413c-a1a9-8201d63c7c86" />