### PR TITLE
[HOTFIX] 기존 Dev profile -> Prod profile로 전환

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -1,22 +1,26 @@
-name: develop-cd.yml
+name: develop-cd
+
 on:
-  pull_request:
-    types: [synchronize, closed, opened]
-    branches: [develop]
-    paths:
-      - 'src/**'
-      - 'build.gradle'
+  push:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
 
 jobs:
-  image-build:
-    if: github.event.pull_request.merged == true
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
+      
       - name: checkout the code
         uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+
       - name: AWS 설정
         id: credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -29,220 +33,68 @@ jobs:
         run: |
           rm -f src/main/resources/application-local.yml
 
-      - name: Add application-blue.yml
+      - name: Add application-prod.yml
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_BLUE }}" > ./src/main/resources/application-blue.yml
+          echo "${{ secrets.APPLICATION_PROD }}" > ./src/main/resources/application-prod.yml
 
-      - name: Add application-green.yml
+      - name: Build with Gradle
         run: |
-          mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_GREEN }}" > ./src/main/resources/application-green.yml
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
 
-      - name: Add application.yml
-        run: |
-          mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_DEFAULT }}" > ./src/main/resources/application.yml
-
-      - name: Add application-dev.yml
-        run: |
-          mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_DEV }}" > ./src/main/resources/application-dev.yml
       - name: Jib로 이미지 빌드 및 ECR 업로드
         run: ./gradlew jib -PjibToImage=${{ secrets.ECR_REGISTRY }} -PjibTag=runid-${{ github.run_id }}
 
