### PR TITLE
[FEAT] gemini-nano banana 를 활용한 이미지 생성 api 구현

### DIFF
--- a/src/main/java/or/sopt/houme/ai/image/LocalFastApiImageClient.java
+++ b/src/main/java/or/sopt/houme/ai/image/LocalFastApiImageClient.java
@@ -39,7 +39,7 @@ public class LocalFastApiImageClient implements FastApiImageClient {
         // 1) 프롬프트 합성
         String prompt = promptService.makePrompt(request);
 
-        // 2) 이미지 생성 + S3 업로드 (내부 서비스 활용)
+        // 2) 이미지 생성 + S3 업로드 (Provider 선택은 resolver에서 처리)
         ImageUploadResponseDTO response = openAiService.createImage(prompt);
 
         // pullPrompt 정보 보강 (기존 FastAPI 응답 정합성 유지)

--- a/src/main/java/or/sopt/houme/domain/gemini/client/GeminiImageClient.java
+++ b/src/main/java/or/sopt/houme/domain/gemini/client/GeminiImageClient.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.domain.gemini.client;
+
+import or.sopt.houme.domain.gemini.dto.GeminiImageRequest;
+import or.sopt.houme.domain.gemini.dto.GeminiImageResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "geminiImageClient",
+        url = "${gemini.api-base-url:https://generativelanguage.googleapis.com/v1beta}"
+)
+public interface GeminiImageClient {
+
+    @PostMapping(
+            value = "/models/{model}:generateContent",
+            consumes = MediaType.APPLICATION_JSON_VALUE
+    )
+    GeminiImageResponse generateImage(
+            @PathVariable("model") String model,
+            @RequestHeader("x-goog-api-key") String apiKey,
+            @RequestBody GeminiImageRequest request
+    );
+}

