### PR TITLE
[CHORE] 회원가입 로직 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/OAuthController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
+import or.sopt.houme.domain.user.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -45,14 +46,15 @@ public class OAuthController {
 
     @Operation(summary = "카카오 인증서버 토큰 검증 API",
     description = "프론트에서 전달한 code를 이용해 토큰 교환 및 로그인 처리를 수행합니다. <br><br>" +
-            "액세스 토큰은 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다.")
+            "기존회원이면 액세스 토큰은 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다. <br>" +
+            "신규회원이면 signupToken(임시토큰)과 prefill 정보를 반환합니다.")
     @GetMapping("/oauth/kakao/callback")
-    public ResponseEntity<ApiResponse<Boolean>> kakaoLogin(@RequestParam("code") String accessCode,
+    public ResponseEntity<ApiResponse<KakaoLoginResponse>> kakaoLogin(@RequestParam("code") String accessCode,
                                                            @RequestParam(value = "env", required = false) String env,
                                                            HttpServletRequest request,
                                                            HttpServletResponse response) {
 
-        Boolean result = (env == null)
+        KakaoLoginResponse result = (env == null)
                 ? oAuthService.kakaoLogin(accessCode, request, response)
                 : oAuthService.kakaoLogin(accessCode, env, request, response);
 

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
@@ -2,12 +2,14 @@ package or.sopt.houme.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.controller.dto.*;
 import or.sopt.houme.domain.user.entity.Gender;
 import or.sopt.houme.domain.user.service.UserDeletionService;
 import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
@@ -25,6 +27,7 @@ public class UserController {
 
     private final UserService userService;
     private final UserDeletionService userDeletionService;
+    private final OAuthService oAuthService;
 
     @GetMapping(value = "/mypage/user")  // 유저의 이름, 사용가능한 크레딧 개수 조회
     @Operation(summary = "마이페이지 기본 정보 제공 API")
@@ -68,6 +71,37 @@ public class UserController {
         }
 
         String username = userService.updateUser(userDetails.getUser(), createUserRequest.name(), gender, birthday);
+
+        return ResponseEntity.ok(ApiResponse.ok(username));
+    }
+
+    @PostMapping(value = "/sign-up")
+    @Operation(summary = "소셜 회원가입 API",
+            description = "카카오 소셜로그인 완료 후 발급된 signupToken(임시토큰)과 함께 호출하면 회원을 생성합니다. <br><br>" +
+                    "성공 시 access-token 헤더와 refresh-token 쿠키를 함께 반환합니다.")
+    public ResponseEntity<ApiResponse<String>> signUp(@RequestBody @Valid SocialSignUpRequest signUpRequest,
+                                                      HttpServletResponse response) {
+        Gender gender;
+        LocalDate birthday;
+
+        try {
+            gender = Gender.valueOf(signUpRequest.gender());
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        try {
+            birthday = LocalDate.parse(signUpRequest.birthday());
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        String username = oAuthService.signUpWithToken(
+                signUpRequest.signupToken(),
+                signUpRequest.name(),
+                gender,
+                birthday,
+                response
+        );
 
         return ResponseEntity.ok(ApiResponse.ok(username));
     }

--- a/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/UserController.java
@@ -76,7 +76,7 @@ public class UserController {
     }
 
     @PostMapping(value = "/sign-up")
-    @Operation(summary = "소셜 회원가입 API",
+    @Operation(summary = "소셜 자체 회원가입 API",
             description = "카카오 소셜로그인 완료 후 발급된 signupToken(임시토큰)과 함께 호출하면 회원을 생성합니다. <br><br>" +
                     "성공 시 access-token 헤더와 refresh-token 쿠키를 함께 반환합니다.")
     public ResponseEntity<ApiResponse<String>> signUp(@RequestBody @Valid SocialSignUpRequest signUpRequest,

--- a/src/main/java/or/sopt/houme/domain/user/controller/dto/KakaoLoginResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/dto/KakaoLoginResponse.java
@@ -1,0 +1,22 @@
+package or.sopt.houme.domain.user.controller.dto;
+
+public record KakaoLoginResponse(
+        boolean isNewUser,
+        String signupToken,
+        Prefill prefill
+) {
+    public static KakaoLoginResponse newUser(String signupToken, String email, String nickname) {
+        return new KakaoLoginResponse(true, signupToken, new Prefill(email, nickname));
+    }
+
+    public static KakaoLoginResponse existingUser() {
+        return new KakaoLoginResponse(false, null, null);
+    }
+
+    public record Prefill(
+            String email,
+            String nickname
+    ) {
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/user/controller/dto/SocialSignUpRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/controller/dto/SocialSignUpRequest.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.domain.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import or.sopt.houme.domain.user.valid.ValidBirthday;
+
+public record SocialSignUpRequest(
+        @NotBlank(message = "signupToken은 필수 입력값입니다.")
+        String signupToken,
+
+        @NotBlank(message = "이름은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "숫자, 특수문자는 입력할 수 없어요.")
+        String name,
+
+        @NotBlank(message = "성별은 필수 입력값입니다.")
+        @Pattern(
+                regexp = "MALE|FEMALE|NONBINARY",
+                message = "성별은 MALE, FEMALE, NONBINARY 중 하나여야 해요."
+        )
+        String gender,
+
+        @NotBlank(message = "생년월일은 필수 입력값입니다.")
+        @ValidBirthday
+        String birthday
+) {
+}
+

--- a/src/main/java/or/sopt/houme/domain/user/entity/record/SignupSession.java
+++ b/src/main/java/or/sopt/houme/domain/user/entity/record/SignupSession.java
@@ -1,4 +1,4 @@
-package or.sopt.houme.domain.user.service;
+package or.sopt.houme.domain.user.entity.record;
 
 public record SignupSession(
         Long kakaoId,

--- a/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.user.repository;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.entity.record.SignupSession;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -14,6 +16,7 @@ import java.util.Optional;
 public class SignupSessionRepository {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     private static final String PREFIX = "signup-session:";
 
@@ -42,7 +45,9 @@ public class SignupSessionRepository {
         if (value instanceof SignupSession session) {
             return Optional.of(session);
         }
+        if (value instanceof Map<?, ?> map) {
+            return Optional.ofNullable(objectMapper.convertValue(map, SignupSession.class));
+        }
         return Optional.empty();
     }
 }
-

--- a/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
@@ -1,7 +1,7 @@
 package or.sopt.houme.domain.user.repository;
 
 import lombok.RequiredArgsConstructor;
-import or.sopt.houme.domain.user.service.SignupSession;
+import or.sopt.houme.domain.user.entity.record.SignupSession;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;

--- a/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/SignupSessionRepository.java
@@ -1,0 +1,48 @@
+package or.sopt.houme.domain.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.service.SignupSession;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class SignupSessionRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String PREFIX = "signup-session:";
+
+    public void save(String signupToken, SignupSession session, long ttlSeconds) {
+        if (!StringUtils.hasText(signupToken) || session == null) {
+            return;
+        }
+        String key = PREFIX + signupToken;
+        redisTemplate.opsForValue().set(key, session, Duration.ofSeconds(ttlSeconds));
+    }
+
+    public Optional<SignupSession> consume(String signupToken) {
+        if (!StringUtils.hasText(signupToken)) {
+            return Optional.empty();
+        }
+        String key = PREFIX + signupToken;
+
+        Object value;
+        try {
+            value = redisTemplate.opsForValue().getAndDelete(key);
+        } catch (Exception e) {
+            value = redisTemplate.opsForValue().get(key);
+            redisTemplate.delete(key);
+        }
+
+        if (value instanceof SignupSession session) {
+            return Optional.of(session);
+        }
+        return Optional.empty();
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -8,14 +8,17 @@ import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.user.client.KaKaoOAuthClient;
 import or.sopt.houme.domain.user.client.KaKaoUserInfoClient;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
+import or.sopt.houme.domain.user.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.controller.dto.KaKaoOAuthTokenDTO;
 import or.sopt.houme.domain.user.controller.dto.KaKaoUserInfoResponse;
 import or.sopt.houme.domain.user.entity.Role;
 import or.sopt.houme.domain.user.entity.SocialType;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.entity.UserStatus;
+import or.sopt.houme.domain.user.entity.record.SignupSession;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.domain.user.repository.SignupSessionRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.UserException;
@@ -26,10 +29,13 @@ import or.sopt.houme.global.jwt.JWTUtil;
 import or.sopt.houme.global.util.CookieUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.List;
 
 @Service
@@ -45,10 +51,13 @@ public class OAuthService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistTokenRepository blacklistTokenRepository;
+    private final SignupSessionRepository signupSessionRepository;
 
     private final KaKaoConfig kaKaoConfig;
     private final CookieConfig cookieConfig;
 
+    @Value("${auth.signup-token.ttl-seconds:600}")
+    private long signupTokenTtlSeconds;
 
     /**
      * 카카오 인증 서버에 인가코드를 요청하는 메서드입니다
@@ -80,10 +89,7 @@ public class OAuthService {
     }
 
 
-    public Boolean kakaoLogin(String accessCode, String env, HttpServletRequest request, HttpServletResponse response) {
-
-        // 신규회원인지 검증하는 필드
-        Boolean isNewUser = false;
+    public KakaoLoginResponse kakaoLogin(String accessCode, String env, HttpServletRequest request, HttpServletResponse response) {
 
         // 인가코드가 비어있다면 예외발생
         if (accessCode == null || accessCode.isEmpty()) {
@@ -115,27 +121,36 @@ public class OAuthService {
             throw new UserException(ErrorCode.KAKAO_ACCESSTOKEN_INVALID);
         }
 
-        // 만약 해당 이메일을 통해 회원가입된 회원이 존재하지 않는다면, 새로운 회원을 생성합니다
-        Boolean userExist = userRepository.existsByEmail(userInfo.getKakao_account().getEmail());
-
-        if (userExist == Boolean.FALSE) {
-            User newUser = User.builder()
-//                  이름은 자체 회원가입시 입력 받습니다.
-                    .password(null)
-                    .email(userInfo.getKakao_account().getEmail())
-                    .role(Role.ROLE_USER)
-                    .socialType(SocialType.KAKAO)
-                    .status(UserStatus.ACTIVE)
-                    .hasGeneratedImage(Boolean.FALSE)
-                    .build();
-
-            userRepository.save(newUser);
-
-            isNewUser = true;
+        String email = Optional.ofNullable(userInfo.getKakao_account())
+                .map(KaKaoUserInfoResponse.KakaoAccount::getEmail)
+                .orElse(null);
+        if (!StringUtils.hasText(email)) {
+            throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
         }
 
-        // 그리고 회원 정보를 기반으로 액세스토큰을 발급하여 헤더에 넣습니다
-        User byEmail = userRepository.findByEmail(userInfo.getKakao_account().getEmail())
+        String nickname = Optional.ofNullable(userInfo.getKakao_account())
+                .map(KaKaoUserInfoResponse.KakaoAccount::getProfile)
+                .map(KaKaoUserInfoResponse.KakaoAccount.Profile::getNickname)
+                .orElse(null);
+
+        Boolean userExist = userRepository.existsByEmail(email);
+
+        // 회원 정보가 없는 경우 -> 임시토큰을 발급하여 반환합니다
+        if (userExist == Boolean.FALSE) {
+            String signupToken = UUID.randomUUID().toString().replace("-", "");
+
+            SignupSession signupSession = SignupSession.of(
+                    userInfo.getId(),
+                    email,
+                    nickname
+            );
+            signupSessionRepository.save(signupToken, signupSession, signupTokenTtlSeconds);
+
+            return KakaoLoginResponse.newUser(signupToken, email, nickname);
+        }
+
+        // 회원정보가 존재하는 경우 -> 회원 정보를 기반으로 액세스토큰을 발급하여 헤더에 넣습니다
+        User byEmail = userRepository.findByEmail(email)
                 .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));
 
         String access = jwtUtil.createJwt("access", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
@@ -155,7 +170,7 @@ public class OAuthService {
                 cookieConfig.getSameSite()
         );
 
-        return isNewUser;
+        return KakaoLoginResponse.existingUser();
     }
 
     // Backward-compatible overloads for existing tests and callers
@@ -163,7 +178,7 @@ public class OAuthService {
         return requestRedirect(request, null);
     }
 
-    public Boolean kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
+    public KakaoLoginResponse kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
         return kakaoLogin(accessCode, null, request, response);
     }
 

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -1,32 +1,33 @@
 package or.sopt.houme.domain.user.service;
 
 import feign.FeignException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.credit.entity.Credit;
+import or.sopt.houme.domain.credit.entity.CreditStatus;
+import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.user.client.KaKaoOAuthClient;
 import or.sopt.houme.domain.user.client.KaKaoUserInfoClient;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.controller.dto.KaKaoOAuthTokenDTO;
 import or.sopt.houme.domain.user.controller.dto.KaKaoUserInfoResponse;
-import or.sopt.houme.domain.user.entity.Role;
-import or.sopt.houme.domain.user.entity.SocialType;
-import or.sopt.houme.domain.user.entity.User;
-import or.sopt.houme.domain.user.entity.UserStatus;
+import or.sopt.houme.domain.user.entity.*;
 import or.sopt.houme.domain.user.entity.record.SignupSession;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
 import or.sopt.houme.domain.user.repository.SignupSessionRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.CreditException;
 import or.sopt.houme.global.api.handler.UserException;
 import or.sopt.houme.global.config.CookieConfig;
 import or.sopt.houme.global.config.JWTConfig;
 import or.sopt.houme.global.config.KaKaoConfig;
 import or.sopt.houme.global.jwt.JWTUtil;
 import or.sopt.houme.global.util.CookieUtil;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,7 @@ import org.springframework.beans.factory.annotation.Value;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
@@ -46,6 +48,7 @@ public class OAuthService {
     private final KaKaoOAuthClient kaKaoOAuthClient;
     private final KaKaoUserInfoClient kaKaoUserInfoClient;
     private final UserRepository userRepository;
+    private final CreditRepository creditRepository;
     private final JWTUtil jwtUtil;
     private final JWTConfig jwtConfig;
 
@@ -180,6 +183,63 @@ public class OAuthService {
 
     public KakaoLoginResponse kakaoLogin(String accessCode, HttpServletRequest request, HttpServletResponse response) {
         return kakaoLogin(accessCode, null, request, response);
+    }
+
+    @Transactional
+    public String signUpWithToken(String signupToken, String name, Gender gender, LocalDate birthday, HttpServletResponse response) {
+        SignupSession signupSession = signupSessionRepository.consume(signupToken)
+                .orElseThrow(() -> new UserException(ErrorCode.SIGNUP_TOKEN_INVALID));
+
+        if (!StringUtils.hasText(signupSession.email())) {
+            throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        if (userRepository.existsByEmail(signupSession.email())) {
+            throw new UserException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        User savedUser = userRepository.save(
+                User.builder()
+                        .password(null)
+                        .email(signupSession.email())
+                        .name(name)
+                        .birthday(birthday)
+                        .gender(gender)
+                        .role(Role.ROLE_USER)
+                        .socialType(SocialType.KAKAO)
+                        .status(UserStatus.ACTIVE)
+                        .hasGeneratedImage(Boolean.FALSE)
+                        .build()
+        );
+
+        try {
+            creditRepository.save(
+                    Credit.builder()
+                            .status(CreditStatus.ACTIVE)
+                            .user(savedUser)
+                            .build()
+            );
+        } catch (Exception e) {
+            throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
+        }
+
+        String access = jwtUtil.createJwt("access", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
+        String refresh = jwtUtil.createJwt("refresh", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
+
+        refreshTokenRepository.saveRefreshToken(savedUser.getId(), refresh, jwtConfig.getRefreshTokenValidityInSeconds());
+
+        response.setHeader("access-token", access);
+
+        CookieUtil.addSameSiteCookie(
+                response,
+                "refresh-token",
+                refresh,
+                jwtConfig.getRefreshTokenValidityInSeconds().intValue(),
+                cookieConfig.getDomain(),
+                cookieConfig.isSecure(),
+                cookieConfig.getSameSite()
+        );
+
+        return savedUser.getName();
     }
 
 

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -46,7 +46,7 @@ import java.util.stream.IntStream;
 @Slf4j
 public class OAuthService {
 
-    private static final int SIGN_UP_CREDIT_COUNT = 5;
+    private static final int SIGN_UP_CREDIT_COUNT = 1;
 
     private final KaKaoOAuthClient kaKaoOAuthClient;
     private final KaKaoUserInfoClient kaKaoUserInfoClient;

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -39,11 +39,14 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class OAuthService {
+
+    private static final int SIGN_UP_CREDIT_COUNT = 5;
 
     private final KaKaoOAuthClient kaKaoOAuthClient;
     private final KaKaoUserInfoClient kaKaoUserInfoClient;
@@ -70,11 +73,6 @@ public class OAuthService {
      *
      * 현재 fallback 로직이 구현되어있지 않습니다. 아직 Feign의 fallback factory에 대한 학습이 부족해서...
      * 앱잼기간내에 구현해보겠습니다 FIXME
-     * */
-
-    /**
-     *
-     *
      * */
     public String requestRedirect(HttpServletRequest request, String env) {
         String redirectBase = resolveRedirectBase(request, env);
@@ -214,12 +212,13 @@ public class OAuthService {
         );
 
         try {
-            creditRepository.save(
-                    Credit.builder()
+            List<Credit> newCredits = IntStream.range(0, SIGN_UP_CREDIT_COUNT)
+                    .mapToObj(i -> Credit.builder()
                             .status(CreditStatus.ACTIVE)
                             .user(savedUser)
-                            .build()
-            );
+                            .build())
+                    .toList();
+            creditRepository.saveAll(newCredits);
         } catch (Exception e) {
             throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
         }

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -124,6 +124,7 @@ public class OAuthService {
             throw new UserException(ErrorCode.KAKAO_ACCESSTOKEN_INVALID);
         }
 
+        // 응답값에서 이메일을 파싱
         String email = Optional.ofNullable(userInfo.getKakao_account())
                 .map(KaKaoUserInfoResponse.KakaoAccount::getEmail)
                 .orElse(null);
@@ -131,6 +132,7 @@ public class OAuthService {
             throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
         }
 
+        // nickname 파싱
         String nickname = Optional.ofNullable(userInfo.getKakao_account())
                 .map(KaKaoUserInfoResponse.KakaoAccount::getProfile)
                 .map(KaKaoUserInfoResponse.KakaoAccount.Profile::getNickname)
@@ -138,7 +140,7 @@ public class OAuthService {
 
         Boolean userExist = userRepository.existsByEmail(email);
 
-        // 회원 정보가 없는 경우 -> 임시토큰을 발급하여 반환합니다
+        // 회원 정보가 없는 경우 (이메일이 존재하지 않음) -> 임시토큰을 발급하여 반환합니다
         if (userExist == Boolean.FALSE) {
             String signupToken = UUID.randomUUID().toString().replace("-", "");
 

--- a/src/main/java/or/sopt/houme/domain/user/service/SignupSession.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/SignupSession.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.domain.user.service;
+
+public record SignupSession(
+        Long kakaoId,
+        String email,
+        String nickname
+) {
+    public static SignupSession of(Long kakaoId, String email, String nickname) {
+        return new SignupSession(kakaoId, email, nickname);
+    }
+}
+

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -42,7 +42,7 @@ import java.util.stream.IntStream;
 @Transactional
 public class UserServiceImpl implements UserService {
 
-    private static final int SIGN_UP_CREDIT_COUNT = 5;
+    private static final int SIGN_UP_CREDIT_COUNT = 1;
 
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -42,6 +42,8 @@ import java.util.stream.IntStream;
 @Transactional
 public class UserServiceImpl implements UserService {
 
+    private static final int SIGN_UP_CREDIT_COUNT = 5;
+
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
     private final TagRepository tagRepository;
@@ -190,12 +192,13 @@ public class UserServiceImpl implements UserService {
         findUser.updateUserFromSignUp(name, birthday, gender);
 
         try {
-            Credit newCredit = Credit.builder()
-                    .status(CreditStatus.ACTIVE)
-                    .user(findUser)
-                    .build();
-
-            creditRepository.save(newCredit);
+            List<Credit> newCredits = IntStream.range(0, SIGN_UP_CREDIT_COUNT)
+                    .mapToObj(i -> Credit.builder()
+                            .status(CreditStatus.ACTIVE)
+                            .user(findUser)
+                            .build())
+                    .toList();
+            creditRepository.saveAll(newCredits);
         }catch (Exception e) {
             throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
         }

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -32,6 +32,10 @@ public enum ErrorCode {
 
     // 회원관련
     USERNAME_DUPLICATE(HttpStatus.BAD_REQUEST,40009,"username이 중복되었습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 40021, "이미 가입된 이메일입니다."),
+
+    // 소셜 회원가입 관련
+    SIGNUP_TOKEN_INVALID(HttpStatus.BAD_REQUEST, 40020, "회원가입 토큰이 유효하지 않습니다."),
 
     // 좋아요 관련
     MISMATCHED_IS_LIKE(HttpStatus.BAD_REQUEST,40011 ,"좋아요와 요인의 선호 여부가 일치하지 않습니다."),

--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig {
 
         // 인가 경로 설정
         http.authorizeHttpRequests((auth)->auth
+                .requestMatchers(HttpMethod.POST, "/api/v1/sign-up").permitAll()
                 .requestMatchers(WhiteListConfig.swaggerWhitelist().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.oauthWhitelist().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.serverWhitelist().toArray(new String[0])).permitAll()

--- a/src/test/java/or/sopt/houme/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/OAuthControllerTest.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.user.controller;
 
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
+import or.sopt.houme.domain.user.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.entity.*;
 import or.sopt.houme.domain.user.service.OAuthService;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,10 +72,11 @@ class OAuthControllerTest {
     }
 
     @Test
-    @DisplayName("GET /oauth/kakao/callback 요청 시 카카오 로그인 성공 여부가 반환된다")
+    @DisplayName("GET /oauth/kakao/callback 요청 시 카카오 로그인 결과가 반환된다")
     void testKakaoLoginCallback() throws Exception {
         // given
-        when(oAuthService.kakaoLogin(eq("abc123"), any(HttpServletRequest.class), any(HttpServletResponse.class))).thenReturn(true);
+        when(oAuthService.kakaoLogin(eq("abc123"), any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(KakaoLoginResponse.newUser("signup-token", "test@houme.kr", "닉네임"));
 
         // when & then
         mockMvc.perform(get("/oauth/kakao/callback")
@@ -82,7 +84,10 @@ class OAuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").value("응답 성공"))
-                .andExpect(jsonPath("$.data").value(true));
+                .andExpect(jsonPath("$.data.isNewUser").value(true))
+                .andExpect(jsonPath("$.data.signupToken").value("signup-token"))
+                .andExpect(jsonPath("$.data.prefill.email").value("test@houme.kr"))
+                .andExpect(jsonPath("$.data.prefill.nickname").value("닉네임"));
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.user.controller.dto.CustomUserDetailsService;
 import or.sopt.houme.domain.user.controller.dto.MyPageInfoResponse;
 import or.sopt.houme.domain.user.entity.*;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
+import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.domain.user.service.UserDeletionService;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.config.JWTConfig;
@@ -23,12 +24,14 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDate;
 import java.util.ArrayList;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(
@@ -51,6 +54,9 @@ class UserControllerTest {
 
     @MockBean
     private UserDeletionService userDeletionService;
+
+    @MockBean
+    private OAuthService oAuthService;
 
     @MockBean
     private JWTConfig jwtConfig;
@@ -107,5 +113,32 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").value("응답 성공"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/sign-up 요청 시 소셜 회원가입이 처리된다")
+    void socialSignUp_Success() throws Exception {
+        given(oAuthService.signUpWithToken(
+                any(String.class),
+                any(String.class),
+                any(Gender.class),
+                any(LocalDate.class),
+                any(HttpServletResponse.class)
+        )).willReturn("테스트유저");
+
+        mockMvc.perform(post("/api/v1/sign-up")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "signupToken": "signup-token",
+                                  "name": "테스트유저",
+                                  "gender": "MALE",
+                                  "birthday": "2000-01-01"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"))
+                .andExpect(jsonPath("$.data").value("테스트유저"));
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
@@ -7,12 +7,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import or.sopt.houme.domain.user.client.KaKaoOAuthClient;
 import or.sopt.houme.domain.user.client.KaKaoUserInfoClient;
 import or.sopt.houme.domain.user.controller.dto.CustomUserDetails;
+import or.sopt.houme.domain.user.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.controller.dto.KaKaoOAuthTokenDTO;
 import or.sopt.houme.domain.user.controller.dto.KaKaoUserInfoResponse;
+import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.user.entity.Role;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
+import or.sopt.houme.domain.user.repository.SignupSessionRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.handler.UserException;
 import or.sopt.houme.global.config.CookieConfig;
@@ -46,6 +49,8 @@ class OAuthServiceTest {
     @Mock
     private UserRepository userRepository;
     @Mock
+    private CreditRepository creditRepository;
+    @Mock
     private JWTUtil jwtUtil;
     @Mock
     private JWTConfig jwtConfig;
@@ -53,6 +58,8 @@ class OAuthServiceTest {
     private RefreshTokenRepository refreshTokenRepository;
     @Mock
     private BlacklistTokenRepository blacklistTokenRepository;
+    @Mock
+    private SignupSessionRepository signupSessionRepository;
     @Mock
     private KaKaoConfig kaKaoConfig;
     @Mock
@@ -84,8 +91,8 @@ class OAuthServiceTest {
 
 
     @Test
-    @DisplayName("kakaoLogin() 을 이용해서 소셜로그인을 통해 회원을 생성 할 수 있다")
-    void kakaoLogin_success() {
+    @DisplayName("kakaoLogin() 신규회원이면 회원을 생성하지 않고 signupToken을 발급한다")
+    void kakaoLogin_newUser_issueSignupToken() {
         // Given
         String code = "authCode";
         KaKaoOAuthTokenDTO tokenDTO = new KaKaoOAuthTokenDTO();
@@ -94,17 +101,55 @@ class OAuthServiceTest {
         KaKaoUserInfoResponse.KakaoAccount kakaoAccount = new KaKaoUserInfoResponse.KakaoAccount();
         kakaoAccount.setEmail("test@houme.kr");
 
-        KaKaoUserInfoResponse.Properties properties = new KaKaoUserInfoResponse.Properties();
-        properties.setNickname("테스트닉네임");
+        KaKaoUserInfoResponse.KakaoAccount.Profile profile = new KaKaoUserInfoResponse.KakaoAccount.Profile();
+        profile.setNickname("테스트닉네임");
+        kakaoAccount.setProfile(profile);
 
         KaKaoUserInfoResponse userInfo = new KaKaoUserInfoResponse();
+        userInfo.setId(1234L);
         userInfo.setKakao_account(kakaoAccount);
-        userInfo.setProperties(properties);
 
         when(kaKaoOAuthClient.getToken(any(), any(), any(), any())).thenReturn(tokenDTO);
         when(kaKaoUserInfoClient.getUserInfo("Bearer kakaoAccessToken")).thenReturn(userInfo);
         when(userRepository.existsByEmail("test@houme.kr")).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        ReflectionTestUtils.setField(oAuthService, "signupTokenTtlSeconds", 600L);
+
+        // When
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+
+        KakaoLoginResponse result = oAuthService.kakaoLogin(code, request, response);
+
+        // Then
+        assertTrue(result.isNewUser());
+        assertNotNull(result.signupToken());
+        assertEquals("test@houme.kr", result.prefill().email());
+        assertEquals("테스트닉네임", result.prefill().nickname());
+
+        verify(signupSessionRepository).save(anyString(), any(or.sopt.houme.domain.user.entity.record.SignupSession.class), eq(600L));
+        verify(userRepository, never()).save(any(User.class));
+        verify(refreshTokenRepository, never()).saveRefreshToken(anyLong(), anyString(), anyLong());
+        verify(response, never()).setHeader(eq("access-token"), anyString());
+    }
+
+    @Test
+    @DisplayName("kakaoLogin() 기존회원이면 access/refresh 토큰을 발급한다")
+    void kakaoLogin_existingUser_issueJwtTokens() {
+        // Given
+        String code = "authCode";
+        KaKaoOAuthTokenDTO tokenDTO = new KaKaoOAuthTokenDTO();
+        tokenDTO.setAccess_token("kakaoAccessToken");
+
+        KaKaoUserInfoResponse.KakaoAccount kakaoAccount = new KaKaoUserInfoResponse.KakaoAccount();
+        kakaoAccount.setEmail("test@houme.kr");
+
+        KaKaoUserInfoResponse userInfo = new KaKaoUserInfoResponse();
+        userInfo.setId(1234L);
+        userInfo.setKakao_account(kakaoAccount);
+
+        when(kaKaoOAuthClient.getToken(any(), any(), any(), any())).thenReturn(tokenDTO);
+        when(kaKaoUserInfoClient.getUserInfo("Bearer kakaoAccessToken")).thenReturn(userInfo);
+        when(userRepository.existsByEmail("test@houme.kr")).thenReturn(true);
         when(userRepository.findByEmail("test@houme.kr")).thenReturn(Optional.of(
                 User.builder().id(1L).email("test@houme.kr").role(Role.ROLE_USER).build()
         ));
@@ -121,11 +166,10 @@ class OAuthServiceTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
 
-        Boolean result = oAuthService.kakaoLogin(code, request, response);
+        KakaoLoginResponse result = oAuthService.kakaoLogin(code, request, response);
 
         // Then
-        assertTrue(result); // 신규 회원이므로 true
-        verify(userRepository).save(any(User.class));
+        assertFalse(result.isNewUser());
         verify(refreshTokenRepository).saveRefreshToken(eq(1L), eq("refreshToken"), eq(86400L));
         verify(response).setHeader("access-token", "accessToken");
     }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -375,7 +375,7 @@ class UserServiceImplTest {
         assertEquals(LocalDate.of(2000, 5, 15), dbUser.getBirthday());
 
         verify(creditRepository, times(1))
-                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 5));
+                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 1));
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.*;
 
 class UserServiceImplTest {
@@ -372,7 +374,8 @@ class UserServiceImplTest {
         assertEquals(Gender.MALE, dbUser.getGender());
         assertEquals(LocalDate.of(2000, 5, 15), dbUser.getBirthday());
 
-        verify(creditRepository, times(1)).save(any(Credit.class));
+        verify(creditRepository, times(1))
+                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 5));
     }
 
 
@@ -401,7 +404,7 @@ class UserServiceImplTest {
 
         // 크레딧 저장 시 RuntimeException 발생하도록 설정
         willThrow(new RuntimeException("DB error"))
-                .given(creditRepository).save(any(Credit.class));
+                .given(creditRepository).saveAll(anyList());
 
         // when & then
         assertThatThrownBy(() -> userService.updateUser(inputUser, request.name(), Gender.MALE, LocalDate.of(2000, 5, 15)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #391 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

### 문제 상황

```

1. 소셜로그인 완료시 -> 회원 생성
2. 추가정보 기입 시, patch api를 통해 추가정보 기입

```

의 플로우로 회원가입을 진행했었습니다. 하지만 현재 소셜로그인이 완료되고 추가정보를 기입하는 페이지에서 사용자가 이탈하게 되면 그대로 빈 사용자가 남아버리는 문제를 발견했습니다.


### 해결방안

```

1. 소셜로그인 완료 -> 회원 임시토큰 발급 후 레디스에 저장 {token: email,name....}
2. 추가 정보 기입 API는 발급된 임시토큰을 파라미터로 넘김
3. 임시토큰을 레디스에서 검증하고 회원 생성

```


### 발생 할 수 있는 문제

```

1. 회원이 이메일을 넘기는 것에 동의하지 않으면 이메일이 넘어오지 않습니다.
1-1. 현재 대부분의 로직에서 회원의 이메일을 PK처럼 사용하고 있어서 이는 서비스 전체적인 잠재적 리스크라고 생각해서 한 번에 수정하도록 하겠습니다.
2. 아직 클라이언트의 개발/배포 서버가 분리되지 않음

```

클라이언트의 개발/배포 서버가 분리되는대로 머지하도록 하겠습니다. 그 전까지 리뷰 남겨주시면 감사하겠습니다.
-> PR을 수정합니다. 회원의 이메일은 필수 동의란으로 반드시 받아야하는 값이기 때문에 문제가 되지 않습니다.


## 🙏 to Client

- 소셜 로그인 요청

로그인은 똑같이 아래의 엔드포인트에서 시작해주시면 됩니다.

```

    @GetMapping("/oauth/kakao")
    @Operation(summary = "카카오 소셜로그인 API",
            description = "카카오 인증서버로 리다이렉트합니다. <br><br>" +
                    "env 파라미터(local|dev)를 전달하면 해당 환경 기준으로 redirect_uri를 고정 생성합니다. <br>" +
                    "env 미전달 시 기존 로직(헤더 기반 추정)으로 동작합니다. <br><br>" +
                    "프론트에서 인가코드(code)를 파싱하여 아래 콜백 API로 전달하세요.")
    public void kakaoOAuthCallback(@RequestParam(value = "env", required = false) String env,
                                   HttpServletRequest request,
                                   HttpServletResponse response) throws IOException {

        String redirectAddress = (env == null)
                ? oAuthService.requestRedirect(request)
                : oAuthService.requestRedirect(request, env);
        response.sendRedirect(redirectAddress);
    }
    
   
```

대신 반환값이 변경되었습니다.

```

  - 신규 회원

  {
    "code": 200,
    "msg": "응답 성공",
    "data": {
      "isNewUser": true,
      "signupToken": "8f3b1c9a7e0d4c6f9a1b2c3d4e5f6789",
      "prefill": {
        "email": "user@example.com",
        "nickname": "홍길동"
      }
    }
  }

  - 기존 회원

  {
    "code": 200,
    "msg": "응답 성공",
    "data": {
      "isNewUser": false,
      "signupToken": null,
      "prefill": null
    }
  }

  참고로 기존 회원인 경우 access-token은 응답 헤더에, refresh-token은 쿠키에 담겨 내려갑니다(응답 바디에는 없음).

```


- 자체 회원가입 

```

    @PostMapping(value = "/sign-up")
    @Operation(summary = "소셜 자체 회원가입 API",
            description = "카카오 소셜로그인 완료 후 발급된 signupToken(임시토큰)과 함께 호출하면 회원을 생성합니다. <br><br>" +
                    "성공 시 access-token 헤더와 refresh-token 쿠키를 함께 반환합니다.")
    public ResponseEntity<ApiResponse<String>> signUp(@RequestBody @Valid SocialSignUpRequest signUpRequest,
                                                      HttpServletResponse response) {
        Gender gender;
        LocalDate birthday;

        try {
            gender = Gender.valueOf(signUpRequest.gender());
        } catch (IllegalArgumentException e) {
            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
        }
        try {
            birthday = LocalDate.parse(signUpRequest.birthday());
        } catch (IllegalArgumentException e) {
            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
        }

        String username = oAuthService.signUpWithToken(
                signUpRequest.signupToken(),
                signUpRequest.name(),
                gender,
                birthday,
                response
        );

        return ResponseEntity.ok(ApiResponse.ok(username));
    }

```

1. HTTP method가 Patch->Post 로 변경되었습니다
2. 요청값은 아래와 같습니다.

```

  {
    "signupToken": "8f3b1c9a7e0d4c6f9a1b2c3d4e5f6789",
    "name": "홍길동",
    "gender": "MALE",
    "birthday": "1997-08-21"
  }

```


## 궁금한점 있으면 말해주세요~!




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 카카오 로그인 응답에 신규/기존 구분 추가(가입 토큰 및 사전입력 정보 포함)
  * 토큰 기반 소셜 회원가입 API 추가(POST /api/v1/sign-up) 및 가입 세션 저장/소비 흐름 도입
  * 신규 가입자 대상 초기 크레딧 자동 지급 플로우 추가

* **버그 수정 / 개선**
  * 가입 토큰 유효성·이메일 중복 관련 오류 코드 추가
  * POST /api/v1/sign-up 엔드포인트 인증 예외 처리 추가

* **테스트**
  * OAuth 로그인·회원가입 흐름 테스트 갱신 및 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->