### PR TITLE
[FEATURE] 큐레이션 새벽 갱신 배치 비활성화

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/infrastructure/scheduler/CurationFurnitureScheduler.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/infrastructure/scheduler/CurationFurnitureScheduler.java
@@ -12,7 +12,6 @@ import or.sopt.houme.domain.furniture.service.CurationRawProductService;
 import or.sopt.houme.domain.furniture.service.ImageHashService;
 import or.sopt.houme.domain.furniture.service.NaverShopService;
 import or.sopt.houme.global.discord.DiscordWebhookService;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -37,73 +36,82 @@ public class CurationFurnitureScheduler {
     private final CurationRawProductService curationRawProductService;
     private final DiscordWebhookService discordWebhookService;
 
-    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
+    // CSV 기반 수동 적재 방식으로 전환되어 새벽 2시 자동 갱신 배치를 비활성화합니다.
+    // @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
     public void refreshCurationResults() {
-        Instant startedAt = Instant.now();
-        int totalTags = 0;
-        int successTags = 0;
-        int emptyTags = 0;
-        String status = "성공";
-        Exception failure = null;
+        log.info("큐레이션 새벽 배치가 비활성화되었습니다. (CSV 기반 수동 적재)");
 
-        try {
-            List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
-            totalTags = furnitureTags.size();
-            if (furnitureTags.isEmpty()) {
-                status = "대상없음";
-                log.info("큐레이션 배치: 대상 태그 없음");
-                return;
-            }
-
-            for (int i = 0; i < furnitureTags.size(); i++) {
-                if (i > 0) {
-                    sleep(NAVER_RATE_LIMIT_MILLIS);
-                }
-
-                FurnitureTag furnitureTag = furnitureTags.get(i);
-                boolean hasResult = false;
-
-                List<FurnitureProductsInfoResponse.FurnitureProductInfo> naverInfos = fetchNaverCurationWithRetry(furnitureTag);
-                if (!naverInfos.isEmpty()) {
-                    curationFurnitureService.saveCurationResults(furnitureTag, naverInfos, CurationSource.NAVER);
-                    hasResult = true;
-                }
-
-                List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos = fetchRawCurationWithRetry(furnitureTag);
-                if (!rawInfos.isEmpty()) {
-                    curationFurnitureService.saveCurationResults(furnitureTag, rawInfos, CurationSource.RAW);
-                    hasResult = true;
-                }
-
-                if (hasResult) {
-                    successTags++;
-                    continue;
-                }
-
-                emptyTags++;
-                log.warn("큐레이션 배치: NAVER/RAW 모두 결과 없음 tagId={}", furnitureTag.getId());
-            }
-        } catch (Exception e) {
-            status = "실패";
-            failure = e;
-            throw e;
-        } finally {
-            StringBuilder message = new StringBuilder();
-            long elapsedSeconds = Duration.between(startedAt, Instant.now()).toSeconds();
-            message.append("[큐레이션 배치] 상태=").append(status)
-                    .append(" 대상=").append(totalTags)
-                    .append(" 성공=").append(successTags)
-                    .append(" 결과없음=").append(emptyTags)
-                    .append(" 소요=").append(elapsedSeconds).append("s");
-            if (failure != null) {
-                message.append(" 에러=").append(failure.getClass().getSimpleName());
-                String errorMessage = failure.getMessage();
-                if (errorMessage != null && !errorMessage.isBlank()) {
-                    message.append(" (").append(errorMessage).append(")");
-                }
-            }
-            discordWebhookService.sendMessage(message.toString());
-        }
+        /*
+         * [기존 로직 보존]
+         * CSV 기반 큐레이션 데이터 수급 전에는 매일 새벽 2시에 아래 배치로
+         * NAVER/RAW 큐레이션 TOP_N 결과를 갱신했습니다.
+         *
+         * Instant startedAt = Instant.now();
+         * int totalTags = 0;
+         * int successTags = 0;
+         * int emptyTags = 0;
+         * String status = "성공";
+         * Exception failure = null;
+         *
+         * try {
+         *     List<FurnitureTag> furnitureTags = furnitureTagRepository.findAll();
+         *     totalTags = furnitureTags.size();
+         *     if (furnitureTags.isEmpty()) {
+         *         status = "대상없음";
+         *         log.info("큐레이션 배치: 대상 태그 없음");
+         *         return;
+         *     }
+         *
+         *     for (int i = 0; i < furnitureTags.size(); i++) {
+         *         if (i > 0) {
+         *             sleep(NAVER_RATE_LIMIT_MILLIS);
+         *         }
+         *
+         *         FurnitureTag furnitureTag = furnitureTags.get(i);
+         *         boolean hasResult = false;
+         *
+         *         List<FurnitureProductsInfoResponse.FurnitureProductInfo> naverInfos = fetchNaverCurationWithRetry(furnitureTag);
+         *         if (!naverInfos.isEmpty()) {
+         *             curationFurnitureService.saveCurationResults(furnitureTag, naverInfos, CurationSource.NAVER);
+         *             hasResult = true;
+         *         }
+         *
+         *         List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos = fetchRawCurationWithRetry(furnitureTag);
+         *         if (!rawInfos.isEmpty()) {
+         *             curationFurnitureService.saveCurationResults(furnitureTag, rawInfos, CurationSource.RAW);
+         *             hasResult = true;
+         *         }
+         *
+         *         if (hasResult) {
+         *             successTags++;
+         *             continue;
+         *         }
+         *
+         *         emptyTags++;
+         *         log.warn("큐레이션 배치: NAVER/RAW 모두 결과 없음 tagId={}", furnitureTag.getId());
+         *     }
+         * } catch (Exception e) {
+         *     status = "실패";
+         *     failure = e;
+         *     throw e;
+         * } finally {
+         *     StringBuilder message = new StringBuilder();
+         *     long elapsedSeconds = Duration.between(startedAt, Instant.now()).toSeconds();
+         *     message.append("[큐레이션 배치] 상태=").append(status)
+         *             .append(" 대상=").append(totalTags)
+         *             .append(" 성공=").append(successTags)
+         *             .append(" 결과없음=").append(emptyTags)
+         *             .append(" 소요=").append(elapsedSeconds).append("s");
+         *     if (failure != null) {
+         *         message.append(" 에러=").append(failure.getClass().getSimpleName());
+         *         String errorMessage = failure.getMessage();
+         *         if (errorMessage != null && !errorMessage.isBlank()) {
+         *             message.append(" (").append(errorMessage).append(")");
+         *         }
+         *     }
+         *     discordWebhookService.sendMessage(message.toString());
+         * }
+         */
     }
 
     private List<FurnitureProductsInfoResponse.FurnitureProductInfo> fetchNaverCurationWithRetry(FurnitureTag furnitureTag) {


### PR DESCRIPTION
## 📣 Related Issue

- close #411

## 📝 Summary

- `CurationFurnitureScheduler`의 새벽 2시 자동 갱신 트리거(`@Scheduled`)를 주석 처리해 배치 실행을 비활성화했습니다.
- 기존 TOP5 큐레이션 갱신 로직은 삭제하지 않고 메서드 내부 주석 블록으로 보존했습니다.
- CSV 기반 수동 적재 방식으로 전환되었음을 로그/주석으로 명시했습니다.

## 🙏 Question & PR point

- 향후 배치 재활성화가 필요할 경우, 주석 처리된 `@Scheduled`와 기존 본문을 복구하면 됩니다.
- 현재는 자동 갱신이 완전히 멈추므로, 큐레이션 데이터는 CSV 적재 플로우를 기준으로만 갱신됩니다.
- 컴파일 검증: `./gradlew compileJava`

## 📬 Postman

- N/A (스케줄러 비활성화 작업)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 큐레이션 배치 작업을 비활성화했습니다. 자동으로 실행되던 일정 작업이 더 이상 수행되지 않으며, 향후 필요 시 재활성화될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->