### PR TITLE
[FEATURE] 네이버 API 의존성 삭제 및 큐레이션 개수 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -29,6 +29,7 @@ import or.sopt.houme.global.config.NaverProperties;
 public class FurnitureFacadeImpl implements FurnitureFacade {
 
     private static final int CURATION_LIMIT = 5;
+    private static final int RAW_CURATION_LIMIT = 4;
 
     private final NaverShopService naverShopService;
     private final ImageHashService imageHashService;
@@ -89,7 +90,7 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
             // 2-2. 그 후에 동일한 hash 기반 이미지 유사도를 판별하여 반환합니다
             if (!rawCandidates.isEmpty()) {
                 List<FurnitureProductsInfoResponse.FurnitureProductInfo> rankedRawInfos =
-                        imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), rawCandidates, CURATION_LIMIT);
+                        imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), rawCandidates, RAW_CURATION_LIMIT);
                 rawInfos = curationFurnitureService.saveCurationResults(
                         furnitureTag,
                         rankedRawInfos,

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -106,10 +106,8 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         }
 
         log.info("큐레이션 종료:{}",formatted);
-        return FurnitureProductsInfoResponse.of(
-                user.getName(),
-                java.util.stream.Stream.concat(naverInfos.stream(), rawInfos.stream()).toList()
-        );
+        // 네이버 큐레이션 비활성화로 RAW 결과만 반환합니다.
+        return FurnitureProductsInfoResponse.of(user.getName(), rawInfos);
     }
 
     // 기획의사결정용

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -49,29 +49,31 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         log.info("연관된 가구들을 조회합니다:{}",formatted);
         FurnitureTag furnitureTag = furnitureService.findFurnitureTag(user, imageId, categoryId);
 
-        List<FurnitureProductsInfoResponse.FurnitureProductInfo> naverInfos =
-                curationFurnitureService.getCurationProducts(furnitureTag, CurationSource.NAVER);
-        if (naverInfos.isEmpty()) {
-            log.info("네이버 API 호출을 시작합니다");
-            String keyword = furnitureTag.getSearchKeyword();
-            List<NaverFurnitureProductDto> products = naverShopService.search(keyword, 50);
-
-            // 2. FastAPI 호출 → 유사도 기반 상위 상품 리스트만 반환
-            // 12/05 FAST API 삭제
-            log.info("유사도 기반 네이버 상품 조회를 시작합니다");
-            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rankedInfos =
-                    imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), products, CURATION_LIMIT);
-
-            // 2-1. 최종반환된 리스트를 기반으로 추천가구 엔티티 저장하고, 큐레이션 결과 저장
-            log.info("네이버 큐레이션 결과 저장");
-            naverInfos = curationFurnitureService.saveCurationResults(
-                    furnitureTag,
-                    rankedInfos,
-                    CurationSource.NAVER
-            );
-        } else {
-            log.info("네이버 큐레이션 결과를 DB에서 조회합니다");
-        }
+        // 네이버 큐레이션은 현재 비활성화합니다.
+        // 기존 로직은 추후 복구를 위해 주석으로 유지합니다.
+//        List<FurnitureProductsInfoResponse.FurnitureProductInfo> naverInfos =
+//                curationFurnitureService.getCurationProducts(furnitureTag, CurationSource.NAVER);
+//        if (naverInfos.isEmpty()) {
+//            log.info("네이버 API 호출을 시작합니다");
+//            String keyword = furnitureTag.getSearchKeyword();
+//            List<NaverFurnitureProductDto> products = naverShopService.search(keyword, 50);
+//
+//            // 2. FastAPI 호출 → 유사도 기반 상위 상품 리스트만 반환
+//            // 12/05 FAST API 삭제
+//            log.info("유사도 기반 네이버 상품 조회를 시작합니다");
+//            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rankedInfos =
+//                    imageHashService.rankByImageSimilarity(furnitureTag.getFurnitureUrl(), products, CURATION_LIMIT);
+//
+//            // 2-1. 최종반환된 리스트를 기반으로 추천가구 엔티티 저장하고, 큐레이션 결과 저장
+//            log.info("네이버 큐레이션 결과 저장");
+//            naverInfos = curationFurnitureService.saveCurationResults(
+//                    furnitureTag,
+//                    rankedInfos,
+//                    CurationSource.NAVER
+//            );
+//        } else {
+//            log.info("네이버 큐레이션 결과를 DB에서 조회합니다");
+//        }
 
 
         // 기본적인 로직은 naver 로직과 동일합니다


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #421 
- close #418 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

큐레이션 로직에서 네이버 API를 제거하였습니다.
이제 모든 데이터는 프리셋을 통해서 전달됩니다.

또한 큐레이션 데이터를 다섯개에서 네개로 수정하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 로직 삭제를 최소화하고 주석으로 처리하였습니다.
- color 데이터 기획파트에서 넘겨주시는대로 기입하도록 하겠습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 가구 추천 결과 랭킹 기준을 조정했습니다.
  * 추천 알고리즘을 단순화하여 더 일관된 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->