### PR TITLE
[CHORE] 소셜로그인 로직 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
@@ -28,23 +28,23 @@ public class OAuthController {
 
     @GetMapping("/oauth/kakao")
     @Operation(summary = "카카오 소셜로그인 API",
-            description = "카카오로 로그인 요청을 전송합니다. <br><br>" +
-                    "카카오 인증서버로 요청을 보내고 그 후에 **localhost:3000**로 리다이렉트 됩니다. <br><br>" +
-                    "리다이렉트 주소에 포함되어 있는 인가코드를 밑의 API의 파라미터에 넣어주세요")
-    public void kakaoOAuthCallback(HttpServletResponse response) throws IOException {
+            description = "카카오 인증서버로 리다이렉트합니다. <br><br>" +
+                    "요청의 Origin(예: http://localhost:5173, https://www.houme.kr)을 기반으로 동적으로 redirect_uri를 계산합니다. <br><br>" +
+                    "프론트에서 인가코드(code)를 파싱하여 아래 콜백 API로 전달하세요.")
+    public void kakaoOAuthCallback(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        String redirectAddress = oAuthService.requestRedirect();
+        String redirectAddress = oAuthService.requestRedirect(request);
         response.sendRedirect(redirectAddress);
     }
 
 
     @Operation(summary = "카카오 인증서버 토큰 검증 API",
-    description = "리다이렉트에서 AccessCode를 가지고 서버로 돌아오기 위한 엔드포인트입니다 <br><br><br>" +
-            "해당 코드를 이용해서 사용자 정보를 파싱하고 **액세스 토큰는 헤더에, 리프레시 토큰은 쿠키에 담아** 반환합니다")
+    description = "프론트에서 전달한 code를 이용해 토큰 교환 및 로그인 처리를 수행합니다. <br><br>" +
+            "액세스 토큰은 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다.")
     @GetMapping("/oauth/kakao/callback")
