### PR TITLE
[CHORE] 큐레이션 성능 최적화

### DIFF
--- a/src/main/java/or/sopt/houme/HoumeApplication.java
+++ b/src/main/java/or/sopt/houme/HoumeApplication.java
@@ -3,9 +3,11 @@ package or.sopt.houme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class HoumeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/CurationFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/CurationFurniture.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.furniture.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
                 )
         }
 )
+@Comment("큐레이션용 가구 데이터를 저장하는 엔티티입니다")
 public class CurationFurniture {
 
     @Id

--- a/src/main/java/or/sopt/houme/domain/furniture/entity/CurationFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/entity/CurationFurniture.java
@@ -1,0 +1,64 @@
+package or.sopt.houme.domain.furniture.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(
+        name = "curation_furnitures",
+        indexes = {
+                @Index(name = "idx_curation_furniture_tag_id", columnList = "furniture_tag_id"),
+                @Index(name = "idx_curation_recommend_furniture_id", columnList = "recommend_furniture_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_curation_furniture_tag_rank",
+                        columnNames = {"furniture_tag_id", "rank"}
+                )
+        }
+)
+public class CurationFurniture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "furniture_tag_id", nullable = false)
+    private FurnitureTag furnitureTag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommend_furniture_id", nullable = false)
+    private RecommendFurniture recommendFurniture;
+
+    @Column(name = "rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "similarity", nullable = false)
+    private Double similarity;
+
+    @Column(name = "fetched_at", nullable = false)
+    private LocalDateTime fetchedAt;
+
+    public static CurationFurniture of(
+            FurnitureTag furnitureTag,
+            RecommendFurniture recommendFurniture,
+            int rank,
+            double similarity,
+            LocalDateTime fetchedAt
+    ) {
+        return CurationFurniture.builder()
+                .furnitureTag(furnitureTag)
+                .recommendFurniture(recommendFurniture)
+                .rank(rank)
+                .similarity(similarity)
+                .fetchedAt(fetchedAt)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
@@ -6,20 +6,18 @@ import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsIn
 import or.sopt.houme.domain.furniture.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
 import or.sopt.houme.domain.furniture.dto.external.naverShop.NaverFurnitureProductDto;
 import or.sopt.houme.domain.furniture.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.furniture.service.ImageHashService;
 import or.sopt.houme.domain.furniture.service.NaverShopService;
-import or.sopt.houme.domain.furniture.service.RecommendFurnitureService;
 import or.sopt.houme.domain.user.entity.User;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Map;
 
 import or.sopt.houme.global.config.NaverProperties;
 
@@ -31,7 +29,7 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
     private final NaverShopService naverShopService;
     private final ImageHashService imageHashService;
     private final FurnitureService furnitureService;
-    private final RecommendFurnitureService recommendFurnitureService;
+    private final CurationFurnitureService curationFurnitureService;
     private final NaverProperties naverProperties;
 
     @Override
@@ -45,6 +43,13 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         log.info("연관된 가구들을 조회합니다:{}",formatted);
         FurnitureTag furnitureTag = furnitureService.findFurnitureTag(user, imageId, categoryId);
 
+        List<FurnitureProductsInfoResponse.FurnitureProductInfo> cachedInfos =
+                curationFurnitureService.getCurationProducts(furnitureTag);
+        if (!cachedInfos.isEmpty()) {
+            log.info("큐레이션 결과를 DB에서 조회합니다");
+            return FurnitureProductsInfoResponse.of(user.getName(), cachedInfos);
+        }
+
         // 2. 네이버 API 호출
         log.info("네이버 API 호출을 시작합니다");
         String keyword = furnitureTag.getSearchKeyword();
@@ -56,23 +61,10 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos =
                 imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), products, 5);
 
-        // 3-1. 최종반환된 리스트를 기반으로 추천가구 엔티티 저장하고, 엔티티 id 매핑 반환
-        log.info("최종반환된 리스트를 기반으로 추천가구 엔티티 저장하고, 엔티티 id 매핑");
-        Map<Long, Long> idMapByProductId = recommendFurnitureService.saveRecommendFurniture(infos);
-
-        // 4. 최종 응답 조립 (Facade 책임) - id 포함
-        log.info("최종 응답 조립 (Facade 책임) - id 포함");
-        List<FurnitureProductsInfoResponse.FurnitureProductInfo> responseInfos = infos.stream()
-                .map(info -> FurnitureProductsInfoResponse.FurnitureProductInfo.of(
-                        idMapByProductId.get(info.furnitureProductId()),
-                        info.furnitureProductImageUrl(),
-                        info.furnitureProductSiteUrl(),
-                        info.furnitureProductName(),
-                        info.furnitureProductMallName(),
-                        info.furnitureProductId(),
-                        info.similarity()
-                ))
-                .toList();
+        // 3-1. 최종반환된 리스트를 기반으로 추천가구 엔티티 저장하고, 큐레이션 결과 저장
+        log.info("최종반환된 리스트를 기반으로 큐레이션 결과 저장");
+        List<FurnitureProductsInfoResponse.FurnitureProductInfo> responseInfos =
+                curationFurnitureService.saveCurationResults(furnitureTag, infos);
 
         log.info("큐레이션 종료:{}",formatted);
         return FurnitureProductsInfoResponse.of(user.getName(), responseInfos);

