### PR TITLE
[FEAT] 수집 데이터 크롤링 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // html parsing
+    implementation 'org.jsoup:jsoup:1.17.2'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -1,0 +1,118 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(
+        name = "curation_raw_products",
+        indexes = {
+                @Index(name = "idx_raw_source", columnList = "source"),
+                @Index(name = "idx_raw_category", columnList = "category"),
+                @Index(name = "idx_raw_fetched_at", columnList = "fetched_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_raw_source_category_product_id",
+                        columnNames = {"source", "category", "product_id"}
+                )
+        }
+)
+@Comment("큐레이션 원본 수집 데이터를 저장하는 엔티티입니다")
+public class CurationRawProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source", nullable = false)
+    private String source;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private SoozipCategory category;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "product_image_url", columnDefinition = "varchar(2048)", nullable = false)
+    private String productImageUrl;
+
+    @Column(name = "product_site_url", columnDefinition = "varchar(2048)", nullable = false)
+    private String productSiteUrl;
+
+    @Column(name = "product_name", nullable = false)
+    private String productName;
+
+    @Column(name = "product_mall_name")
+    private String productMallName;
+
+    @Column(name = "fetched_at", nullable = false)
+    private LocalDateTime fetchedAt;
+
+    public static CurationRawProduct of(
+            String source,
+            SoozipCategory category,
+            Long productId,
+            String productImageUrl,
+            String productSiteUrl,
+            String productName,
+            String productMallName,
+            LocalDateTime fetchedAt
+    ) {
+        return CurationRawProduct.builder()
+                .source(source)
+                .category(category)
+                .productId(productId)
+                .productImageUrl(productImageUrl)
+                .productSiteUrl(productSiteUrl)
+                .productName(productName)
+                .productMallName(productMallName)
+                .fetchedAt(fetchedAt)
+                .build();
+    }
+
+    public void updateFrom(
+            String productImageUrl,
+            String productSiteUrl,
+            String productName,
+            String productMallName,
+            LocalDateTime fetchedAt
+    ) {
+        if (productImageUrl != null && !productImageUrl.isBlank()) {
+            this.productImageUrl = productImageUrl;
+        }
+        if (productSiteUrl != null && !productSiteUrl.isBlank()) {
+            this.productSiteUrl = productSiteUrl;
+        }
+        if (productName != null && !productName.isBlank()) {
+            this.productName = productName;
+        }
+        if (productMallName != null && !productMallName.isBlank()) {
+            this.productMallName = productMallName;
+        }
+        if (fetchedAt != null) {
+            this.fetchedAt = fetchedAt;
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/SoozipCategory.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/SoozipCategory.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+@RequiredArgsConstructor
+public enum SoozipCategory {
+    MINI_ELECTRONICS(73, "미니가전"),
+    FURNITURE(75, "가구"),
+    LIGHTING(76, "조명"),
+    LIVING_GOODS(86, "생활용품"),
+    HOME_FABRIC(47, "홈패브릭"),
+    ACCESSORY(52, "소품");
+
+    private final int cateNo;
+    private final String label;
+
+    public static Optional<SoozipCategory> fromCateNo(int cateNo) {
+        return Arrays.stream(values())
+                .filter(category -> category.cateNo == cateNo)
+                .findFirst();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminSoozipRawProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminSoozipRawProductController.java
@@ -1,0 +1,70 @@
+package or.sopt.houme.domain.furniture.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.presentation.dto.response.SoozipRawProductSaveResponse;
+import or.sopt.houme.domain.furniture.service.CurationRawProductService;
+import or.sopt.houme.domain.furniture.service.SoozipCrawlingService;
+import or.sopt.houme.domain.furniture.service.dto.CurationRawProductSaveResult;
+import or.sopt.houme.global.api.ApiResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/curations/soozip")
+@Tag(name = "어드민 큐레이션 원본 API")
+public class AdminSoozipRawProductController {
+
+    private static final String SOURCE_SOOZIP = "soozip";
+
+    private final SoozipCrawlingService soozipCrawlingService;
+    private final CurationRawProductService curationRawProductService;
+
+    @PostMapping("/raw")
+    @Operation(summary = "Soozip 원본 수집 저장 API",
+            description = "Soozip 리스트를 크롤링하여 curation_raw_products에 저장합니다.\n\n" +
+                    "카테고리 번호:\n" +
+                    "- 73: 미니가전\n" +
+                    "- 75: 가구\n" +
+                    "- 76: 조명\n" +
+                    "- 86: 생활용품\n" +
+                    "- 47: 홈패브릭\n" +
+                    "- 52: 소품")
+    public ResponseEntity<ApiResponse<SoozipRawProductSaveResponse>> saveSoozipRawProducts(
+            @Parameter(
+                    description = "Soozip 카테고리 번호 (기본값=75).",
+                    example = "75"
+            )
+            @RequestParam(required = false, defaultValue = "75") Integer cateNo,
+            @Parameter(
+                    description = "Soozip 목록에서 크롤링할 최대 페이지 수. 미지정 시 마지막 페이지까지 순회합니다.",
+                    example = "1"
+            )
+            @RequestParam(required = false) Integer maxPages
+    ) {
+        SoozipCategory category = SoozipCategory.fromCateNo(cateNo)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_VALID_EXCEPTION));
+        List<NaverFurnitureProductDto> products = soozipCrawlingService.fetchCategoryProducts(cateNo, maxPages);
+        CurationRawProductSaveResult result = curationRawProductService.saveAll(SOURCE_SOOZIP, category, products);
+        SoozipRawProductSaveResponse response = SoozipRawProductSaveResponse.of(
+                SOURCE_SOOZIP,
+                category,
+                products.size(),
+                result
+        );
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/SoozipRawProductSaveResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/SoozipRawProductSaveResponse.java
@@ -1,0 +1,29 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.service.dto.CurationRawProductSaveResult;
+
+public record SoozipRawProductSaveResponse(
+        String source,
+        SoozipCategory category,
+        int productCount,
+        int insertedCount,
+        int updatedCount,
+        int skippedCount
+) {
+    public static SoozipRawProductSaveResponse of(
+            String source,
+            SoozipCategory category,
+            int productCount,
+            CurationRawProductSaveResult result
+    ) {
+        return new SoozipRawProductSaveResponse(
+                source,
+                category,
+                productCount,
+                result.insertedCount(),
+                result.updatedCount(),
+                result.skippedCount()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -1,0 +1,17 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationRawProductRepository extends JpaRepository<CurationRawProduct, Long> {
+    List<CurationRawProduct> findAllBySourceAndCategoryAndProductIdIn(
+            String source,
+            SoozipCategory category,
+            List<Long> productIds
+    );
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductService.java
@@ -1,0 +1,112 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.service.dto.CurationRawProductSaveResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CurationRawProductService {
+
+    private final CurationRawProductRepository curationRawProductRepository;
+
+    @Transactional
+    public CurationRawProductSaveResult saveAll(
+            String source,
+            SoozipCategory category,
+            List<NaverFurnitureProductDto> products
+    ) {
+        if (products == null || products.isEmpty()) {
+            return CurationRawProductSaveResult.empty();
+        }
+
+        List<Long> productIds = products.stream()
+                .map(NaverFurnitureProductDto::furnitureProductId)
+                .filter(id -> id != null)
+                .distinct()
+                .toList();
+
+        Map<Long, CurationRawProduct> existingById = new HashMap<>();
+        if (!productIds.isEmpty()) {
+            existingById = curationRawProductRepository.findAllBySourceAndCategoryAndProductIdIn(
+                            source,
+                            category,
+                            productIds
+                    )
+                    .stream()
+                    .collect(Collectors.toMap(CurationRawProduct::getProductId, p -> p));
+        }
+
+        int inserted = 0;
+        int updated = 0;
+        int skipped = 0;
+        LocalDateTime fetchedAt = LocalDateTime.now();
+        List<CurationRawProduct> toSave = new ArrayList<>();
+        Set<Long> seen = new HashSet<>();
+
+        for (NaverFurnitureProductDto dto : products) {
+            Long productId = dto.furnitureProductId();
+            if (productId == null || !seen.add(productId)) {
+                skipped++;
+                continue;
+            }
+
+            if (isBlank(dto.furnitureProductImageUrl())
+                    || isBlank(dto.furnitureProductSiteUrl())
+                    || isBlank(dto.furnitureProductName())) {
+                skipped++;
+                continue;
+            }
+
+            CurationRawProduct entity = existingById.get(productId);
+            if (entity == null) {
+                entity = CurationRawProduct.of(
+                        source,
+                        category,
+                        productId,
+                        dto.furnitureProductImageUrl(),
+                        dto.furnitureProductSiteUrl(),
+                        dto.furnitureProductName(),
+                        dto.furnitureProductMallName(),
+                        fetchedAt
+                );
+                inserted++;
+            } else {
+                entity.updateFrom(
+                        dto.furnitureProductImageUrl(),
+                        dto.furnitureProductSiteUrl(),
+                        dto.furnitureProductName(),
+                        dto.furnitureProductMallName(),
+                        fetchedAt
+                );
+                updated++;
+            }
+
+            toSave.add(entity);
+        }
+
+        if (!toSave.isEmpty()) {
+            curationRawProductRepository.saveAll(toSave);
+        }
+
+        return new CurationRawProductSaveResult(inserted, updated, skipped);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
@@ -42,14 +42,28 @@ public class SoozipCrawlingService {
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
 
+    /**
+     * Soozip 기본 카테고리(cate_no=75) 상품을 모두 가져옵니다.
+     * maxPages 제한이 없으면 마지막 페이지까지 순회합니다.
+     */
     public List<NaverFurnitureProductDto> fetchFurnitureProducts() {
         return fetchCategoryProducts(DEFAULT_CATE_NO, null);
     }
 
+    /**
+     * 기본 카테고리 상품을 페이지 제한과 함께 가져옵니다.
+     * maxPages가 비어있거나 유효하지 않으면 전체 페이지를 순회합니다.
+     */
     public List<NaverFurnitureProductDto> fetchFurnitureProducts(Integer maxPages) {
         return fetchCategoryProducts(DEFAULT_CATE_NO, maxPages);
     }
 
+    /**
+     * 카테고리별 리스트 페이지를 순회하여 중복 없는 상품 목록을 반환합니다.
+     * - 1페이지를 먼저 가져온 뒤 마지막 페이지를 파악합니다.
+     * - productId 기준으로 페이지 간 중복을 제거합니다.
+     * - 특정 페이지 결과가 비어있으면 조기 종료합니다.
+     */
     public List<NaverFurnitureProductDto> fetchCategoryProducts(int cateNo, Integer maxPages) {
         Document first = fetchDocument(cateNo, 1);
         int lastPage = parseLastPage(first);
@@ -74,7 +88,13 @@ public class SoozipCrawlingService {
         return products;
     }
 
+    /**
+     * 리스트 페이지 HTML을 내려받아 Jsoup으로 파싱합니다.
+     * 네트워크 오류나 2xx가 아닌 응답은 예외로 처리합니다.
+     */
     private Document fetchDocument(int cateNo, int page) {
+
+        // 해당 주소로부터 cateNo을 기준으로 카테고리를 파싱합니다.
         String url = BASE_URL + "/product/list.html?cate_no=" + cateNo + "&page=" + page;
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -97,6 +117,10 @@ public class SoozipCrawlingService {
         }
     }
 
+    /**
+     * 페이지네이션에서 마지막 페이지 번호를 추출합니다.
+     * ".last"가 없으면 모든 링크를 훑어 최댓값을 찾습니다.
+     */
     private int parseLastPage(Document doc) {
         Element last = doc.selectFirst(".ec-base-paginate a.last");
         Integer page = parsePageFromHref(last == null ? null : last.attr("href"));
@@ -114,6 +138,9 @@ public class SoozipCrawlingService {
         return maxPage;
     }
 
+    /**
+     * "?cate_no=75&page=3" 형태의 링크에서 page 파라미터를 추출합니다.
+     */
     private Integer parsePageFromHref(String href) {
         if (href == null || href.isBlank()) {
             return null;
@@ -125,6 +152,13 @@ public class SoozipCrawlingService {
         return null;
     }
 
+    /**
+     * Cafe24 리스트 DOM 구조를 기준으로 상품 DTO를 생성합니다.
+     * - 목록: ul.prdList > li
+     * - 이미지: .prdImg img (첫 번째 이미지)
+     * - 링크: .prdImg a 또는 .description .name a
+     * - 이름: .description .name a 내부 span 중 마지막 텍스트
+     */
     private List<NaverFurnitureProductDto> parseProducts(Document doc) {
         List<NaverFurnitureProductDto> products = new ArrayList<>();
         Elements items = doc.select("ul.prdList > li");
@@ -159,6 +193,10 @@ public class SoozipCrawlingService {
         return products;
     }
 
+    /**
+     * 제목 앵커에서 상품명을 추출합니다.
+     * 마지막 span 텍스트를 우선 사용하고, 없으면 앵커 텍스트를 사용합니다.
+     */
     private String extractProductName(Element item) {
         Element nameAnchor = item.selectFirst(".description .name a");
         if (nameAnchor == null) {
@@ -181,6 +219,9 @@ public class SoozipCrawlingService {
         return text.isBlank() ? null : text;
     }
 
+    /**
+     * 상품 상세 URL을 추출하고 상대경로를 정규화합니다.
+     */
     private String extractProductUrl(Element item) {
         Element link = item.selectFirst(".prdImg a");
         if (link == null) {
@@ -198,6 +239,9 @@ public class SoozipCrawlingService {
         return normalizeUrl(url);
     }
 
+    /**
+     * 상품 이미지 URL을 추출하고 프로토콜 없는 URL을 정규화합니다.
+     */
     private String extractImageUrl(Element item) {
         Element img = item.selectFirst(".prdImg img");
         if (img == null) {
@@ -212,6 +256,12 @@ public class SoozipCrawlingService {
         return normalizeUrl(url);
     }
 
+    /**
+     * URL을 정규화합니다.
+     * - "//..." -> "https://..."
+     * - "/..."  -> BASE_URL + "/..."
+     * - "path"  -> BASE_URL + "/path"
+     */
     private String normalizeUrl(String url) {
         if (url == null || url.isBlank()) {
             return null;
@@ -228,6 +278,12 @@ public class SoozipCrawlingService {
         return url;
     }
 
+    /**
+     * productId를 우선순위대로 추출합니다.
+     * 1) product_no 쿼리 파라미터
+     * 2) "/product/.../{id}/" 경로 세그먼트
+     * 3) "li#anchorBoxId_{id}" 폴백
+     */
     private Long extractProductId(Element item, String productUrl) {
         Long productId = parseProductIdFromHref(productUrl);
         if (productId != null) {
@@ -250,6 +306,9 @@ public class SoozipCrawlingService {
         return null;
     }
 
+    /**
+     * Cafe24 URL 패턴에서 productId를 파싱합니다.
+     */
     private Long parseProductIdFromHref(String href) {
         if (href == null || href.isBlank()) {
             return null;
@@ -268,6 +327,9 @@ public class SoozipCrawlingService {
         return null;
     }
 
+    /**
+     * 페이지 번호 파싱 유틸입니다.
+     */
     private Integer parseIntSafely(String value) {
         try {
             return Integer.parseInt(value);
@@ -276,6 +338,9 @@ public class SoozipCrawlingService {
         }
     }
 
+    /**
+     * productId 파싱 유틸입니다.
+     */
     private Long parseLongSafely(String value) {
         try {
             return Long.parseLong(value);
@@ -284,6 +349,9 @@ public class SoozipCrawlingService {
         }
     }
 
+    /**
+     * productId 기준 중복 제거 후 목록에 추가합니다.
+     */
     private void addProducts(List<NaverFurnitureProductDto> source,
                              List<NaverFurnitureProductDto> target,
                              Set<Long> seen) {
@@ -297,6 +365,9 @@ public class SoozipCrawlingService {
         }
     }
 
+    /**
+     * 페이지 요청 간 간단한 지연을 둡니다.
+     */
     private void sleep(long millis) {
         try {
             Thread.sleep(millis);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
@@ -4,6 +4,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
 import or.sopt.houme.global.util.HtmlTextCleaner;
@@ -25,7 +26,6 @@ import java.util.regex.Pattern;
 @Service
 public class SoozipCrawlingService {
 
-    private static final String BASE_URL = "https://soozip.co.kr";
     private static final int DEFAULT_CATE_NO = 75;
     private static final long PAGE_DELAY_MILLIS = 250L;
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
@@ -36,6 +36,9 @@ public class SoozipCrawlingService {
     private static final Pattern PAGE_PARAM = Pattern.compile("[?&]page=(\\d+)");
     private static final Pattern PRODUCT_NO_PARAM = Pattern.compile("[?&]product_no=(\\d+)");
     private static final Pattern PRODUCT_PATH = Pattern.compile("/product/[^/]+/(\\d+)/");
+
+    @Value("${soozip.base-url}")
+    private String baseUrl;
 
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(CONNECT_TIMEOUT)
@@ -95,7 +98,7 @@ public class SoozipCrawlingService {
     private Document fetchDocument(int cateNo, int page) {
 
         // 해당 주소로부터 cateNo을 기준으로 카테고리를 파싱합니다.
-        String url = BASE_URL + "/product/list.html?cate_no=" + cateNo + "&page=" + page;
+        String url = baseUrl() + "/product/list.html?cate_no=" + cateNo + "&page=" + page;
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(REQUEST_TIMEOUT)
@@ -108,7 +111,7 @@ public class SoozipCrawlingService {
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
                 throw new IOException("Unexpected status: " + response.statusCode());
             }
-            return Jsoup.parse(response.body(), BASE_URL);
+            return Jsoup.parse(response.body(), baseUrl());
         } catch (IOException e) {
             throw new IllegalStateException("Failed to fetch Soozip list page: " + url, e);
         } catch (InterruptedException e) {
@@ -259,8 +262,8 @@ public class SoozipCrawlingService {
     /**
      * URL을 정규화합니다.
      * - "//..." -> "https://..."
-     * - "/..."  -> BASE_URL + "/..."
-     * - "path"  -> BASE_URL + "/path"
+     * - "/..."  -> baseUrl + "/..."
+     * - "path"  -> baseUrl + "/path"
      */
     private String normalizeUrl(String url) {
         if (url == null || url.isBlank()) {
@@ -270,10 +273,10 @@ public class SoozipCrawlingService {
             return "https:" + url;
         }
         if (url.startsWith("/")) {
-            return BASE_URL + url;
+            return baseUrl() + url;
         }
         if (!url.startsWith("http")) {
-            return BASE_URL + "/" + url;
+            return baseUrl() + "/" + url;
         }
         return url;
     }
@@ -363,6 +366,13 @@ public class SoozipCrawlingService {
             seen.add(id);
             target.add(product);
         }
+    }
+
+    private String baseUrl() {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalStateException("SOOZIP_BASE_URL 환경변수가 필요합니다.");
+        }
+        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     }
 
     /**

--- a/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/SoozipCrawlingService.java
@@ -1,0 +1,307 @@
+package or.sopt.houme.domain.furniture.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
+import or.sopt.houme.global.util.HtmlTextCleaner;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class SoozipCrawlingService {
+
+    private static final String BASE_URL = "https://soozip.co.kr";
+    private static final int DEFAULT_CATE_NO = 75;
+    private static final long PAGE_DELAY_MILLIS = 250L;
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final String USER_AGENT = "Houme-SoozipCrawler/1.0";
+    private static final String MALL_NAME = "SOOZIP";
+
+    private static final Pattern PAGE_PARAM = Pattern.compile("[?&]page=(\\d+)");
+    private static final Pattern PRODUCT_NO_PARAM = Pattern.compile("[?&]product_no=(\\d+)");
+    private static final Pattern PRODUCT_PATH = Pattern.compile("/product/[^/]+/(\\d+)/");
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    public List<NaverFurnitureProductDto> fetchFurnitureProducts() {
+        return fetchCategoryProducts(DEFAULT_CATE_NO, null);
+    }
+
+    public List<NaverFurnitureProductDto> fetchFurnitureProducts(Integer maxPages) {
+        return fetchCategoryProducts(DEFAULT_CATE_NO, maxPages);
+    }
+
+    public List<NaverFurnitureProductDto> fetchCategoryProducts(int cateNo, Integer maxPages) {
+        Document first = fetchDocument(cateNo, 1);
+        int lastPage = parseLastPage(first);
+        if (maxPages != null && maxPages > 0) {
+            lastPage = Math.min(lastPage, maxPages);
+        }
+
+        List<NaverFurnitureProductDto> products = new ArrayList<>();
+        Set<Long> seen = new HashSet<>();
+        addProducts(parseProducts(first), products, seen);
+
+        for (int page = 2; page <= lastPage; page++) {
+            sleep(PAGE_DELAY_MILLIS);
+            Document doc = fetchDocument(cateNo, page);
+            List<NaverFurnitureProductDto> pageProducts = parseProducts(doc);
+            if (pageProducts.isEmpty()) {
+                break;
+            }
+            addProducts(pageProducts, products, seen);
+        }
+
+        return products;
+    }
+
+    private Document fetchDocument(int cateNo, int page) {
+        String url = BASE_URL + "/product/list.html?cate_no=" + cateNo + "&page=" + page;
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(REQUEST_TIMEOUT)
+                .GET()
+                .header("User-Agent", USER_AGENT)
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IOException("Unexpected status: " + response.statusCode());
+            }
+            return Jsoup.parse(response.body(), BASE_URL);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to fetch Soozip list page: " + url, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Failed to fetch Soozip list page: " + url, e);
+        }
+    }
+
+    private int parseLastPage(Document doc) {
+        Element last = doc.selectFirst(".ec-base-paginate a.last");
+        Integer page = parsePageFromHref(last == null ? null : last.attr("href"));
+        if (page != null && page > 0) {
+            return page;
+        }
+
+        int maxPage = 1;
+        for (Element link : doc.select(".ec-base-paginate a[href*='page=']")) {
+            Integer p = parsePageFromHref(link.attr("href"));
+            if (p != null && p > maxPage) {
+                maxPage = p;
+            }
+        }
+        return maxPage;
+    }
+
+    private Integer parsePageFromHref(String href) {
+        if (href == null || href.isBlank()) {
+            return null;
+        }
+        Matcher matcher = PAGE_PARAM.matcher(href);
+        if (matcher.find()) {
+            return parseIntSafely(matcher.group(1));
+        }
+        return null;
+    }
+
+    private List<NaverFurnitureProductDto> parseProducts(Document doc) {
+        List<NaverFurnitureProductDto> products = new ArrayList<>();
+        Elements items = doc.select("ul.prdList > li");
+        for (Element item : items) {
+            String productUrl = extractProductUrl(item);
+            String imageUrl = extractImageUrl(item);
+            Long productId = extractProductId(item, productUrl);
+            String name = extractProductName(item);
+
+            if (name == null || name.isBlank()) {
+                Element img = item.selectFirst(".prdImg img");
+                if (img != null) {
+                    name = img.attr("alt");
+                }
+            }
+
+            if (productId == null || name == null || name.isBlank()
+                    || productUrl == null || productUrl.isBlank()
+                    || imageUrl == null || imageUrl.isBlank()) {
+                continue;
+            }
+
+            products.add(new NaverFurnitureProductDto(
+                    imageUrl,
+                    productUrl,
+                    HtmlTextCleaner.clean(name),
+                    MALL_NAME,
+                    productId
+            ));
+        }
+
+        return products;
+    }
+
+    private String extractProductName(Element item) {
+        Element nameAnchor = item.selectFirst(".description .name a");
+        if (nameAnchor == null) {
+            return null;
+        }
+
+        Elements spans = nameAnchor.select("span");
+        for (int i = spans.size() - 1; i >= 0; i--) {
+            String text = spans.get(i).text().trim();
+            if (!text.isEmpty()) {
+                return text;
+            }
+        }
+
+        String text = nameAnchor.ownText().trim();
+        if (text.isBlank()) {
+            text = nameAnchor.text().trim();
+        }
+
+        return text.isBlank() ? null : text;
+    }
+
+    private String extractProductUrl(Element item) {
+        Element link = item.selectFirst(".prdImg a");
+        if (link == null) {
+            link = item.selectFirst(".description .name a");
+        }
+        if (link == null) {
+            return null;
+        }
+
+        String url = link.absUrl("href");
+        if (url == null || url.isBlank()) {
+            url = link.attr("href");
+        }
+
+        return normalizeUrl(url);
+    }
+
+    private String extractImageUrl(Element item) {
+        Element img = item.selectFirst(".prdImg img");
+        if (img == null) {
+            return null;
+        }
+
+        String url = img.absUrl("src");
+        if (url == null || url.isBlank()) {
+            url = img.attr("src");
+        }
+
+        return normalizeUrl(url);
+    }
+
+    private String normalizeUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        if (url.startsWith("//")) {
+            return "https:" + url;
+        }
+        if (url.startsWith("/")) {
+            return BASE_URL + url;
+        }
+        if (!url.startsWith("http")) {
+            return BASE_URL + "/" + url;
+        }
+        return url;
+    }
+
+    private Long extractProductId(Element item, String productUrl) {
+        Long productId = parseProductIdFromHref(productUrl);
+        if (productId != null) {
+            return productId;
+        }
+
+        Element link = item.selectFirst(".prdImg a, .description .name a");
+        if (link != null) {
+            productId = parseProductIdFromHref(link.attr("href"));
+            if (productId != null) {
+                return productId;
+            }
+        }
+
+        String itemId = item.id();
+        if (itemId != null && itemId.startsWith("anchorBoxId_")) {
+            return parseLongSafely(itemId.substring("anchorBoxId_".length()));
+        }
+
+        return null;
+    }
+
+    private Long parseProductIdFromHref(String href) {
+        if (href == null || href.isBlank()) {
+            return null;
+        }
+
+        Matcher queryMatcher = PRODUCT_NO_PARAM.matcher(href);
+        if (queryMatcher.find()) {
+            return parseLongSafely(queryMatcher.group(1));
+        }
+
+        Matcher pathMatcher = PRODUCT_PATH.matcher(href);
+        if (pathMatcher.find()) {
+            return parseLongSafely(pathMatcher.group(1));
+        }
+
+        return null;
+    }
+
+    private Integer parseIntSafely(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Long parseLongSafely(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void addProducts(List<NaverFurnitureProductDto> source,
+                             List<NaverFurnitureProductDto> target,
+                             Set<Long> seen) {
+        for (NaverFurnitureProductDto product : source) {
+            Long id = product.furnitureProductId();
+            if (id == null || seen.contains(id)) {
+                continue;
+            }
+            seen.add(id);
+            target.add(product);
+        }
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/dto/CurationRawProductSaveResult.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/dto/CurationRawProductSaveResult.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.domain.furniture.service.dto;
+
+public record CurationRawProductSaveResult(
+        int insertedCount,
+        int updatedCount,
+        int skippedCount
+) {
+    public static CurationRawProductSaveResult empty() {
+        return new CurationRawProductSaveResult(0, 0, 0);
+    }
+
+    public int totalSaved() {
+        return insertedCount + updatedCount;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -82,6 +82,7 @@ soozip:
 discord:
   webhook-url: ${DISCORD_WEBHOOK}
 
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -76,6 +76,9 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   allowed-malls: ${NAVER_ALLOWED_MALLS}  # 쉼표 구분 (예: 롯데ON,쿠팡,11번가)
 
+soozip:
+  base-url: ${SOOZIP_BASE_URL}
+
 discord:
   webhook-url: ${DISCORD_WEBHOOK}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -82,7 +82,6 @@ soozip:
 discord:
   webhook-url: ${DISCORD_WEBHOOK}
 
-
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #408 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

jsoup을 이용하여 수집의 데이터를 크롤링하는 로직을 구현하였습니다. 자세한 내용은 [링크](https://github.com/TEAM-HOUME/HOUME-SERVER/discussions/409)에 있습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
네이버 api에서 가구를 가져오는 것과 동일하게, 이제는 수집 몰의 가구 데이터에서도 가구를 가져올 수 있도록 준비합니다.
하지만 이 과정에서 기존에 FurnitureTag와 매핑되던 네이버 api의 제품들처럼 수집몰의 데이터와도 연결할 수 있는 방법이 필요합니다.

이는 익일 진행될 회의해서 결정합니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Soozip 가구 제품 자동 수집 기능 추가 - 카테고리별로 상품 정보를 크롤링하여 데이터베이스에 저장 가능
  * 관리자 API 엔드포인트 추가 - `/api/v1/admin/curations/soozip/raw` 에서 제품 데이터 수집 및 저장 트리거 가능
  * 6개 가구 카테고리 지원 (가전, 가구, 조명, 생활용품, 홈패브릭, 소품)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->