-  deploy:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    needs: [ image-build ]
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Set target IP
-        run: |
-          STATUS=$(curl -k -o /dev/null -w "%{http_code}" "https://${{ secrets.HOUME_DOMAIN }}/actuator/health")
-          echo $STATUS
-          if [ $STATUS = 200 ]; then
-            CURRENT_UPSTREAM=$(curl -s -k https://${{ secrets.HOUME_DOMAIN }}/api/v1/env | jq -r '.env')
-          else
-            CURRENT_UPSTREAM=green
-          fi
-          echo CURRENT_UPSTREAM=$CURRENT_UPSTREAM >> $GITHUB_ENV
-          echo $CURRENT_UPSTREAM
-          if [ $CURRENT_UPSTREAM = blue ]; then
-            echo "CURRENT_PORT=8080" >> $GITHUB_ENV
-            echo "STOPPED_PORT=8081" >> $GITHUB_ENV
-            echo "TARGET_UPSTREAM=green" >> $GITHUB_ENV
-          elif [ $CURRENT_UPSTREAM = green ]; then
-            echo "CURRENT_PORT=8081" >> $GITHUB_ENV
-            echo "STOPPED_PORT=8080" >> $GITHUB_ENV
-            echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
-          else
-            echo "error"
-            exit 1
-          fi
 
-      - name: Docker 로그인
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Docker compose
+      - name: Deploy (ECR pull -> compose up)
         uses: appleboy/ssh-action@v1.0.3
+        id: deploy
         env:
-          TARGET_UPSTREAM: ${{ env.TARGET_UPSTREAM }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: runid-${{ github.run_id }}
         with:
+          host: ${{ secrets.DEVELOP_HOST }}
           username: ubuntu
-          host: ${{ secrets.HOUME_SERVER_IP }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script_stop: true
+          envs: AWS_REGION,ECR_REGISTRY,IMAGE_TAG
           script: |
-            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | sudo docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
-            sudo docker pull ${{ secrets.ECR_REGISTRY }}:latest
-            sudo docker compose -f deploy/docker-compose-${{ env.TARGET_UPSTREAM }}.yml up -d
+            set -euo pipefail
 
-      - name: 새로운 서버 헬스체킹 (재시도 15회, 5초 간격)
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          username: ubuntu
-          host: ${{ secrets.HOUME_SERVER_IP }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            STOPPED_PORT="${{ env.STOPPED_PORT }}"
-            echo "📌 STOPPED_PORT is $STOPPED_PORT"
-            for i in {1..15}
-            do
-              STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$STOPPED_PORT/actuator/health)
-              echo "[$i] $STOPPED_PORT Health check response code: $STATUS"
-              if [ "$STATUS" = "200" ]; then
-                echo "서버 확인"
+            cd /home/ubuntu/infra
+
+            # IAM role 확인(선택)
+            aws sts get-caller-identity
+
+            # ECR 로그인
+            REGISTRY_HOST="${ECR_REGISTRY%%/*}"
+            aws ecr get-login-password --region "${AWS_REGION}" \
+              | sudo docker login --username AWS --password-stdin "${REGISTRY_HOST}"
+
+            # compose가 읽을 .env 갱신
+            printf "ECR_REGISTRY=%s\nIMAGE_TAG=%s\n" "${ECR_REGISTRY}" "${IMAGE_TAG}" | sudo tee /home/ubuntu/infra/.env > /dev/null
+
+            # 최신 이미지 pull + 컨테이너 교체
+            sudo docker compose pull app
+            
+            # ★ 추가
+            if sudo docker ps -aq -f "name=^houme$" | grep -q .; then
+            sudo docker rm -f houme || true
+            fi
+            
+            sudo docker compose up -d --remove-orphans
+
+            # 헬스체크
+            for i in {1..20}; do
+              if curl -sf "http://localhost:8080/actuator/health" > /dev/null; then
+                echo "healthy"
+                sudo docker image prune -f
                 exit 0
               fi
-              sleep 5
+              sleep 3
             done
-            echo "서버 헬스체크 실패"
+
+            sudo docker compose logs --tail 200 app || true
             exit 1
-
-      - name: nginx upstream 변경
-        uses: appleboy/ssh-action@master
-        with:
-          username: ubuntu
-          host: ${{ secrets.HOUME_SERVER_IP }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script_stop: true
-          script: |
-            echo "set \$service_url ${{ env.TARGET_UPSTREAM }};" | sudo tee /etc/nginx/sites-enabled/service-env.inc
-            sudo nginx -t && sudo nginx -s reload
-
-      - name: 기존 서버 중지
-        uses: appleboy/ssh-action@master
-        with:
-          username: ubuntu
-          host: ${{ secrets.HOUME_SERVER_IP }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script_stop: true
-          script: |
-            if [ "$(sudo docker ps -aq -f name=${{ env.CURRENT_UPSTREAM }})" ]; then
-              sudo docker stop ${{ env.CURRENT_UPSTREAM }}
-              sudo docker rm ${{ env.CURRENT_UPSTREAM }}
-            else
-              echo "No container named ${{ env.CURRENT_UPSTREAM }} found. Skipping stop & remove."
-            fi
-
-      - name: 기존 도커 이미지 제거
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          username: ubuntu
-          host: ${{ secrets.HOUME_SERVER_IP }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script_stop: true
-          script: |
-            sudo docker image prune -f
-
-  notify-discord-cd:
-    needs: deploy
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: 디스코드 알림
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          STATUS: ${{ needs.deploy.result }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          actor="${{ github.actor }}"
-          pr_title="$PR_TITLE"
-          pr_url="https://github.com/${REPO}/pull/${{ github.event.pull_request.number }}"
-          action_url="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-
-          if [ "$STATUS" = "success" ]; then
-            icon="✅"
-            color=3066993
-            description="$icon **$actor** 님이 배포를 성공적으로 완료했습니다! 🎉
-            📄 PR 제목: *${pr_title}*
-            🔗 PR 링크: ${pr_url}"
-          elif [ "$STATUS" = "skipped" ]; then
-            icon="⏭️"
-            color=8359053
-            description="$icon **$actor** 님의 배포 job이 스킵되었습니다.
-            🔍 워크플로 조건을 확인해주세요.
-            🔗 PR 링크: ${pr_url}"
-          elif [ "$STATUS" = "cancelled" ]; then
-            icon="⚪"
-            color=9807270    # 회색 계열
-            description="$icon **$actor** 님이 배포를 취소했습니다.
-            🔗 PR 링크: ${pr_url}"
-          else
-            icon="❌"
-            color=15158332
-            description="$icon **$actor** 님의 배포가 실패했습니다. ⚠️
-            📄 PR 제목: *${pr_title}*
-            🔗 PR 링크: ${pr_url}
-            🔍 실패 단계 확인: ${action_url}"
-          fi
-
-          payload=$(jq -n \
-            --arg title "🚀 배포 결과 알림" \
-            --arg description "$description" \
-            --argjson color "$color" \
-            '{
-              "embeds": [
-                {
-                  "title": $title,
-                  "description": $description,
-                  "color": $color,
-                  "timestamp": (now | todateiso8601)
-                }
-              ]
-            }')
-
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "$payload" \
-               "$DISCORD_WEBHOOK"
-
-#          develop -> main PR 생성 로직
-#  create-pr:
-#    if: needs.set-environment.outputs.environment == 'develop'
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: write      # 레포지토리 내용 수정 권한
-#      pull-requests: write # PR 생성 권한
-#    needs: [ set-environment, deploy ]
-#    steps:
-#      - name: checkout
-#        uses: actions/checkout@v4
-#      - name: gh auth login
-#        run: |
-#          echo ${{ secrets.ACCESS_TOKEN }} | gh auth login --with-token
-#      - name: create branch
-#        run: |
-#          git checkout -b release/${{ github.run_id }}
-#          git push origin release/${{ github.run_id }}
-#      - name: create pr
-#        run: |
-#          gh pr create --base main --head release/${{ github.run_id }} --title "[DEPLOY] release/${{ github.run_id }} -> main" --body "release pr"

--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -85,13 +85,13 @@ jobs:
           STATUS: ${{ needs.test.result }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          message="✅ CI 성공"
+          message="✅ DEV-CI 성공"
           color=3066993 # 초록
           if [ "$STATUS" = "skipped" ]; then
             message="⏭️ CI 스킵"
             color=8359053 # 회색
           elif [ "$STATUS" != "success" ]; then
-            message="❌ CI 실패"
+            message="❌ DEV-CI 실패"
             color=15158332 # 빨강
           fi
           # 디스코드에 보낼 payload JSON 생성
@@ -106,7 +106,7 @@ jobs:
               # discord에 등록될 메시지 형태
               "embeds": [
                 {
-                  "title": "🏚️ PR이 생성되었습니다!",
+                  "title": "🏚️ DEV-PR이 생성되었습니다!",
                   "description": "\($actor)님이 PR을 만들었습니다!\n📄 \($pr_title) \n \($message)\n🔗[워크플로우 실행 확인하기](\($pr_url))",
                   "color": $color,
                   "timestamp": now | todateiso8601

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,26 +1,22 @@
-name: prod-cd
-
+name: develop-cd.yml
 on:
-  push:
-    branches: [ "prod" ]
-
-permissions:
-  contents: read
+  pull_request:
+    types: [synchronize, closed, opened]
+    branches: [prod]
+    paths:
+      - 'src/**'
+      - 'build.gradle'
 
 jobs:
-  build:
+  image-build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      
       - name: checkout the code
         uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: "temurin"
-
       - name: AWS 설정
         id: credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -33,68 +29,220 @@ jobs:
         run: |
           rm -f src/main/resources/application-local.yml
 
-      - name: Add application-prod.yml
+      - name: Add application-blue.yml
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_PROD }}" > ./src/main/resources/application-prod.yml
+          echo "${{ secrets.APPLICATION_BLUE }}" > ./src/main/resources/application-blue.yml
 
-      - name: Build with Gradle
+      - name: Add application-green.yml
         run: |
-          chmod +x ./gradlew
-          ./gradlew clean build -x test
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_GREEN }}" > ./src/main/resources/application-green.yml
 
+      - name: Add application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_DEFAULT }}" > ./src/main/resources/application.yml
+
+      - name: Add application-dev.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_DEV }}" > ./src/main/resources/application-dev.yml
       - name: Jib로 이미지 빌드 및 ECR 업로드
         run: ./gradlew jib -PjibToImage=${{ secrets.ECR_REGISTRY }} -PjibTag=runid-${{ github.run_id }}
 
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    needs: [ image-build ]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Set target IP
+        run: |
+          STATUS=$(curl -k -o /dev/null -w "%{http_code}" "https://${{ secrets.HOUME_DOMAIN }}/actuator/health")
+          echo $STATUS
+          if [ $STATUS = 200 ]; then
+            CURRENT_UPSTREAM=$(curl -s -k https://${{ secrets.HOUME_DOMAIN }}/api/v1/env | jq -r '.env')
+          else
+            CURRENT_UPSTREAM=green
+          fi
+          echo CURRENT_UPSTREAM=$CURRENT_UPSTREAM >> $GITHUB_ENV
+          echo $CURRENT_UPSTREAM
+          if [ $CURRENT_UPSTREAM = blue ]; then
+            echo "CURRENT_PORT=8080" >> $GITHUB_ENV
+            echo "STOPPED_PORT=8081" >> $GITHUB_ENV
+            echo "TARGET_UPSTREAM=green" >> $GITHUB_ENV
+          elif [ $CURRENT_UPSTREAM = green ]; then
+            echo "CURRENT_PORT=8081" >> $GITHUB_ENV
+            echo "STOPPED_PORT=8080" >> $GITHUB_ENV
+            echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
+          else
+            echo "error"
+            exit 1
+          fi
 
-      - name: Deploy (ECR pull -> compose up)
-        uses: appleboy/ssh-action@v1.0.3
-        id: deploy
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          IMAGE_TAG: runid-${{ github.run_id }}
+      - name: Docker 로그인
+        uses: docker/login-action@v3
         with:
-          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Docker compose
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          TARGET_UPSTREAM: ${{ env.TARGET_UPSTREAM }}
+        with:
           username: ubuntu
+          host: ${{ secrets.HOUME_SERVER_IP }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script_stop: true
-          envs: AWS_REGION,ECR_REGISTRY,IMAGE_TAG
           script: |
-            set -euo pipefail
+            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | sudo docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+            sudo docker pull ${{ secrets.ECR_REGISTRY }}:latest
+            sudo docker compose -f deploy/docker-compose-${{ env.TARGET_UPSTREAM }}.yml up -d
 
-            cd /home/ubuntu/infra
-
-            # IAM role 확인(선택)
-            aws sts get-caller-identity
-
-            # ECR 로그인
-            REGISTRY_HOST="${ECR_REGISTRY%%/*}"
-            aws ecr get-login-password --region "${AWS_REGION}" \
-              | sudo docker login --username AWS --password-stdin "${REGISTRY_HOST}"
-
-            # compose가 읽을 .env 갱신
-            printf "ECR_REGISTRY=%s\nIMAGE_TAG=%s\n" "${ECR_REGISTRY}" "${IMAGE_TAG}" | sudo tee /home/ubuntu/infra/.env > /dev/null
-
-            # 최신 이미지 pull + 컨테이너 교체
-            sudo docker compose pull app
-            
-            # ★ 추가
-            if sudo docker ps -aq -f "name=^houme$" | grep -q .; then
-            sudo docker rm -f houme || true
-            fi
-            
-            sudo docker compose up -d --remove-orphans
-
-            # 헬스체크
-            for i in {1..20}; do
-              if curl -sf "http://localhost:8080/actuator/health" > /dev/null; then
-                echo "healthy"
-                sudo docker image prune -f
+      - name: 새로운 서버 헬스체킹 (재시도 15회, 5초 간격)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOUME_SERVER_IP }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            STOPPED_PORT="${{ env.STOPPED_PORT }}"
+            echo "📌 STOPPED_PORT is $STOPPED_PORT"
+            for i in {1..15}
+            do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$STOPPED_PORT/actuator/health)
+              echo "[$i] $STOPPED_PORT Health check response code: $STATUS"
+              if [ "$STATUS" = "200" ]; then
+                echo "서버 확인"
                 exit 0
               fi
-              sleep 3
+              sleep 5
             done
-
-            sudo docker compose logs --tail 200 app || true
+            echo "서버 헬스체크 실패"
             exit 1
+
+      - name: nginx upstream 변경
+        uses: appleboy/ssh-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOUME_SERVER_IP }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            echo "set \$service_url ${{ env.TARGET_UPSTREAM }};" | sudo tee /etc/nginx/sites-enabled/service-env.inc
+            sudo nginx -t && sudo nginx -s reload
+
+      - name: 기존 서버 중지
+        uses: appleboy/ssh-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOUME_SERVER_IP }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            if [ "$(sudo docker ps -aq -f name=${{ env.CURRENT_UPSTREAM }})" ]; then
+              sudo docker stop ${{ env.CURRENT_UPSTREAM }}
+              sudo docker rm ${{ env.CURRENT_UPSTREAM }}
+            else
+              echo "No container named ${{ env.CURRENT_UPSTREAM }} found. Skipping stop & remove."
+            fi
+
+      - name: 기존 도커 이미지 제거
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          username: ubuntu
+          host: ${{ secrets.PROD_HOST }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            sudo docker image prune -f
+
+  notify-discord-cd:
+    needs: deploy
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: 디스코드 알림
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          STATUS: ${{ needs.deploy.result }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          actor="${{ github.actor }}"
+          pr_title="$PR_TITLE"
+          pr_url="https://github.com/${REPO}/pull/${{ github.event.pull_request.number }}"
+          action_url="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+          if [ "$STATUS" = "success" ]; then
+            icon="✅"
+            color=3066993
+            description="$icon **$actor** 님이 배포를 성공적으로 완료했습니다! 🎉
+            📄 PR 제목: *${pr_title}*
+            🔗 PR 링크: ${pr_url}"
+          elif [ "$STATUS" = "skipped" ]; then
+            icon="⏭️"
+            color=8359053
+            description="$icon **$actor** 님의 배포 job이 스킵되었습니다.
+            🔍 워크플로 조건을 확인해주세요.
+            🔗 PR 링크: ${pr_url}"
+          elif [ "$STATUS" = "cancelled" ]; then
+            icon="⚪"
+            color=9807270    # 회색 계열
+            description="$icon **$actor** 님이 배포를 취소했습니다.
+            🔗 PR 링크: ${pr_url}"
+          else
+            icon="❌"
+            color=15158332
+            description="$icon **$actor** 님의 배포가 실패했습니다. ⚠️
+            📄 PR 제목: *${pr_title}*
+            🔗 PR 링크: ${pr_url}
+            🔍 실패 단계 확인: ${action_url}"
+          fi
+
+          payload=$(jq -n \
+            --arg title "🚀 배포 결과 알림" \
+            --arg description "$description" \
+            --argjson color "$color" \
+            '{
+              "embeds": [
+                {
+                  "title": $title,
+                  "description": $description,
+                  "color": $color,
+                  "timestamp": (now | todateiso8601)
+                }
+              ]
+            }')
+
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "$payload" \
+               "$DISCORD_WEBHOOK"
+
+#          develop -> main PR 생성 로직
+#  create-pr:
+#    if: needs.set-environment.outputs.environment == 'develop'
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write      # 레포지토리 내용 수정 권한
+#      pull-requests: write # PR 생성 권한
+#    needs: [ set-environment, deploy ]
+#    steps:
+#      - name: checkout
+#        uses: actions/checkout@v4
+#      - name: gh auth login
+#        run: |
+#          echo ${{ secrets.ACCESS_TOKEN }} | gh auth login --with-token
+#      - name: create branch
+#        run: |
+#          git checkout -b release/${{ github.run_id }}
+#          git push origin release/${{ github.run_id }}
+#      - name: create pr
+#        run: |
+#          gh pr create --base main --head release/${{ github.run_id }} --title "[DEPLOY] release/${{ github.run_id }} -> main" --body "release pr"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,0 +1,99 @@
+name: prod-cd
+
+on:
+  push:
+    branches: [ "prod" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: checkout the code
+        uses: actions/checkout@v4
+
+      - name: AWS 설정
+        id: credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Remove application-local.yml
+        run: |
+          rm -f src/main/resources/application-local.yml
+
+      - name: Add application-prod.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_PROD }}" > ./src/main/resources/application-prod.yml
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      - name: Jib로 이미지 빌드 및 ECR 업로드
+        run: ./gradlew jib -PjibToImage=${{ secrets.ECR_REGISTRY }} -PjibTag=runid-${{ github.run_id }}
+
+
+      - name: Deploy (ECR pull -> restart)
+        uses: appleboy/ssh-action@v1.0.3
+        id: deploy
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: runid-${{ github.run_id }}
+          CONTAINER_NAME: houme
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script_stop: true
+          envs: AWS_REGION,ECR_REGISTRY,IMAGE_TAG,CONTAINER_NAME
+          script: |
+            set -euo pipefail
+
+            ECR_IMAGE_REPO="${ECR_REGISTRY}"
+            IMAGE="${ECR_IMAGE_REPO}:${IMAGE_TAG}"
+            REGISTRY_HOST="${ECR_IMAGE_REPO%%/*}"
+
+            aws ecr get-login-password --region "${AWS_REGION}" \
+              | sudo docker login --username AWS --password-stdin "${REGISTRY_HOST}"
+
+            sudo docker pull "${IMAGE}"
+
+            for name in "${CONTAINER_NAME}" blue green; do
+              if sudo docker ps -aq -f "name=^${name}$" | grep -q .; then
+                sudo docker stop "${name}" || true
+                sudo docker rm "${name}" || true
+              fi
+            done
+
+            sudo docker run -d --name "${CONTAINER_NAME}" --restart unless-stopped \
+              -p 8080:8080 \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e SERVER_ENV=prod \
+              "${IMAGE}"
+
+            for i in {1..20}; do
+              if curl -sf "http://localhost:8080/actuator/health" > /dev/null; then
+                echo "healthy"
+                sudo docker image prune -f
+                exit 0
+              fi
+              sleep 3
+            done
+
+            sudo docker logs --tail 200 "${CONTAINER_NAME}" || true
+            exit 1

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -11,15 +11,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      
+      - name: checkout the code
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: "temurin"
-
-      - name: checkout the code
-        uses: actions/checkout@v4
 
       - name: AWS 설정
         id: credentials

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,0 +1,121 @@
+name: develop-ci
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches: [prod]
+    paths:
+      - 'src/**'
+      - 'build.gradle'
+
+jobs:
+  test:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      # redis 설정
+      - name: set up redis
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: 'latest'
+
+      - name: checkout the code
+        uses: actions/checkout@v4
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '8.8'  # 사용하려는 Gradle 버전 명시
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Add application-test.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_TEST }}" > ./src/main/resources/application-test.yml
+
+      - name: Run Gradle build and tests
+        run: |
+          ./gradlew clean build -Dspring.profiles.active=test
+          ./gradlew jacocoTestReport
+      - name: Jacoco Report to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: 📝 Code Coverage
+          paths: ${{ github.workspace }}/build/reports/jacoco/index/jacoco.xml
+          token: ${{ secrets.ACCESS_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          update-comment: true
+      - name: Upload jacoco HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: ${{ github.workspace }}/build/reports/jacoco/index/html/
+      - name: Get the Coverage info
+        run: |
+          echo "🍀총 커버리지 ${{ steps.jacoco.outputs.coverage-overall }}"
+          echo "☘️변경된 파일들 커버리지 ${{ steps.jacoco.outputs.coverage-changed-files }}"
+      - name: 테스트 결과 PR 코멘트에 등록
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+      - name: 테스트 실패시 코드 라인에 대한 체크 추가
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+  # Discord 알림란
+  notify-discord-ci:
+    needs: test # test job이 끝나야 실행
+    runs-on: ubuntu-latest
+    if: always()  # 성공하든 실패하든
+    steps:
+      - name: 디스코드 알림
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          STATUS: ${{ needs.test.result }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          message="✅ PROD-CI 성공"
+          color=3066993 # 초록
+          if [ "$STATUS" = "skipped" ]; then
+            message="⏭️ CI 스킵"
+            color=8359053 # 회색
+          elif [ "$STATUS" != "success" ]; then
+            message="❌ PROD-CI 실패"
+            color=15158332 # 빨강
+          fi
+          # 디스코드에 보낼 payload JSON 생성
+          # actor: 작성자, message: CI 완수 메시지, pr_url: PR 링크
+          pr_title="$PR_TITLE"
+          payload=$(jq -n --arg actor "${{ github.actor }}" \
+                          --arg message "$message" \
+                          --arg pr_url "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+                          --arg pr_title "$pr_title" \
+                          --argjson color "$color" \
+            '{
+              # discord에 등록될 메시지 형태
+              "embeds": [
+                {
+                  "title": "🏚️ PROD-PR이 생성되었습니다!",
+                  "description": "\($actor)님이 PR을 만들었습니다!\n📄 \($pr_title) \n \($message)\n🔗[워크플로우 실행 확인하기](\($pr_url))",
+                  "color": $color,
+                  "timestamp": now | todateiso8601
+                }
+              ]
+            }')
+
+            # discord  웹훅 URL로 서버에 Post 요청
+          curl  -H "Content-Type: application/json" \
+                -X POST \
+                -d "$payload" \
+                "$DISCORD_WEBHOOK"

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,4 +1,4 @@
-name: develop-ci
+name: prod-ci
 on:
   pull_request:
     types: [opened, synchronize, closed]

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -85,13 +85,13 @@ jobs:
           STATUS: ${{ needs.test.result }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          message="✅ PROD-CI 성공"
+          message="✅ CI 성공"
           color=3066993 # 초록
           if [ "$STATUS" = "skipped" ]; then
             message="⏭️ CI 스킵"
             color=8359053 # 회색
           elif [ "$STATUS" != "success" ]; then
-            message="❌ PROD-CI 실패"
+            message="❌ CI 실패"
             color=15158332 # 빨강
           fi
           # 디스코드에 보낼 payload JSON 생성
@@ -106,7 +106,7 @@ jobs:
               # discord에 등록될 메시지 형태
               "embeds": [
                 {
-                  "title": "🏚️ PROD-PR이 생성되었습니다!",
+                  "title": "🏚️ PR이 생성되었습니다!",
                   "description": "\($actor)님이 PR을 만들었습니다!\n📄 \($pr_title) \n \($message)\n🔗[워크플로우 실행 확인하기](\($pr_url))",
                   "color": $color,
                   "timestamp": now | todateiso8601


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #377 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

기존에 dev profile로 사용하던 여러 인프라 요소들을 prod로 전환합니다.
직전에 구축한 prod profile을 dev profile로 전환합니다.

이유는 다음과 같습니다.

```

1. 기존에 사용하던 dev 인프라의 사양이 높음 (t3.small, alb, metabase 를 포함한 모니터링...)
2. 새롭게 prod 환경에서 dev의 모든 환경을 복제하자니 마이그레이션 리소스와 서버비 금액적 부담이 너무 큼
3. dev 환경의 트래픽은 많지 않으니, 좋은 인프라 환경을 구축할 필요성이 prod에 비해 떨어짐
3-1. 성능 테스트와 같이 실제 인프라를 모방해야하는 경우, 일시적으로 실제 배포환경의 인프라를 복제하여 구축

```

복제 방안은 다음과 같습니다.


```

1. 기존 dev profile의 인프라의 핵심 요소는 AWS ALB임
2. alb에서 https SSL 인증서와 리다이렉트를 진행하고 있었기 때문에, 그대로 dev.houme.kr의 라우팅 대상을 A레코드의 IP로 전환하고 새롭게 구축된 prod.houme.kr이 별칭을 이용하여 alb를 타겟팅하도록 전환
3. 내부 CD 로직에서 deploy 대상을 prod IP로 전환함

```


++) dev.houme.kr 의 SSL 인증서는 더이상 ACM을 사용하지 않고 certbot을 이용하고 prod 환경에서만 ALB로 리다이렉트 합니다.
이유는 추후 서버 확장에 따른 ALB 확장성이라는 옵션을 배포 인프라에서 유지하기 위함입니다.

## 🙏 Question & PR point