--- a/src/main/java/or/sopt/houme/domain/gemini/dto/GeminiImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/gemini/dto/GeminiImageRequest.java
@@ -1,0 +1,33 @@
+package or.sopt.houme.domain.gemini.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GeminiImageRequest(
+        List<Content> contents,
+        GenerationConfig generationConfig
+) {
+    public static GeminiImageRequest of(String prompt) {
+        return new GeminiImageRequest(
+                List.of(new Content("user", List.of(Part.text(prompt)))),
+                new GenerationConfig(List.of("IMAGE"))
+        );
+    }
+
+    public record Content(String role, List<Part> parts) {
+    }
+
+    public record Part(String text, InlineData inlineData) {
+        public static Part text(String text) {
+            return new Part(text, null);
+        }
+    }
+
+    public record InlineData(String mimeType, String data) {
+    }
+
+    public record GenerationConfig(List<String> responseModalities) {
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/gemini/dto/GeminiImageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/gemini/dto/GeminiImageResponse.java
@@ -1,0 +1,19 @@
+package or.sopt.houme.domain.gemini.dto;
+
+import java.util.List;
+
+public record GeminiImageResponse(
+        List<Candidate> candidates
+) {
+    public record Candidate(Content content) {
+    }
+
+    public record Content(List<Part> parts) {
+    }
+
+    public record Part(InlineData inlineData, String text) {
+    }
+
+    public record InlineData(String mimeType, String data) {
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/gemini/service/GeminiImageService.java
+++ b/src/main/java/or/sopt/houme/domain/gemini/service/GeminiImageService.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.domain.gemini.service;
+
+import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+
+public interface GeminiImageService {
+    ImageUploadResponseDTO createImage(String prompt);
+}

--- a/src/main/java/or/sopt/houme/domain/gemini/service/GeminiImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/gemini/service/GeminiImageServiceImpl.java
@@ -1,0 +1,115 @@
+package or.sopt.houme.domain.gemini.service;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.gemini.client.GeminiImageClient;
+import or.sopt.houme.domain.gemini.dto.GeminiImageRequest;
+import or.sopt.houme.domain.gemini.dto.GeminiImageResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.ChatGptException;
+import or.sopt.houme.global.api.handler.S3Exception;
+import or.sopt.houme.global.config.GeminiImageConfig;
+import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+import or.sopt.houme.global.util.S3Util;
+import or.sopt.houme.global.util.constant.S3Constant;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GeminiImageServiceImpl implements GeminiImageService {
+
+    private final GeminiImageClient geminiImageClient;
+    private final GeminiImageConfig geminiImageConfig;
+    private final S3Util s3Util;
+
+    @Value("${gemini.api-key:}")
+    private String apiKey;
+
+    @Override
+    public ImageUploadResponseDTO createImage(String prompt) {
+        // Gemini는 해상도 파라미터를 받지 않으므로 프롬프트 힌트로만 전달합니다.
+        String promptWithSize = applySizeHint(prompt, geminiImageConfig.getSize());
+        GeminiImageRequest request = GeminiImageRequest.of(promptWithSize);
+
+        try {
+            GeminiImageResponse response = geminiImageClient.generateImage(
+                    defaultModel(geminiImageConfig.getModel()),
+                    apiKey,
+                    request
+            );
+
+            // Gemini는 inlineData에 base64 문자열로 이미지를 반환합니다.
+            byte[] image = decodeBase64(extractBase64(response));
+            ImageUploadResponseDTO responseDTO = s3Util.uploadByByte(S3Constant.CHAT_GPT_DIRNAME, image);
+            responseDTO.setPullPrompt(promptWithSize);
+            return responseDTO;
+        } catch (FeignException e) {
+            log.info(e.getMessage());
+            throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+        } catch (IllegalArgumentException e) {
+            throw new S3Exception(ErrorCode.INCODING_EXCEPTION);
+        }
+    }
+
+    private String extractBase64(GeminiImageResponse response) {
+        // 후보 목록에서 첫 번째 이미지(base64)를 찾아 반환합니다.
+        if (response == null || response.candidates() == null) {
+            throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+        }
+
+        for (GeminiImageResponse.Candidate candidate : response.candidates()) {
+            if (candidate == null || candidate.content() == null || candidate.content().parts() == null) {
+                continue;
+            }
+            for (GeminiImageResponse.Part part : candidate.content().parts()) {
+                if (part != null && part.inlineData() != null && part.inlineData().data() != null) {
+                    return part.inlineData().data();
+                }
+            }
+        }
+
+        throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+    }
+
+    private byte[] decodeBase64(String base64) {
+        // base64 문자열을 실제 바이너리 이미지로 변환합니다.
+        return Base64.getDecoder().decode(base64);
+    }
+
+    private String defaultModel(String model) {
+        // 설정이 비어있으면 기본 Gemini 이미지 모델을 사용합니다.
+        if (model == null || model.isBlank()) {
+            return "gemini-3-pro-image-preview";
+        }
+        return model;
+    }
+
+    private String applySizeHint(String prompt, String size) {
+        // Gemini가 해상도 파라미터를 받지 않으므로 프롬프트에 힌트만 추가합니다.
+        String normalized = normalizeSize(size);
+        if (normalized == null) {
+            return prompt;
+        }
+        return prompt + "\n\nResolution: " + normalized + ".";
+    }
+
+    private String normalizeSize(String size) {
+        // 1k/2k/4k 또는 1024x1024 같은 입력을 표준 해상도로 정규화합니다.
+        if (size == null || size.isBlank()) {
+            return null;
+        }
+        String trimmed = size.trim().toLowerCase();
+        if ("1k".equals(trimmed)) return "1024x1024";
+        if ("2k".equals(trimmed)) return "2048x2048";
+        if ("4k".equals(trimmed)) return "4096x4096";
+        if (trimmed.matches("\\d{3,4}x\\d{3,4}")) {
+            return trimmed;
+        }
+        return null;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/controller/GenerateImageController.java
@@ -39,6 +39,18 @@ public class GenerateImageController {
         return ResponseEntity.ok(ApiResponse.ok(imageInfoResponse));
     }
 
+    @Operation(summary = "Gemini 이미지 생성 API",
+            description = "사용자가 요청한 내용을 기반으로 새로운 이미지를 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다.")
+    @PostMapping("/v1/generated-images/generate/gemini")
+    public ResponseEntity<ApiResponse<ImageInfoResponse>> generateImageByGemini(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid GenerateImageRequest request){
+
+        ImageInfoResponse imageInfoResponse = generateImageFacade.generateImageByGemini(userDetails.getUser(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok(imageInfoResponse));
+    }
+
     @Operation(summary = "LangChain를 이용한 이미지 생성 API",
             description = "사용자가 요청한 내용을 기반으로 새로운 이미지를 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다. <br><br>" +
                     "FastAPI를 활용한 API 입니다")
@@ -52,6 +64,19 @@ public class GenerateImageController {
         return ResponseEntity.ok(ApiResponse.ok(imageInfoResponse));
     }
 
+    @Operation(summary = "Gemini 이미지 생성 API (FastAPI 대체)",
+            description = "사용자가 요청한 내용을 기반으로 새로운 이미지를 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다. <br><br>" +
+                    "Gemini 모델을 활용한 API 입니다")
+    @PostMapping("/v2/generated-images/generate/gemini")
+    public ResponseEntity<ApiResponse<ImageInfoResponse>> generateImageByFastApiGemini(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid GenerateImageRequest request){
+
+        ImageInfoResponse imageInfoResponse = generateImageFacade.generateImageByFastApiGemini(userDetails.getUser(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok(imageInfoResponse));
+    }
+
     @Operation(summary = "비동기를 이용한 이미지 2장 생성 API",
             description = "사용자가 요청한 내용을 기반으로 높은 스타일 2개로 새로운 이미지 2장을 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다. <br><br>" +
                     "FastAPI를 활용한 API 입니다")
@@ -61,6 +86,19 @@ public class GenerateImageController {
             @RequestBody @Valid GenerateImageRequest request){
 
         ImageInfoListResponse imageInfoListResponse = generateImageFacade.generateImageBy2ea(userDetails.getUser(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
+    }
+
+    @Operation(summary = "Gemini 비동기 이미지 2장 생성 API",
+            description = "사용자가 요청한 내용을 기반으로 높은 스타일 2개로 새로운 이미지 2장을 생성합니다. 생성된 이미지는 저장되며, 별도의 조회 API를 통해 확인할 수 있습니다. <br><br>" +
+                    "Gemini 모델을 활용한 API 입니다")
+    @PostMapping("/v3/generated-images/generate/gemini")
+    public ResponseEntity<ApiResponse<ImageInfoListResponse>> generate2ImageByFastApiGemini(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid GenerateImageRequest request){
+
+        ImageInfoListResponse imageInfoListResponse = generateImageFacade.generateImageBy2eaGemini(userDetails.getUser(), request);
 
         return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
     }

--- a/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/facade/GenerateImageFacade.java
@@ -16,6 +16,7 @@ import or.sopt.houme.domain.generateImage.service.AsyncGenerateImageService;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImage.service.GenerateImageTransactionService;
 import or.sopt.houme.domain.generateImage.service.imageGenerationLog.ImageGenerationTransactionService;
+import or.sopt.houme.domain.gemini.service.GeminiImageService;
 import or.sopt.houme.domain.house.entity.House;
 import or.sopt.houme.domain.house.entity.enums.Activity;
 import or.sopt.houme.domain.house.entity.enums.Equilibrium;
@@ -24,6 +25,7 @@ import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.openai.facade.OpenAiFacade;
 import or.sopt.houme.domain.prompt.dto.PromptFurnitureListDTO;
 import or.sopt.houme.domain.prompt.dto.PromptRequestDTO;
+import or.sopt.houme.domain.prompt.service.PromptService;
 import or.sopt.houme.domain.taste.dto.response.TagDTO;
 import or.sopt.houme.domain.taste.entity.Tag;
 import or.sopt.houme.domain.taste.entity.Taste;
@@ -51,6 +53,8 @@ public class GenerateImageFacade {
 
     private final GenerateImageService generateImageService;
     private final OpenAiFacade openAiFacade;
+    private final PromptService promptService;
+    private final GeminiImageService geminiImageService;
     private final HouseService houseService;
     private final CreditService creditService;
     private final TasteTagService tasteTagService;
@@ -73,6 +77,15 @@ public class GenerateImageFacade {
     // 스프링을 이용한 이미지 생성
     @Transactional
     public ImageInfoResponse generateImage(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageInternal(user, generateImageRequest, false);
+    }
+
+    @Transactional
+    public ImageInfoResponse generateImageByGemini(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageInternal(user, generateImageRequest, true);
+    }
+
+    private ImageInfoResponse generateImageInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         /**
          * redis 저장 (user랑 상태값)
@@ -119,8 +132,15 @@ public class GenerateImageFacade {
 
         try {
 
-            // OpenAI로 image 생성
-            ImageUploadResponseDTO imageUploadResponseDTO = openAiFacade.makeImage(promptRequestDTO);
+            // OpenAI/Gemini로 image 생성
+            ImageUploadResponseDTO imageUploadResponseDTO;
+
+            if (useGemini) {
+                String prompt = promptService.makePrompt(promptRequestDTO);
+                imageUploadResponseDTO = geminiImageService.createImage(prompt);
+            } else {
+                imageUploadResponseDTO = openAiFacade.makeImage(promptRequestDTO);
+            }
 
             // house에 프롬프트 저장
             houseService.saveHousePrompt(house, imageUploadResponseDTO.getPullPrompt());
@@ -164,9 +184,18 @@ public class GenerateImageFacade {
             log.info("Image 생성 중 오류 발생 {}", e.getMessage());
             throw new GenerateImageException(ErrorCode.GENERATED_IMAGE_EXCEPTION);
         }
+    
     }
 
     public ImageInfoResponse generateImageByFastApi(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageByFastApiInternal(user, generateImageRequest, false);
+    }
+
+    public ImageInfoResponse generateImageByFastApiGemini(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageByFastApiInternal(user, generateImageRequest, true);
+    }
+
+    private ImageInfoResponse generateImageByFastApiInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         /**
          * [짧은 트랜잭션이 일어나는 부분] (하나의 로직으로 처리)
@@ -216,8 +245,15 @@ public class GenerateImageFacade {
             PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(generateImageRequest.floorPlan().floorPlanId(),
                     priorityTag.getId(), equilibrium, promptFurnitureListDTO);
 
-            // OpenAI로 image 생성
-            ImageUploadResponseDTO imageUploadResponseDTO = openAiFacade.makeImageByFastApi(promptRequestDTO);
+            // OpenAI/Gemini로 image 생성
+            ImageUploadResponseDTO imageUploadResponseDTO;
+
+            if (useGemini) {
+                String prompt = promptService.makePrompt(promptRequestDTO);
+                imageUploadResponseDTO = geminiImageService.createImage(prompt);
+            } else {
+                imageUploadResponseDTO = openAiFacade.makeImageByFastApi(promptRequestDTO);
+            }
 
             ImageInfoResponse imageInfoResponse = generateImageTransactionService.saveAllDataAndConfirmCredit(
                     user, lockedCredit, generateImageRequest, imageUploadResponseDTO, priorityTag, activity
@@ -261,10 +297,19 @@ public class GenerateImageFacade {
                 creditService.releaseLock(user);
             }
         }
+    
     }
 
     // 비동기 이미지 생성 요청
     public ImageInfoListResponse generateImageBy2ea(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageBy2eaInternal(user, generateImageRequest, false);
+    }
+
+    public ImageInfoListResponse generateImageBy2eaGemini(User user, GenerateImageRequest generateImageRequest) {
+        return generateImageBy2eaInternal(user, generateImageRequest, true);
+    }
+
+    private ImageInfoListResponse generateImageBy2eaInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         // finally 블록에서 사용하기 위해 선언
         Credit lockedCredit = null;
@@ -311,9 +356,13 @@ public class GenerateImageFacade {
             PromptRequestDTO promptRequestDTO1 = PromptRequestDTO.of(generateImageRequest.floorPlan().floorPlanId(),
                     priorityIdList.get(0).id(), equilibrium, promptFurnitureListDTO);
 
-            // OpenAI로 image 비동기 생성
+            // OpenAI/Gemini로 image 비동기 생성
             // 1번 이미지 (항상 실행됨)
-            futures.add(asyncGenerateImageService.generateImageAsync(promptRequestDTO1));
+            if (useGemini) {
+                futures.add(asyncGenerateImageService.generateGeminiImageAsync(promptRequestDTO1));
+            } else {
+                futures.add(asyncGenerateImageService.generateImageAsync(promptRequestDTO1));
+            }
 
             // 2번째 태그가 존재할 시에 2번 이미지 준비
             if (priorityIdList.size() > 1) {
@@ -321,9 +370,13 @@ public class GenerateImageFacade {
                 PromptRequestDTO promptRequestDTO2 = PromptRequestDTO.of(generateImageRequest.floorPlan().floorPlanId(),
                         priorityIdList.get(1).id(), equilibrium, promptFurnitureListDTO);
 
-                // OpenAI로 image 비동기 생성
+                // OpenAI/Gemini로 image 비동기 생성
                 // 2번 이미지
-                futures.add(asyncGenerateImageService.generateImageAsync(promptRequestDTO2));
+                if (useGemini) {
+                    futures.add(asyncGenerateImageService.generateGeminiImageAsync(promptRequestDTO2));
+                } else {
+                    futures.add(asyncGenerateImageService.generateImageAsync(promptRequestDTO2));
+                }
             }
 
             // allOf로 모든 1번, 2번 이미지 생성 기다리기
@@ -422,6 +475,7 @@ public class GenerateImageFacade {
                 creditService.releaseLock(user);
             }
         }
+    
     }
 
     // houseId로 결과 이미지 찾아오기

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/AsyncGenerateImageService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/AsyncGenerateImageService.java
@@ -9,4 +9,6 @@ public interface AsyncGenerateImageService {
 
     // 비동기로 이미지 생성
     CompletableFuture<ImageUploadResponseDTO> generateImageAsync(PromptRequestDTO promptRequestDTO);
+
+    CompletableFuture<ImageUploadResponseDTO> generateGeminiImageAsync(PromptRequestDTO promptRequestDTO);
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/AsyncGenerateImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/AsyncGenerateImageServiceImpl.java
@@ -2,7 +2,9 @@ package or.sopt.houme.domain.generateImage.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.gemini.service.GeminiImageService;
 import or.sopt.houme.domain.openai.facade.OpenAiFacade;
+import or.sopt.houme.domain.prompt.service.PromptService;
 import or.sopt.houme.domain.prompt.dto.PromptRequestDTO;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.springframework.scheduling.annotation.Async;
@@ -17,6 +19,8 @@ public class AsyncGenerateImageServiceImpl implements AsyncGenerateImageService{
 
     // OpenAi 이미지 생성 파사드
     private final OpenAiFacade openAiFacade;
+    private final PromptService promptService;
+    private final GeminiImageService geminiImageService;
 
     // 비동기 이미지 생성 처리
     @Async("imageGenerationExecutor")
@@ -33,6 +37,21 @@ public class AsyncGenerateImageServiceImpl implements AsyncGenerateImageService{
             // 예외 발생
             log.error("이미지 생성 중 예외발생: {}", e.getMessage());
             // 비동기 작업 내에서 발생한 예외를 CompletableFuture에 담아 반환
+            return CompletableFuture.failedFuture(e);
+        }
+
+    }
+
+    @Async("imageGenerationExecutor")
+    @Override
+    public CompletableFuture<ImageUploadResponseDTO> generateGeminiImageAsync(PromptRequestDTO promptRequestDTO) {
+
+        try {
+            String prompt = promptService.makePrompt(promptRequestDTO);
+            ImageUploadResponseDTO response = geminiImageService.createImage(prompt);
+            return CompletableFuture.completedFuture(response);
+        } catch (Exception e){
+            log.error("이미지 생성 중 예외발생: {}", e.getMessage());
             return CompletableFuture.failedFuture(e);
         }
 

--- a/src/main/java/or/sopt/houme/global/config/GeminiImageConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/GeminiImageConfig.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gemini.image")
+public class GeminiImageConfig {
+    private String model;
+    private String size;
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,9 +22,9 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        show_sql: true
+        show_sql: false
 
   security:
     oauth2:
@@ -63,6 +63,13 @@ openai:
     quality: medium
     background: auto
     output-format: webp
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+  api-base-url: ${GEMINI_API_BASE_URL:https://generativelanguage.googleapis.com/v1beta}
+  image:
+    model: gemini-3-pro-image-preview
+    size: 1024x1024
 
 naver:
   client-id: ${NAVER_CLIENT_ID}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #396 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

기존 open-ai로의 이미지 생성 로직을 유지한 채, 나노바나나를 활용한 이미지 생성 api를 구현하였습니다.
대부분의 로직은 기존의 이미지 생성 로직과 동일하며 이미지 생성을 요청하는 벤더만 변경되었습니다.

원래는 Provider클래스와 port-adapter 아키텍쳐를 활용하여 open-ai와 gemini를 동적으로 변경하여 사용하도록 구현하려 했습니다만, 다음과 같은 이유로 해당 구현은 보류하였습니다.

```

1. port-adapter는 현재 저희 하우미 아키텍쳐에서 차용하고 있지 않습니다 -> 구조의 불필요한 복잡성 증가
2. 동적으로 바뀔 필요가 없음. 벤더를 하나로 고정하여 사용하기 때문

```

추후 fallback 로직처럼 1번벤더 try -> 실패시 2번 벤더로의 요청으로 디벨롭이 가능할 것으로 예상됩니다. 해당 내용은 내부 회의 후 결정하여 디벨롭 시키도록 하겠습니다.

---

또한 이미지 수정기능을 제공한다는 점에서 굉장히 매력적이라고 생각했습니다. 이는 B-3 phase에 도입될 가능성이 있는 [이미지 수정 기능](https://ai.google.dev/gemini-api/docs/image-generation?hl=ko#java_1)에 적극 도입 가능한 기능으로 판단됩니다.

링크를 참고해주시면 감사하겠습니다.


## 🙏 Question & PR point

@maehwasoo 엔드포인트에 `/gemini` 를 추가하면 제미나이를 이용한 이미지 생성을 활용할 수 있습니다.
머지되면, 개발서버에서 테스트 후 피드백주시면 감사하겠습니다.

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


