### PR TITLE
[CHORE] prod 환경 CI&CD 구현

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,0 +1,99 @@
+name: prod-cd
+
+on:
+  push:
+    branches: [ "prod" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: checkout the code
+        uses: actions/checkout@v4
+
+      - name: AWS 설정
+        id: credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Remove application-local.yml
+        run: |
+          rm -f src/main/resources/application-local.yml
+
+      - name: Add application-prod.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_PROD }}" > ./src/main/resources/application-prod.yml
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      - name: Jib로 이미지 빌드 및 ECR 업로드
+        run: ./gradlew jib -PjibToImage=${{ secrets.ECR_REGISTRY }} -PjibTag=runid-${{ github.run_id }}
+
+
+      - name: Deploy (ECR pull -> restart)
+        uses: appleboy/ssh-action@v1.0.3
+        id: deploy
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: runid-${{ github.run_id }}
+          CONTAINER_NAME: houme
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script_stop: true
+          envs: AWS_REGION,ECR_REGISTRY,IMAGE_TAG,CONTAINER_NAME
+          script: |
+            set -euo pipefail
+
+            ECR_IMAGE_REPO="${ECR_REGISTRY}"
+            IMAGE="${ECR_IMAGE_REPO}:${IMAGE_TAG}"
+            REGISTRY_HOST="${ECR_IMAGE_REPO%%/*}"
+
+            aws ecr get-login-password --region "${AWS_REGION}" \
+              | sudo docker login --username AWS --password-stdin "${REGISTRY_HOST}"
+
+            sudo docker pull "${IMAGE}"
+
+            for name in "${CONTAINER_NAME}" blue green; do
+              if sudo docker ps -aq -f "name=^${name}$" | grep -q .; then
+                sudo docker stop "${name}" || true
+                sudo docker rm "${name}" || true
+              fi
+            done
+
+            sudo docker run -d --name "${CONTAINER_NAME}" --restart unless-stopped \
+              -p 8080:8080 \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e SERVER_ENV=prod \
+              "${IMAGE}"
+
+            for i in {1..20}; do
+              if curl -sf "http://localhost:8080/actuator/health" > /dev/null; then
+                echo "healthy"
+                sudo docker image prune -f
+                exit 0
+              fi
+              sleep 3
+            done
+
+            sudo docker logs --tail 200 "${CONTAINER_NAME}" || true
+            exit 1

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -11,15 +11,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      
+      - name: checkout the code
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: "temurin"
-
-      - name: checkout the code
-        uses: actions/checkout@v4
 
       - name: AWS 설정
         id: credentials

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,0 +1,121 @@
+name: develop-ci
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches: [prod]
+    paths:
+      - 'src/**'
+      - 'build.gradle'
+
+jobs:
+  test:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      # redis 설정
+      - name: set up redis
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: 'latest'
+
+      - name: checkout the code
+        uses: actions/checkout@v4
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '8.8'  # 사용하려는 Gradle 버전 명시
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Add application-test.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_TEST }}" > ./src/main/resources/application-test.yml
+
+      - name: Run Gradle build and tests
+        run: |
+          ./gradlew clean build -Dspring.profiles.active=test
+          ./gradlew jacocoTestReport
+      - name: Jacoco Report to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: 📝 Code Coverage
+          paths: ${{ github.workspace }}/build/reports/jacoco/index/jacoco.xml
+          token: ${{ secrets.ACCESS_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          update-comment: true
+      - name: Upload jacoco HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: ${{ github.workspace }}/build/reports/jacoco/index/html/
+      - name: Get the Coverage info
+        run: |
+          echo "🍀총 커버리지 ${{ steps.jacoco.outputs.coverage-overall }}"
+          echo "☘️변경된 파일들 커버리지 ${{ steps.jacoco.outputs.coverage-changed-files }}"
+      - name: 테스트 결과 PR 코멘트에 등록
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+      - name: 테스트 실패시 코드 라인에 대한 체크 추가
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+  # Discord 알림란
+  notify-discord-ci:
+    needs: test # test job이 끝나야 실행
+    runs-on: ubuntu-latest
+    if: always()  # 성공하든 실패하든
+    steps:
+      - name: 디스코드 알림
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          STATUS: ${{ needs.test.result }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          message="✅ PROD-CI 성공"
+          color=3066993 # 초록
+          if [ "$STATUS" = "skipped" ]; then
+            message="⏭️ CI 스킵"
+            color=8359053 # 회색
+          elif [ "$STATUS" != "success" ]; then
+            message="❌ PROD-CI 실패"
+            color=15158332 # 빨강
+          fi
+          # 디스코드에 보낼 payload JSON 생성
+          # actor: 작성자, message: CI 완수 메시지, pr_url: PR 링크
+          pr_title="$PR_TITLE"
+          payload=$(jq -n --arg actor "${{ github.actor }}" \
+                          --arg message "$message" \
+                          --arg pr_url "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+                          --arg pr_title "$pr_title" \
+                          --argjson color "$color" \
+            '{
+              # discord에 등록될 메시지 형태
+              "embeds": [
+                {
+                  "title": "🏚️ PROD-PR이 생성되었습니다!",
+                  "description": "\($actor)님이 PR을 만들었습니다!\n📄 \($pr_title) \n \($message)\n🔗[워크플로우 실행 확인하기](\($pr_url))",
+                  "color": $color,
+                  "timestamp": now | todateiso8601
+                }
+              ]
+            }')
+
+            # discord  웹훅 URL로 서버에 Post 요청
+          curl  -H "Content-Type: application/json" \
+                -X POST \
+                -d "$payload" \
+                "$DISCORD_WEBHOOK"

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,4 +1,4 @@
-name: develop-ci
+name: prod-ci
 on:
   pull_request:
     types: [opened, synchronize, closed]


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #377 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

기존의 dev->prod로 전환하고 새로운 dev 환경을 만드는게 목표였으나....
기존의 dev라는 명칭으로 들어가있는 환경변수와 스크립트가 너무 많이 존재하는 문제가 있었습니다.

하나하나 다 들어가서 수정하다가 되돌릴 수 없는 빌드 오류가 우려되어, 새로운 prod 환경을 구축하는 방향으로 구현하였습니다.


현재까지 구현된 내용은 다음과 같습니다.

```

1. prod.houme.kr 인스턴스 생성 및 https 연결
2. cd&ci 스크립트 구현

```

개선사항으로는 다음과 같습니다.

```

1. 배포서버와 개발서버가 같은 DB를 공유하고 있음 -> dev서버 DB 로컬로 분리
2. prod서버 무중단 배포 구현 (배포가 제대로 되는지 확인 후 블루그린으로 구현하도록 합니다)
3. dev서버 사양을 t2.micro로 낮추고 prod 서버를 상향
4. 서버 이전에 따른 모니터링 (Grafana, Metabase 등) 구현

```



## 🙏 Question & PR point

추후 확장까지 고려한 리뷰 부탁드리겠습니다


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