-    public ResponseEntity<ApiResponse<Boolean>> kakaoLogin(@RequestParam("code") String accessCode, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Boolean>> kakaoLogin(@RequestParam("code") String accessCode, HttpServletRequest request, HttpServletResponse response) {
 
-        Boolean result = oAuthService.kakaoLogin(accessCode, response);
+        Boolean result = oAuthService.kakaoLogin(accessCode, request, response);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -2,7 +2,6 @@ package or.sopt.houme.domain.user.service;
 
 import feign.FeignException;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +25,12 @@ import or.sopt.houme.global.config.KaKaoConfig;
 import or.sopt.houme.global.jwt.JWTUtil;
 import or.sopt.houme.global.util.CookieUtil;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -55,15 +59,26 @@ public class OAuthService {
      * 현재 fallback 로직이 구현되어있지 않습니다. 아직 Feign의 fallback factory에 대한 학습이 부족해서...
      * 앱잼기간내에 구현해보겠습니다 FIXME
      * */
-    public String requestRedirect() {
+
+    /**
+     *
+     *
+     * */
+    public String requestRedirect(HttpServletRequest request) {
+        String redirectBase = resolveRedirectBase(request);
+        String redirectUri = redirectBase + "/oauth/kakao/callback";
+
+        String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
+        String encodedScope = URLEncoder.encode(kaKaoConfig.getScope(), StandardCharsets.UTF_8);
+
         return String.format(
-                "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code",
-                kaKaoConfig.getClientId(), kaKaoConfig.getRedirectUri()
+                "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s",
+                kaKaoConfig.getClientId(), encodedRedirect, encodedScope
         );
     }
 
 
-    public Boolean kakaoLogin(String accessCode, HttpServletResponse response) {
+    public Boolean kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
 
         // 신규회원인지 검증하는 필드
         Boolean isNewUser = false;
@@ -78,7 +93,9 @@ public class OAuthService {
         KaKaoOAuthTokenDTO authorizationCode;
         try {
             log.info("액세스 토큰 발급을 시작합니다");
-            authorizationCode = getKaKaoOAuthTokenDTO(accessCode);
+            String redirectBase = resolveRedirectBase(request);
+            String redirectUri = redirectBase + "/oauth/kakao/callback";
+            authorizationCode = getKaKaoOAuthTokenDTO(accessCode, redirectUri);
         } catch (FeignException e) {
             log.info(e.getMessage());
             throw new UserException(ErrorCode.KAKAO_AUTH_CODE_INVALID);
@@ -177,13 +194,30 @@ public class OAuthService {
 
 
 
-    private KaKaoOAuthTokenDTO getKaKaoOAuthTokenDTO(String accessCode) {
-
+    private KaKaoOAuthTokenDTO getKaKaoOAuthTokenDTO(String accessCode, String redirectUri) {
         return kaKaoOAuthClient.getToken(
                 "authorization_code",
                 kaKaoConfig.getClientId(),
-                kaKaoConfig.getRedirectUri(),
+                redirectUri,
                 accessCode
         );
+    }
+
+    private String resolveRedirectBase(HttpServletRequest request) {
+        String origin = request.getHeader("Origin");
+        if (StringUtils.hasText(origin)) {
+            return origin;
+        }
+
+        String scheme = java.util.Objects.toString(request.getHeader("X-Forwarded-Proto"), request.getScheme());
+        String forwardedHost = request.getHeader("X-Forwarded-Host");
+        if (StringUtils.hasText(forwardedHost)) {
+            return scheme + "://" + forwardedHost;
+        }
+
+        String host = request.getServerName();
+        int port = request.getServerPort();
+        boolean isDefault = ("http".equalsIgnoreCase(scheme) && port == 80) || ("https".equalsIgnoreCase(scheme) && port == 443);
+        return scheme + "://" + host + (isDefault ? "" : ":" + port);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -71,6 +71,8 @@ public class OAuthService {
         String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
         String encodedScope = URLEncoder.encode(kaKaoConfig.getScope(), StandardCharsets.UTF_8);
 
+        log.info("소셜로그인 주소입니다: {}", encodedRedirect);
+
         return String.format(
                 "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s",
                 kaKaoConfig.getClientId(), encodedRedirect, encodedScope
@@ -96,6 +98,9 @@ public class OAuthService {
             String redirectBase = resolveRedirectBase(request);
             String redirectUri = redirectBase + "/oauth/kakao/callback";
             authorizationCode = getKaKaoOAuthTokenDTO(accessCode, redirectUri);
+
+            log.info("인가코드를 발급하기 위한 리다이렉트 주소입니다: {}", redirectUri);
+
         } catch (FeignException e) {
             log.info(e.getMessage());
             throw new UserException(ErrorCode.KAKAO_AUTH_CODE_INVALID);

--- a/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
@@ -21,7 +21,7 @@ public class WhiteListConfig {
     // oauth 관련 인가 설정
     public static final List<String> oauthWhitelist() {
         return List.of(
-                "/oauth/kakao/",
+                "/oauth/kakao",
                 "/oauth/kakao/callback",
                 "/access",
                 "/reissue"

--- a/src/test/java/or/sopt/houme/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/OAuthControllerTest.java
@@ -62,7 +62,7 @@ class OAuthControllerTest {
     @DisplayName("GET /oauth/kakao 요청 시 카카오 인증서버로 리다이렉트된다")
     void testKakaoOAuthRedirect() throws Exception {
         // given
-        when(oAuthService.requestRedirect()).thenReturn("https://kauth.kakao.com/oauth");
+        when(oAuthService.requestRedirect(any(HttpServletRequest.class))).thenReturn("https://kauth.kakao.com/oauth");
 
         // when & then
         mockMvc.perform(get("/oauth/kakao"))
@@ -74,7 +74,7 @@ class OAuthControllerTest {
     @DisplayName("GET /oauth/kakao/callback 요청 시 카카오 로그인 성공 여부가 반환된다")
     void testKakaoLoginCallback() throws Exception {
         // given
-        when(oAuthService.kakaoLogin(eq("abc123"), any(HttpServletResponse.class))).thenReturn(true);
+        when(oAuthService.kakaoLogin(eq("abc123"), any(HttpServletRequest.class), any(HttpServletResponse.class))).thenReturn(true);
 
         // when & then
         mockMvc.perform(get("/oauth/kakao/callback")

--- a/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
@@ -66,12 +66,18 @@ class OAuthServiceTest {
     @DisplayName("카카오 인증 요청 URL을 생성한다")
     void requestRedirectTest() {
         when(kaKaoConfig.getClientId()).thenReturn("client-id");
-        when(kaKaoConfig.getRedirectUri()).thenReturn("http://localhost:3000/oauth/kakao/callback");
+        when(kaKaoConfig.getScope()).thenReturn("profile_nickname,account_email");
 
-        String result = oAuthService.requestRedirect();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+
+        String result = oAuthService.requestRedirect(request);
+
+        String expectedRedirect = java.net.URLEncoder.encode("http://localhost:5173/oauth/kakao/callback", java.nio.charset.StandardCharsets.UTF_8);
+        String expectedScope = java.net.URLEncoder.encode("profile_nickname,account_email", java.nio.charset.StandardCharsets.UTF_8);
 
         assertEquals(
-                "https://kauth.kakao.com/oauth/authorize?client_id=client-id&redirect_uri=http://localhost:3000/oauth/kakao/callback&response_type=code",
+                "https://kauth.kakao.com/oauth/authorize?client_id=client-id&redirect_uri=" + expectedRedirect + "&response_type=code&scope=" + expectedScope,
                 result
         );
     }
@@ -112,7 +118,10 @@ class OAuthServiceTest {
         when(cookieConfig.getSameSite()).thenReturn("true");
 
         // When
-        Boolean result = oAuthService.kakaoLogin(code, response);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+
+        Boolean result = oAuthService.kakaoLogin(code, request, response);
 
         // Then
         assertTrue(result); // 신규 회원이므로 true
@@ -125,13 +134,15 @@ class OAuthServiceTest {
     @Test
     @DisplayName("kakaoLogin() 중, 인가 코드가 null이면 정해진 예외가 발생한다")
     void whenNullCode_thenThrowException() {
-        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(null, response));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(null, request, response));
     }
 
     @Test
     @DisplayName("kakaoLogin() 중, 인가 코드가 빈 문자열이면 정해진 예외가 발생한다")
     void whenEmptyCode_thenThrowException() {
-        assertThrows(UserException.class, () -> oAuthService.kakaoLogin("", response));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertThrows(UserException.class, () -> oAuthService.kakaoLogin("", request, response));
     }
 
     @Test
@@ -141,7 +152,9 @@ class OAuthServiceTest {
         when(kaKaoOAuthClient.getToken(any(), any(), any(), any()))
                 .thenThrow(FeignException.class);
 
-        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(accessCode, response));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(accessCode, request, response));
     }
 
     @Test
@@ -155,7 +168,9 @@ class OAuthServiceTest {
         when(kaKaoUserInfoClient.getUserInfo("Bearer kakaoAccessToken"))
                 .thenThrow(FeignException.class);
 
-        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(accessCode, response));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+        assertThrows(UserException.class, () -> oAuthService.kakaoLogin(accessCode, request, response));
     }
 
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #364 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

주요하게 바뀐 부분은

```

    public String requestRedirect(HttpServletRequest request) {
        String redirectBase = resolveRedirectBase(request);
        String redirectUri = redirectBase + "/oauth/kakao/callback";

        String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
        String encodedScope = URLEncoder.encode(kaKaoConfig.getScope(), StandardCharsets.UTF_8);

        log.info("소셜로그인 주소입니다: {}", encodedRedirect);

        return String.format(
                "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s",
                kaKaoConfig.getClientId(), encodedRedirect, encodedScope
        );
    }

```

이 부분일거라고 생각합니다.
해당 부분은 요청 주소의 Origin을 파싱하여 해당 주소를 기반으로 리다이렉트 주소를 만들게 됩니다. 그러면 houme.kr이든 localhost든 무관하게 리다이렉트 주소로 사용 할 수 있게 됩니다.

관련하여 Scheme을 파싱할 수 있도록 구현한 헬퍼 메서드들이 아래와 같습니다.

```

    private String resolveRedirectBase(HttpServletRequest request) {
        String origin = request.getHeader("Origin");
        if (StringUtils.hasText(origin)) {
            return origin;
        }

        String scheme = java.util.Objects.toString(request.getHeader("X-Forwarded-Proto"), request.getScheme());
        String forwardedHost = request.getHeader("X-Forwarded-Host");
        if (StringUtils.hasText(forwardedHost)) {
            return scheme + "://" + forwardedHost;
        }

        String host = request.getServerName();
        int port = request.getServerPort();
        boolean isDefault = ("http".equalsIgnoreCase(scheme) && port == 80) || ("https".equalsIgnoreCase(scheme) && port == 443);
        return scheme + "://" + host + (isDefault ? "" : ":" + port);
    }


```



## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

Q. 그럼 기존의 로그인 방식에 문제가 발생하진 않을까요?

A. 아마 발생하지 않을 것으로 예상되긴 합니다. 왜냐면 기존의 로그인 프로세스가 /oauth/kakao 엔드포인트로 요청을 날리는게 아닌, 고정된 리다이렉트 주소로 날렸을 것으로 예상되기 때문이에요.
-> 고로 아마 이 로그인 방식을 사용하려면 클라이언트의 소셜로그인 로직이 바뀌어야 할 것으로 예상됩니다....!


사실 로직 자체에 대한 구현은 한참 전에 구상이 됐었는데 클라이언트 개발자 분들과 협업이 필요한 부분이라 미루다가 이제야 PR을 올리게 됐네요. 한 번씩 확인해보시고 우려되는 포인트 있으시면 말씀해주세요!!
문제가 없다면 배포 후에도 문제가 없는지 확인을 해봐야 할 것 같아서 @earl9rey 클라이언트 로그인 담당자 성하님도 리뷰어에 추가해두었습니다!



+) 해당 방식으로 구현되면서부터는 서버 개발자분들도 소셜로그인이 로컬에서 가능해지십니다.



## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
