### PR TITLE
[CHORE] 소셜로그인 임시 로직 리팩터링

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
@@ -36,7 +36,9 @@ public class OAuthController {
                                    HttpServletRequest request,
                                    HttpServletResponse response) throws IOException {
 
-        String redirectAddress = oAuthService.requestRedirect(request, env);
+        String redirectAddress = (env == null)
+                ? oAuthService.requestRedirect(request)
+                : oAuthService.requestRedirect(request, env);
         response.sendRedirect(redirectAddress);
     }
 
@@ -50,7 +52,9 @@ public class OAuthController {
                                                            HttpServletRequest request,
                                                            HttpServletResponse response) {
 
-        Boolean result = oAuthService.kakaoLogin(accessCode, env, request, response);
+        Boolean result = (env == null)
+                ? oAuthService.kakaoLogin(accessCode, request, response)
+                : oAuthService.kakaoLogin(accessCode, env, request, response);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
@@ -29,11 +29,14 @@ public class OAuthController {
     @GetMapping("/oauth/kakao")
     @Operation(summary = "카카오 소셜로그인 API",
             description = "카카오 인증서버로 리다이렉트합니다. <br><br>" +
-                    "요청의 Origin(예: http://localhost:5173, https://www.houme.kr)을 기반으로 동적으로 redirect_uri를 계산합니다. <br><br>" +
+                    "env 파라미터(local|dev)를 전달하면 해당 환경 기준으로 redirect_uri를 고정 생성합니다. <br>" +
+                    "env 미전달 시 기존 로직(헤더 기반 추정)으로 동작합니다. <br><br>" +
                     "프론트에서 인가코드(code)를 파싱하여 아래 콜백 API로 전달하세요.")
-    public void kakaoOAuthCallback(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void kakaoOAuthCallback(@RequestParam(value = "env", required = false) String env,
+                                   HttpServletRequest request,
+                                   HttpServletResponse response) throws IOException {
 
-        String redirectAddress = oAuthService.requestRedirect(request);
+        String redirectAddress = oAuthService.requestRedirect(request, env);
         response.sendRedirect(redirectAddress);
     }
 
@@ -42,9 +45,12 @@ public class OAuthController {
     description = "프론트에서 전달한 code를 이용해 토큰 교환 및 로그인 처리를 수행합니다. <br><br>" +
             "액세스 토큰은 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다.")
     @GetMapping("/oauth/kakao/callback")
-    public ResponseEntity<ApiResponse<Boolean>> kakaoLogin(@RequestParam("code") String accessCode, HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Boolean>> kakaoLogin(@RequestParam("code") String accessCode,
+                                                           @RequestParam(value = "env", required = false) String env,
+                                                           HttpServletRequest request,
+                                                           HttpServletResponse response) {
 
-        Boolean result = oAuthService.kakaoLogin(accessCode, request, response);
+        Boolean result = oAuthService.kakaoLogin(accessCode, env, request, response);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -64,8 +64,8 @@ public class OAuthService {
      *
      *
      * */
-    public String requestRedirect(HttpServletRequest request) {
-        String redirectBase = resolveRedirectBase(request);
+    public String requestRedirect(HttpServletRequest request, String env) {
+        String redirectBase = resolveRedirectBase(request, env);
         String redirectUri = redirectBase + "/oauth/kakao/callback";
 
         String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
@@ -80,7 +80,7 @@ public class OAuthService {
     }
 
 
-    public Boolean kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
+    public Boolean kakaoLogin(String accessCode, String env, HttpServletRequest request, HttpServletResponse response) {
 
         // 신규회원인지 검증하는 필드
         Boolean isNewUser = false;
@@ -95,7 +95,7 @@ public class OAuthService {
         KaKaoOAuthTokenDTO authorizationCode;
         try {
             log.info("액세스 토큰 발급을 시작합니다");
-            String redirectBase = resolveRedirectBase(request);
+            String redirectBase = resolveRedirectBase(request, env);
             String redirectUri = redirectBase + "/oauth/kakao/callback";
             authorizationCode = getKaKaoOAuthTokenDTO(accessCode, redirectUri);
 
@@ -224,5 +224,20 @@ public class OAuthService {
         int port = request.getServerPort();
         boolean isDefault = ("http".equalsIgnoreCase(scheme) && port == 80) || ("https".equalsIgnoreCase(scheme) && port == 443);
         return scheme + "://" + host + (isDefault ? "" : ":" + port);
+    }
+
+    /**
+     * 로컬 환경이면 로컬주소, 배포환경이면 배포환경의 주소로 리다이렉트 합니다.
+     * */
+    private String resolveRedirectBase(HttpServletRequest request, String env) {
+        if (StringUtils.hasText(env)) {
+            if ("local".equalsIgnoreCase(env)) {
+                return "http://localhost:5173";
+            }
+            if ("dev".equalsIgnoreCase(env)) {
+                return "https://www.houme.kr";
+            }
+        }
+        return resolveRedirectBase(request);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -158,6 +158,15 @@ public class OAuthService {
         return isNewUser;
     }
 
+    // Backward-compatible overloads for existing tests and callers
+    public String requestRedirect(HttpServletRequest request) {
+        return requestRedirect(request, null);
+    }
+
+    public Boolean kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
+        return kakaoLogin(accessCode, null, request, response);
+    }
+
 
     /**
      * @param userDetails userDetails 에서 회원의 id를 받아서 그걸로 리프레시 토큰을 삭제합니다


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #366 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
클라이언트에서 href를 날리게 되면 Origin 헤더가 비어버리는 이슈로 인해서 자동으로 서버의 주소인 dev.houme.kr로 박혀 들어가는 이슈가 존재하였습니다.

그래서 명시적으로 local/dev 환경을 분리하여 파라미터를 받아서 소셜로그인 환경을 분리하는 구현방법을 고안하였습니다.
절대 좋은 구현방법이 아닌 것을 알기에 추후 수정 사항은 다음과 같습니다.

1. 소셜로그인 로직을 서버가 전담하도록 리팩터링
2. 배포, 개발 환경 분리에 따른 환경변수 분리

둘 중 하나를 사용하면 이 문제를 확실하게 해결 할 수 있습니다. 결국 1번으로 돌아가는 상황은 막아보고 싶네요. 책임분리를 위해서 시작한 것이기 때문에 일단은 해당 구현으로 임시로 막아두고 추후 리팩터링 하겠습니다.


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

```
    /**
     * 로컬 환경이면 로컬주소, 배포환경이면 배포환경의 주소로 리다이렉트 합니다.
     * */
    private String resolveRedirectBase(HttpServletRequest request, String env) {
        if (StringUtils.hasText(env)) {
            if ("local".equalsIgnoreCase(env)) {
                return "http://localhost:5173";
            }
            if ("dev".equalsIgnoreCase(env)) {
                return "https://www.houme.kr";
            }
        }
        return resolveRedirectBase(request);
    }

```

이 로직에서 BaseUrl이 그대로 노출되는 것이 우려되실 수 있으실 것 같은데요. 사실 이는 클라이언트 단의 BaseURL로서, 코드에 노출되어도 큰 문제가 발생하는 영역은 아니라 보안적인 issue는 적을 것이라고 생각합니다.

그러면 이제 환경변수로 관리하지 않고 하드코딩되어 있기 때문에 유지보수적으로 불리하지 않냐라는 의문을 제기 할 수 있어요. 일단 이에 대해서 반박해보자면

1. 해당 변수는 이 클래스 이외에 어느곳에도 사용되지 않음 -> 유지보수에 불리할만한 일이 없습니다.
2. 배포환경 분리가 진행된다면 사라질 로직 -> 유지보수의 대상이 아닙니다.

두가지의 이유로 이를 그냥 하드코딩하였습니다. 참고해주시면 감사하겠습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