--- a/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/facade/FurnitureFacadeImpl.java
@@ -50,7 +50,7 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
             return FurnitureProductsInfoResponse.of(user.getName(), cachedInfos);
         }
 
-        // 2. 네이버 API 호출
+        // 2. DB에서 조회된 결과가 없는 경우 -> 네이버 API 호출
         log.info("네이버 API 호출을 시작합니다");
         String keyword = furnitureTag.getSearchKeyword();
         List<NaverFurnitureProductDto> products = naverShopService.search(keyword, 50);

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationFurnitureRepository.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.entity.CurationFurniture;
+import or.sopt.houme.domain.furniture.entity.FurnitureTag;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationFurnitureRepository extends JpaRepository<CurationFurniture, Long> {
+
+    @EntityGraph(attributePaths = "recommendFurniture")
+    List<CurationFurniture> findAllByFurnitureTagOrderByRankAsc(FurnitureTag furnitureTag);
+
+    void deleteByFurnitureTag(FurnitureTag furnitureTag);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/scheduler/CurationFurnitureScheduler.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/scheduler/CurationFurnitureScheduler.java
@@ -1,0 +1,82 @@
+package or.sopt.houme.domain.furniture.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsInfoResponse;
+import or.sopt.houme.domain.furniture.dto.external.naverShop.NaverFurnitureProductDto;
+import or.sopt.houme.domain.furniture.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
+import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
+import or.sopt.houme.domain.furniture.service.ImageHashService;
+import or.sopt.houme.domain.furniture.service.NaverShopService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CurationFurnitureScheduler {
+
+    private static final int NAVER_DISPLAY = 50;
+    private static final int TOP_N = 5;
+    private static final int MAX_RETRY = 2;
+    private static final long RETRY_BACKOFF_MILLIS = 1_000L;
+    private static final long NAVER_RATE_LIMIT_MILLIS = 200L;
+
+    private final FurnitureTagRepository furnitureTagRepository;
+    private final NaverShopService naverShopService;
+    private final ImageHashService imageHashService;
+    private final CurationFurnitureService curationFurnitureService;
+
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void refreshCurationResults() {
+        List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
+        if (furnitureTags.isEmpty()) {
+            log.info("큐레이션 배치: 대상 태그 없음");
+            return;
+        }
+
+        for (int i = 0; i < furnitureTags.size(); i++) {
+            if (i > 0) {
+                sleep(NAVER_RATE_LIMIT_MILLIS);
+            }
+
+            FurnitureTag furnitureTag = furnitureTags.get(i);
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos = fetchCurationWithRetry(furnitureTag);
+            if (infos.isEmpty()) {
+                log.warn("큐레이션 배치: 결과 없음 tagId={}", furnitureTag.getId());
+                continue;
+            }
+
+            curationFurnitureService.saveCurationResults(furnitureTag, infos);
+        }
+    }
+
+    private List<FurnitureProductsInfoResponse.FurnitureProductInfo> fetchCurationWithRetry(FurnitureTag furnitureTag) {
+        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+            try {
+                return fetchCurationInfos(furnitureTag);
+            } catch (Exception e) {
+                log.warn("큐레이션 배치 실패: tagId={}, attempt={}", furnitureTag.getId(), attempt, e);
+                sleep(RETRY_BACKOFF_MILLIS * attempt);
+            }
+        }
+
+        return List.of();
+    }
+
+    private List<FurnitureProductsInfoResponse.FurnitureProductInfo> fetchCurationInfos(FurnitureTag furnitureTag) {
+        List<NaverFurnitureProductDto> products = naverShopService.search(furnitureTag.getSearchKeyword(), NAVER_DISPLAY);
+        return imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), products, TOP_N);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/scheduler/CurationFurnitureScheduler.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/scheduler/CurationFurnitureScheduler.java
@@ -30,7 +30,7 @@ public class CurationFurnitureScheduler {
     private final ImageHashService imageHashService;
     private final CurationFurnitureService curationFurnitureService;
 
-    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
     public void refreshCurationResults() {
         List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
         if (furnitureTags.isEmpty()) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureService.java
@@ -1,0 +1,16 @@
+package or.sopt.houme.domain.furniture.service;
+
+import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsInfoResponse;
+import or.sopt.houme.domain.furniture.entity.FurnitureTag;
+
+import java.util.List;
+
+public interface CurationFurnitureService {
+
+    List<FurnitureProductsInfoResponse.FurnitureProductInfo> getCurationProducts(FurnitureTag furnitureTag);
+
+    List<FurnitureProductsInfoResponse.FurnitureProductInfo> saveCurationResults(
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos
+    );
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureServiceImpl.java
@@ -1,0 +1,112 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.furniture.dto.external.naverShop.FurnitureProductsInfoResponse;
+import or.sopt.houme.domain.furniture.entity.CurationFurniture;
+import or.sopt.houme.domain.furniture.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.repository.CurationFurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CurationFurnitureServiceImpl implements CurationFurnitureService {
+
+    private final CurationFurnitureRepository curationFurnitureRepository;
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+    private final RecommendFurnitureService recommendFurnitureService;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<FurnitureProductsInfoResponse.FurnitureProductInfo> getCurationProducts(FurnitureTag furnitureTag) {
+        List<CurationFurniture> curations = curationFurnitureRepository.findAllByFurnitureTagOrderByRankAsc(furnitureTag);
+        if (curations.isEmpty()) {
+            return List.of();
+        }
+
+        return curations.stream()
+                .map(curation -> {
+                    RecommendFurniture recommendFurniture = curation.getRecommendFurniture();
+
+                    return FurnitureProductsInfoResponse.FurnitureProductInfo.of(
+                            recommendFurniture.getId(),
+                            recommendFurniture.getFurnitureProductImageUrl(),
+                            recommendFurniture.getFurnitureProductSiteUrl(),
+                            recommendFurniture.getFurnitureProductName(),
+                            recommendFurniture.getFurnitureProductMallName(),
+                            recommendFurniture.getFurnitureProductId(),
+                            curation.getSimilarity()
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional
+    @Override
+    public List<FurnitureProductsInfoResponse.FurnitureProductInfo> saveCurationResults(
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos
+    ) {
+        if (infos == null || infos.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Long> idMapByProductId = recommendFurnitureService.saveRecommendFurniture(infos);
+        LocalDateTime fetchedAt = LocalDateTime.now();
+        List<CurationFurniture> curations = new ArrayList<>();
+
+        int rank = 1;
+        for (FurnitureProductsInfoResponse.FurnitureProductInfo info : infos) {
+            Long recommendFurnitureId = idMapByProductId.get(info.furnitureProductId());
+            if (recommendFurnitureId == null) {
+                log.warn("큐레이션 저장 실패: recommendFurnitureId 없음, productId={}", info.furnitureProductId());
+                continue;
+            }
+
+            RecommendFurniture recommendFurniture = recommendFurnitureRepository.getReferenceById(recommendFurnitureId);
+            curations.add(CurationFurniture.of(
+                    furnitureTag,
+                    recommendFurniture,
+                    rank,
+                    info.similarity(),
+                    fetchedAt
+            ));
+            rank++;
+        }
+
+        if (curations.isEmpty()) {
+            return List.of();
+        }
+
+        curationFurnitureRepository.deleteByFurnitureTag(furnitureTag);
+        curationFurnitureRepository.saveAll(curations);
+
+        return mapResponseWithIds(infos, idMapByProductId);
+    }
+
+    private List<FurnitureProductsInfoResponse.FurnitureProductInfo> mapResponseWithIds(
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos,
+            Map<Long, Long> idMapByProductId
+    ) {
+        return infos.stream()
+                .map(info -> FurnitureProductsInfoResponse.FurnitureProductInfo.of(
+                        idMapByProductId.get(info.furnitureProductId()),
+                        info.furnitureProductImageUrl(),
+                        info.furnitureProductSiteUrl(),
+                        info.furnitureProductName(),
+                        info.furnitureProductMallName(),
+                        info.furnitureProductId(),
+                        info.similarity()
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #397 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

### 원인

기존 큐레이션 로직의 가장 큰 병목포인트는 아래와 같았습니다.

```

1. 매 호출마다 50개의 가구를 가져옴 
2. 유사도를 판별 후 5개의 결과를 반환

```

이를 해결하기 위해서 기존 파이프라인과 수정된 파이프라인을 [discussion](https://github.com/TEAM-HOUME/HOUME-SERVER/discussions/398)에 정리해두었습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 아무래도 DB에 데이터가 없는 경우에는 실행시간이 이전과 같습니다만, 데이터가 존재하는 경우에는 즉시 응답됩니다.
- 새벽 두시에 모든 카테고리에 대한 데이터를 가져오기 때문에 위와 같은 문제가 발생할 확률은 매우 적다고 생각합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데이터베이스 기반 가구 큐레이션 캐싱 시스템 추가
  * 매일 오전 2시(서울 시간)에 자동으로 큐레이션 데이터 갱신
  * 이미지 유사도 기반 가구 추천 순위 지정
  * 캐시된 결과를 통한 빠른 가구 정보 조회

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->