### PR TITLE
[FEAT] 큐레이션 데이터 저장 시, 디스코드 웹훅 기능 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/infrastructure/scheduler/CurationFurnitureScheduler.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/infrastructure/scheduler/CurationFurnitureScheduler.java
@@ -9,9 +9,12 @@ import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
 import or.sopt.houme.domain.furniture.service.ImageHashService;
 import or.sopt.houme.domain.furniture.service.NaverShopService;
+import or.sopt.houme.global.discord.DiscordWebhookService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -29,28 +32,62 @@ public class CurationFurnitureScheduler {
     private final NaverShopService naverShopService;
     private final ImageHashService imageHashService;
     private final CurationFurnitureService curationFurnitureService;
+    private final DiscordWebhookService discordWebhookService;
 
     @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
     public void refreshCurationResults() {
-        List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
-        if (furnitureTags.isEmpty()) {
-            log.info("큐레이션 배치: 대상 태그 없음");
-            return;
-        }
+        Instant startedAt = Instant.now();
+        int totalTags = 0;
+        int successTags = 0;
+        int emptyTags = 0;
+        String status = "성공";
+        Exception failure = null;
 
-        for (int i = 0; i < furnitureTags.size(); i++) {
-            if (i > 0) {
-                sleep(NAVER_RATE_LIMIT_MILLIS);
+        try {
+            List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
+            totalTags = furnitureTags.size();
+            if (furnitureTags.isEmpty()) {
+                status = "대상없음";
+                log.info("큐레이션 배치: 대상 태그 없음");
+                return;
             }
 
-            FurnitureTag furnitureTag = furnitureTags.get(i);
-            List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos = fetchCurationWithRetry(furnitureTag);
-            if (infos.isEmpty()) {
-                log.warn("큐레이션 배치: 결과 없음 tagId={}", furnitureTag.getId());
-                continue;
-            }
+            for (int i = 0; i < furnitureTags.size(); i++) {
+                if (i > 0) {
+                    sleep(NAVER_RATE_LIMIT_MILLIS);
+                }
 
-            curationFurnitureService.saveCurationResults(furnitureTag, infos);
+                FurnitureTag furnitureTag = furnitureTags.get(i);
+                List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos = fetchCurationWithRetry(furnitureTag);
+                if (infos.isEmpty()) {
+                    emptyTags++;
+                    log.warn("큐레이션 배치: 결과 없음 tagId={}", furnitureTag.getId());
+                    continue;
+                }
+
+                curationFurnitureService.saveCurationResults(furnitureTag, infos);
+                successTags++;
+            }
+        } catch (Exception e) {
+            status = "실패";
+            failure = e;
+            throw e;
+        } finally {
+            StringBuilder message = new StringBuilder();
+            long elapsedSeconds = Duration.between(startedAt, Instant.now()).toSeconds();
+            message.append("[큐레이션 배치] 상태=").append(status)
+                    .append(" 대상=").append(totalTags)
+                    .append(" 성공=").append(successTags)
+                    .append(" 결과없음=").append(emptyTags)
+                    .append(" 소요=").append(elapsedSeconds).append("s");
+            if (failure != null) {
+                message.append(" 에러=").append(failure.getClass().getSimpleName());
+                String errorMessage = failure.getMessage();
+                if (errorMessage != null && !errorMessage.isBlank()) {
+                    message.append(" (").append(errorMessage).append(")");
+                }
+            }
+            discordWebhookService.sendMessage(message.toString());
         }
     }
 

--- a/src/main/java/or/sopt/houme/global/discord/DiscordWebhookService.java
+++ b/src/main/java/or/sopt/houme/global/discord/DiscordWebhookService.java
@@ -1,0 +1,64 @@
+package or.sopt.houme.global.discord;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordWebhookService {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${discord.webhook-url:}")
+    private String webhookUrl;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT)
+            .build();
+
+    public void sendMessage(String content) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.debug("Discord webhook URL is not configured. Skip sending.");
+            return;
+        }
+        if (content == null || content.isBlank()) {
+            return;
+        }
+
+        try {
+            String payload = objectMapper.writeValueAsString(new DiscordWebhookPayload(content));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(
+                    request,
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+            );
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                log.warn("Discord webhook failed. status={}, body={}", response.statusCode(), response.body());
+            }
+        } catch (Exception e) {
+            log.warn("Discord webhook failed.", e);
+        }
+    }
+
+    private record DiscordWebhookPayload(String content) {
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -76,6 +76,9 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   allowed-malls: ${NAVER_ALLOWED_MALLS}  # 쉼표 구분 (예: 롯데ON,쿠팡,11번가)
 
+discord:
+  webhook-url: ${DISCORD_WEBHOOK}
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #400 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

매일 새벽 두 시, 큐레이션을 위한 가구 데이터 저장이 완료되면 슬랙으로 웹훅이 전송되도록 기능을 구현하였습니다.
채널은 server-curation 입니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 배치 처리 결과를 Discord 웹훅으로 자동 알림받기 기능 추가

* **Refactor**
  * 배치 처리 로직 개선 - 강화된 오류 처리 및 진행 현황 추적
  * 경과 시간 및 태그별 처리 결과 상세 로깅 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->