### PR TITLE
[FEATURE] curation_raw_product ADMIN CRUD API 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - 정상 응답은 `ApiResponse.ok(...)`를 사용하고, 기본 메시지 `응답 성공`을 유지합니다.
 - 에러는 `ErrorCode` 기반으로 관리합니다.
 - 예외는 `GeneralException` 또는 도메인별 예외(`UserException`, `GenerateImageException` 등)로 감싸서 던집니다.
+- `IllegalArgumentException`을 서비스/엔티티에서 직접 던지지 않습니다. 입력/도메인 검증 실패는 반드시 도메인 예외(`UserException`, `FurnitureException`, `ValidException` 등) + `ErrorCode`로 변환합니다.
 - 전역 예외 처리는 `GlobalExceptionHandler`를 통해 일관되게 반환합니다.
 - 필터(JWT) 레벨 예외는 컨트롤러 예외 처리기가 잡지 못하므로 필터 내부 응답 형식을 준수합니다.
 

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -21,7 +21,9 @@ import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -44,6 +46,7 @@ import java.util.Set;
 )
 @Comment("큐레이션 원본 수집 데이터를 저장하는 엔티티입니다")
 public class CurationRawProduct {
+    private static final Pattern SOURCE_PATTERN = Pattern.compile("^[a-z0-9][a-z0-9_-]{0,49}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -123,7 +126,7 @@ public class CurationRawProduct {
             LocalDateTime fetchedAt
     ) {
         return CurationRawProduct.builder()
-                .source(source)
+                .source(normalizeSource(source))
                 .category(category)
                 .productId(productId)
                 .productImageUrl(productImageUrl)
@@ -203,7 +206,7 @@ public class CurationRawProduct {
             LocalDateTime fetchedAt
     ) {
         if (source != null && !source.isBlank()) {
-            this.source = source;
+            this.source = normalizeSource(source);
         }
         if (category != null) {
             this.category = category;
@@ -234,5 +237,17 @@ public class CurationRawProduct {
 
     public void clearFurnitureTags() {
         furnitureTagMappings.clear();
+    }
+
+    private static String normalizeSource(String source) {
+        if (source == null || source.isBlank()) {
+            throw new IllegalArgumentException("source must not be blank");
+        }
+
+        String canonical = source.trim().toLowerCase(Locale.ROOT);
+        if (!SOURCE_PATTERN.matcher(canonical).matches()) {
+            throw new IllegalArgumentException("source format is invalid");
+        }
+        return canonical;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -186,6 +186,35 @@ public class CurationRawProduct {
         }
     }
 
+    public void updateAdminFields(
+            String source,
+            SoozipCategory category,
+            Long productId,
+            String productImageUrl,
+            String productSiteUrl,
+            String productName,
+            String productMallName,
+            String brand,
+            Long listPrice,
+            Integer discountRate,
+            Long discountPrice,
+            Long baseShippingFee,
+            Long freeShippingCondition,
+            LocalDateTime fetchedAt
+    ) {
+        if (source != null && !source.isBlank()) {
+            this.source = source;
+        }
+        if (category != null) {
+            this.category = category;
+        }
+        if (productId != null) {
+            this.productId = productId;
+        }
+        updateFrom(productImageUrl, productSiteUrl, productName, productMallName, fetchedAt);
+        updateMeta(brand, listPrice, discountRate, discountPrice, baseShippingFee, freeShippingCondition);
+    }
+
     public boolean addFurnitureTag(FurnitureTag furnitureTag) {
         if (furnitureTag == null) {
             return false;

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -17,6 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.FurnitureException;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
@@ -241,12 +243,12 @@ public class CurationRawProduct {
 
     private static String normalizeSource(String source) {
         if (source == null || source.isBlank()) {
-            throw new IllegalArgumentException("source must not be blank");
+            throw new FurnitureException(ErrorCode.NOT_VALID_EXCEPTION);
         }
 
         String canonical = source.trim().toLowerCase(Locale.ROOT);
         if (!SOURCE_PATTERN.matcher(canonical).matches()) {
-            throw new IllegalArgumentException("source format is invalid");
+            throw new FurnitureException(ErrorCode.NOT_VALID_EXCEPTION);
         }
         return canonical;
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
@@ -1,0 +1,70 @@
+package or.sopt.houme.domain.furniture.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
+import or.sopt.houme.domain.furniture.service.admin.AdminCurationRawProductService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/curation-raw-products")
+@Tag(name = "어드민 큐레이션 원본 상품 API")
+public class AdminCurationRawProductController {
+
+    private final AdminCurationRawProductService adminCurationRawProductService;
+
+    @GetMapping
+    @Operation(summary = "curation_raw_product 전체 조회 API")
+    public ResponseEntity<ApiResponse<AdminCurationRawProductListResponse>> getRawProducts() {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getAll()));
+    }
+
+    @GetMapping("/{curationRawProductId}")
+    @Operation(summary = "curation_raw_product 개별 제품 상세조회 API")
+    public ResponseEntity<ApiResponse<AdminCurationRawProductResponse>> getRawProduct(
+            @PathVariable Long curationRawProductId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getById(curationRawProductId)));
+    }
+
+    @PostMapping
+    @Operation(summary = "curation_raw_product 가구 추가 API")
+    public ResponseEntity<ApiResponse<AdminCurationRawProductResponse>> createRawProduct(
+            @Valid @RequestBody AdminCurationRawProductCreateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.create(request)));
+    }
+
+    @PatchMapping("/{curationRawProductId}")
+    @Operation(summary = "curation_raw_product 가구 수정 API")
+    public ResponseEntity<ApiResponse<AdminCurationRawProductResponse>> updateRawProduct(
+            @PathVariable Long curationRawProductId,
+            @RequestBody AdminCurationRawProductUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.update(curationRawProductId, request)));
+    }
+
+    @DeleteMapping("/{curationRawProductId}")
+    @Operation(summary = "curation_raw_product 가구 삭제 API")
+    public ResponseEntity<ApiResponse<String>> deleteRawProduct(
+            @PathVariable Long curationRawProductId
+    ) {
+        adminCurationRawProductService.delete(curationRawProductId);
+        return ResponseEntity.ok(ApiResponse.ok("큐레이션 원본 상품이 삭제되었습니다."));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,8 +31,11 @@ public class AdminCurationRawProductController {
 
     @GetMapping
     @Operation(summary = "curation_raw_product 전체 조회 API")
-    public ResponseEntity<ApiResponse<AdminCurationRawProductListResponse>> getRawProducts() {
-        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getAll()));
+    public ResponseEntity<ApiResponse<AdminCurationRawProductListResponse>> getRawProducts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getAll(page, size)));
     }
 
     @GetMapping("/{curationRawProductId}")
@@ -54,7 +58,7 @@ public class AdminCurationRawProductController {
     @Operation(summary = "curation_raw_product 가구 수정 API")
     public ResponseEntity<ApiResponse<AdminCurationRawProductResponse>> updateRawProduct(
             @PathVariable Long curationRawProductId,
-            @RequestBody AdminCurationRawProductUpdateRequest request
+            @Valid @RequestBody AdminCurationRawProductUpdateRequest request
     ) {
         return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.update(curationRawProductId, request)));
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.furniture.presentation.controller;
 
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -33,9 +34,14 @@ public class AdminCurationRawProductController {
     @Operation(summary = "curation_raw_product 전체 조회 API")
     public ResponseEntity<ApiResponse<AdminCurationRawProductListResponse>> getRawProducts(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) SoozipCategory category,
+            @RequestParam(required = false) Long minListPrice,
+            @RequestParam(required = false) Long maxListPrice
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getAll(page, size)));
+        return ResponseEntity.ok(ApiResponse.ok(
+                adminCurationRawProductService.getAll(page, size, category, minListPrice, maxListPrice)
+        ));
     }
 
     @GetMapping("/{curationRawProductId}")

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 
 public record AdminCurationRawProductCreateRequest(
         @NotBlank(message = "source는 필수 입력값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$", message = "source 형식이 올바르지 않습니다.")
         String source,
 
         @NotNull(message = "category는 필수 입력값입니다.")

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
@@ -1,7 +1,11 @@
 package or.sopt.houme.domain.furniture.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 
 import java.time.LocalDateTime;
@@ -13,6 +17,7 @@ public record AdminCurationRawProductCreateRequest(
         @NotNull(message = "category는 필수 입력값입니다.")
         SoozipCategory category,
 
+        @Positive(message = "productId는 1 이상이어야 합니다.")
         @NotNull(message = "productId는 필수 입력값입니다.")
         Long productId,
 
@@ -27,10 +32,20 @@ public record AdminCurationRawProductCreateRequest(
 
         String productMallName,
         String brand,
+        @PositiveOrZero(message = "listPrice는 0 이상이어야 합니다.")
         Long listPrice,
+
+        @Min(value = 0, message = "discountRate는 0 이상이어야 합니다.")
+        @Max(value = 100, message = "discountRate는 100 이하여야 합니다.")
         Integer discountRate,
+
+        @PositiveOrZero(message = "discountPrice는 0 이상이어야 합니다.")
         Long discountPrice,
+
+        @PositiveOrZero(message = "baseShippingFee는 0 이상이어야 합니다.")
         Long baseShippingFee,
+
+        @PositiveOrZero(message = "freeShippingCondition는 0 이상이어야 합니다.")
         Long freeShippingCondition,
         LocalDateTime fetchedAt
 ) {

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
@@ -1,0 +1,37 @@
+package or.sopt.houme.domain.furniture.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+import java.time.LocalDateTime;
+
+public record AdminCurationRawProductCreateRequest(
+        @NotBlank(message = "source는 필수 입력값입니다.")
+        String source,
+
+        @NotNull(message = "category는 필수 입력값입니다.")
+        SoozipCategory category,
+
+        @NotNull(message = "productId는 필수 입력값입니다.")
+        Long productId,
+
+        @NotBlank(message = "productImageUrl은 필수 입력값입니다.")
+        String productImageUrl,
+
+        @NotBlank(message = "productSiteUrl은 필수 입력값입니다.")
+        String productSiteUrl,
+
+        @NotBlank(message = "productName은 필수 입력값입니다.")
+        String productName,
+
+        String productMallName,
+        String brand,
+        Long listPrice,
+        Integer discountRate,
+        Long discountPrice,
+        Long baseShippingFee,
+        Long freeShippingCondition,
+        LocalDateTime fetchedAt
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
@@ -1,22 +1,33 @@
 package or.sopt.houme.domain.furniture.presentation.dto.request;
 
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
 
 public record AdminCurationRawProductUpdateRequest(
         String source,
         SoozipCategory category,
+        @Positive(message = "productId는 1 이상이어야 합니다.")
         Long productId,
         String productImageUrl,
         String productSiteUrl,
         String productName,
         String productMallName,
         String brand,
+        @PositiveOrZero(message = "listPrice는 0 이상이어야 합니다.")
         Long listPrice,
+        @Min(value = 0, message = "discountRate는 0 이상이어야 합니다.")
+        @Max(value = 100, message = "discountRate는 100 이하여야 합니다.")
         Integer discountRate,
+        @PositiveOrZero(message = "discountPrice는 0 이상이어야 합니다.")
         Long discountPrice,
+        @PositiveOrZero(message = "baseShippingFee는 0 이상이어야 합니다.")
         Long baseShippingFee,
+        @PositiveOrZero(message = "freeShippingCondition는 0 이상이어야 합니다.")
         Long freeShippingCondition,
         LocalDateTime fetchedAt
 ) {

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
@@ -1,0 +1,23 @@
+package or.sopt.houme.domain.furniture.presentation.dto.request;
+
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+import java.time.LocalDateTime;
+
+public record AdminCurationRawProductUpdateRequest(
+        String source,
+        SoozipCategory category,
+        Long productId,
+        String productImageUrl,
+        String productSiteUrl,
+        String productName,
+        String productMallName,
+        String brand,
+        Long listPrice,
+        Integer discountRate,
+        Long discountPrice,
+        Long baseShippingFee,
+        Long freeShippingCondition,
+        LocalDateTime fetchedAt
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
@@ -3,12 +3,14 @@ package or.sopt.houme.domain.furniture.presentation.dto.request;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
 
 public record AdminCurationRawProductUpdateRequest(
+        @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$", message = "source 형식이 올바르지 않습니다.")
         String source,
         SoozipCategory category,
         @Positive(message = "productId는 1 이상이어야 합니다.")

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductListResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import java.util.List;
+
+public record AdminCurationRawProductListResponse(
+        List<AdminCurationRawProductResponse> products
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductListResponse.java
@@ -3,6 +3,12 @@ package or.sopt.houme.domain.furniture.presentation.dto.response;
 import java.util.List;
 
 public record AdminCurationRawProductListResponse(
-        List<AdminCurationRawProductResponse> products
+        List<AdminCurationRawProductResponse> products,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext,
+        boolean hasPrevious
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductResponse.java
@@ -1,0 +1,44 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+import java.time.LocalDateTime;
+
+public record AdminCurationRawProductResponse(
+        Long id,
+        String source,
+        SoozipCategory category,
+        Long productId,
+        String productImageUrl,
+        String productSiteUrl,
+        String productName,
+        String productMallName,
+        String brand,
+        Long listPrice,
+        Integer discountRate,
+        Long discountPrice,
+        Long baseShippingFee,
+        Long freeShippingCondition,
+        LocalDateTime fetchedAt
+) {
+    public static AdminCurationRawProductResponse of(CurationRawProduct rawProduct) {
+        return new AdminCurationRawProductResponse(
+                rawProduct.getId(),
+                rawProduct.getSource(),
+                rawProduct.getCategory(),
+                rawProduct.getProductId(),
+                rawProduct.getProductImageUrl(),
+                rawProduct.getProductSiteUrl(),
+                rawProduct.getProductName(),
+                rawProduct.getProductMallName(),
+                rawProduct.getBrand(),
+                rawProduct.getListPrice(),
+                rawProduct.getDiscountRate(),
+                rawProduct.getDiscountPrice(),
+                rawProduct.getBaseShippingFee(),
+                rawProduct.getFreeShippingCondition(),
+                rawProduct.getFetchedAt()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductColorRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductColorRepository.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.furniture.repository;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 @Repository
 public interface CurationRawProductColorRepository extends JpaRepository<CurationRawProductColor, Long> {
     List<CurationRawProductColor> findAllByCurationRawProductIdIn(List<Long> curationRawProductIds);
+
+    void deleteAllByCurationRawProduct(CurationRawProduct curationRawProduct);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -15,7 +15,20 @@ import java.util.Optional;
 
 @Repository
 public interface CurationRawProductRepository extends JpaRepository<CurationRawProduct, Long> {
-    Page<CurationRawProduct> findAllByOrderByIdDesc(Pageable pageable);
+    @Query("""
+            select rawProduct
+            from CurationRawProduct rawProduct
+            where (:category is null or rawProduct.category = :category)
+              and (:minListPrice is null or rawProduct.listPrice >= :minListPrice)
+              and (:maxListPrice is null or rawProduct.listPrice <= :maxListPrice)
+            order by rawProduct.id desc
+            """)
+    Page<CurationRawProduct> findAllByFilters(
+            @Param("category") SoozipCategory category,
+            @Param("minListPrice") Long minListPrice,
+            @Param("maxListPrice") Long maxListPrice,
+            Pageable pageable
+    );
 
     Optional<CurationRawProduct> findBySourceAndCategoryAndProductId(
             String source,

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 
 @Repository
 public interface CurationRawProductRepository extends JpaRepository<CurationRawProduct, Long> {
+    List<CurationRawProduct> findAllByOrderByIdDesc();
+
     Optional<CurationRawProduct> findBySourceAndCategoryAndProductId(
             String source,
             SoozipCategory category,

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -3,6 +3,8 @@ package or.sopt.houme.domain.furniture.repository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,7 +15,7 @@ import java.util.Optional;
 
 @Repository
 public interface CurationRawProductRepository extends JpaRepository<CurationRawProduct, Long> {
-    List<CurationRawProduct> findAllByOrderByIdDesc();
+    Page<CurationRawProduct> findAllByOrderByIdDesc(Pageable pageable);
 
     Optional<CurationRawProduct> findBySourceAndCategoryAndProductId(
             String source,

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
@@ -1,0 +1,19 @@
+package or.sopt.houme.domain.furniture.service.admin;
+
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
+
+public interface AdminCurationRawProductService {
+
+    AdminCurationRawProductListResponse getAll();
+
+    AdminCurationRawProductResponse getById(Long curationRawProductId);
+
+    AdminCurationRawProductResponse create(AdminCurationRawProductCreateRequest request);
+
+    AdminCurationRawProductResponse update(Long curationRawProductId, AdminCurationRawProductUpdateRequest request);
+
+    void delete(Long curationRawProductId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
@@ -7,7 +7,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRaw
 
 public interface AdminCurationRawProductService {
 
-    AdminCurationRawProductListResponse getAll();
+    AdminCurationRawProductListResponse getAll(int page, int size);
 
     AdminCurationRawProductResponse getById(Long curationRawProductId);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.furniture.service.admin;
 
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
@@ -7,7 +8,13 @@ import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRaw
 
 public interface AdminCurationRawProductService {
 
-    AdminCurationRawProductListResponse getAll(int page, int size);
+    AdminCurationRawProductListResponse getAll(
+            int page,
+            int size,
+            SoozipCategory category,
+            Long minListPrice,
+            Long maxListPrice
+    );
 
     AdminCurationRawProductResponse getById(Long curationRawProductId);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -35,11 +35,21 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
     @Override
     @Transactional(readOnly = true)
-    public AdminCurationRawProductListResponse getAll(int page, int size) {
+    public AdminCurationRawProductListResponse getAll(
+            int page,
+            int size,
+            SoozipCategory category,
+            Long minListPrice,
+            Long maxListPrice
+    ) {
         int normalizedPage = Math.max(page, 0);
         int normalizedSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        validatePriceRange(minListPrice, maxListPrice);
 
-        Page<CurationRawProduct> pageResult = curationRawProductRepository.findAllByOrderByIdDesc(
+        Page<CurationRawProduct> pageResult = curationRawProductRepository.findAllByFilters(
+                category,
+                minListPrice,
+                maxListPrice,
                 PageRequest.of(normalizedPage, normalizedSize)
         );
 
@@ -192,5 +202,17 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
+    }
+
+    private void validatePriceRange(Long minListPrice, Long maxListPrice) {
+        if (minListPrice != null && minListPrice < 0) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        if (maxListPrice != null && maxListPrice < 0) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        if (minListPrice != null && maxListPrice != null && minListPrice > maxListPrice) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -1,0 +1,154 @@
+package or.sopt.houme.domain.furniture.service.admin;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminCurationRawProductServiceImpl implements AdminCurationRawProductService {
+
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final CurationRawProductColorRepository curationRawProductColorRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminCurationRawProductListResponse getAll() {
+        List<AdminCurationRawProductResponse> products = curationRawProductRepository.findAllByOrderByIdDesc()
+                .stream()
+                .map(AdminCurationRawProductResponse::of)
+                .toList();
+
+        return new AdminCurationRawProductListResponse(products);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminCurationRawProductResponse getById(Long curationRawProductId) {
+        CurationRawProduct rawProduct = getRawProductOrThrow(curationRawProductId);
+        return AdminCurationRawProductResponse.of(rawProduct);
+    }
+
+    @Override
+    public AdminCurationRawProductResponse create(AdminCurationRawProductCreateRequest request) {
+        String source = normalize(request.source());
+        SoozipCategory category = request.category();
+        Long productId = request.productId();
+
+        validateDuplicate(source, category, productId, null);
+
+        CurationRawProduct rawProduct = CurationRawProduct.of(
+                source,
+                category,
+                productId,
+                normalize(request.productImageUrl()),
+                normalize(request.productSiteUrl()),
+                normalize(request.productName()),
+                normalizeNullable(request.productMallName()),
+                request.fetchedAt() != null ? request.fetchedAt() : LocalDateTime.now()
+        );
+
+        rawProduct.updateMeta(
+                normalizeNullable(request.brand()),
+                request.listPrice(),
+                request.discountRate(),
+                request.discountPrice(),
+                request.baseShippingFee(),
+                request.freeShippingCondition()
+        );
+
+        try {
+            CurationRawProduct saved = curationRawProductRepository.save(rawProduct);
+            return AdminCurationRawProductResponse.of(saved);
+        } catch (DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+        }
+    }
+
+    @Override
+    public AdminCurationRawProductResponse update(Long curationRawProductId, AdminCurationRawProductUpdateRequest request) {
+        CurationRawProduct rawProduct = getRawProductOrThrow(curationRawProductId);
+
+        String targetSource = hasText(request.source()) ? normalize(request.source()) : rawProduct.getSource();
+        SoozipCategory targetCategory = request.category() != null ? request.category() : rawProduct.getCategory();
+        Long targetProductId = request.productId() != null ? request.productId() : rawProduct.getProductId();
+
+        validateDuplicate(targetSource, targetCategory, targetProductId, rawProduct.getId());
+
+        rawProduct.updateAdminFields(
+                normalizeNullable(request.source()),
+                request.category(),
+                request.productId(),
+                normalizeNullable(request.productImageUrl()),
+                normalizeNullable(request.productSiteUrl()),
+                normalizeNullable(request.productName()),
+                normalizeNullable(request.productMallName()),
+                normalizeNullable(request.brand()),
+                request.listPrice(),
+                request.discountRate(),
+                request.discountPrice(),
+                request.baseShippingFee(),
+                request.freeShippingCondition(),
+                request.fetchedAt()
+        );
+
+        return AdminCurationRawProductResponse.of(rawProduct);
+    }
+
+    @Override
+    public void delete(Long curationRawProductId) {
+        CurationRawProduct rawProduct = getRawProductOrThrow(curationRawProductId);
+
+        try {
+            curationRawProductColorRepository.deleteAllByCurationRawProduct(rawProduct);
+            rawProduct.clearFurnitureTags();
+            curationRawProductRepository.delete(rawProduct);
+        } catch (DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorCode.FOREIGN_KEY_CONSTRAINT_FAIL);
+        }
+    }
+
+    private CurationRawProduct getRawProductOrThrow(Long curationRawProductId) {
+        return curationRawProductRepository.findById(curationRawProductId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT));
+    }
+
+    private void validateDuplicate(String source, SoozipCategory category, Long productId, Long selfId) {
+        curationRawProductRepository.findBySourceAndCategoryAndProductId(source, category, productId)
+                .filter(existing -> selfId == null || !existing.getId().equals(selfId))
+                .ifPresent(existing -> {
+                    throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+                });
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private String normalizeNullable(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -11,30 +11,52 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductColorReposito
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AdminCurationRawProductServiceImpl implements AdminCurationRawProductService {
 
+    private static final int MAX_PAGE_SIZE = 100;
+    private static final Pattern SOURCE_PATTERN = Pattern.compile("^[a-z0-9][a-z0-9_-]{0,49}$");
+
     private final CurationRawProductRepository curationRawProductRepository;
     private final CurationRawProductColorRepository curationRawProductColorRepository;
 
     @Override
     @Transactional(readOnly = true)
-    public AdminCurationRawProductListResponse getAll() {
-        List<AdminCurationRawProductResponse> products = curationRawProductRepository.findAllByOrderByIdDesc()
+    public AdminCurationRawProductListResponse getAll(int page, int size) {
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+
+        Page<CurationRawProduct> pageResult = curationRawProductRepository.findAllByOrderByIdDesc(
+                PageRequest.of(normalizedPage, normalizedSize)
+        );
+
+        List<AdminCurationRawProductResponse> products = pageResult.getContent()
                 .stream()
                 .map(AdminCurationRawProductResponse::of)
                 .toList();
 
-        return new AdminCurationRawProductListResponse(products);
+        return new AdminCurationRawProductListResponse(
+                products,
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.hasNext(),
+                pageResult.hasPrevious()
+        );
     }
 
     @Override
@@ -46,7 +68,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
     @Override
     public AdminCurationRawProductResponse create(AdminCurationRawProductCreateRequest request) {
-        String source = normalize(request.source());
+        String source = normalizeSource(request.source());
         SoozipCategory category = request.category();
         Long productId = request.productId();
 
@@ -84,30 +106,36 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
     public AdminCurationRawProductResponse update(Long curationRawProductId, AdminCurationRawProductUpdateRequest request) {
         CurationRawProduct rawProduct = getRawProductOrThrow(curationRawProductId);
 
-        String targetSource = hasText(request.source()) ? normalize(request.source()) : rawProduct.getSource();
+        String targetSource = hasText(request.source())
+                ? normalizeSource(request.source())
+                : normalizeSource(rawProduct.getSource());
         SoozipCategory targetCategory = request.category() != null ? request.category() : rawProduct.getCategory();
         Long targetProductId = request.productId() != null ? request.productId() : rawProduct.getProductId();
 
         validateDuplicate(targetSource, targetCategory, targetProductId, rawProduct.getId());
 
-        rawProduct.updateAdminFields(
-                normalizeNullable(request.source()),
-                request.category(),
-                request.productId(),
-                normalizeNullable(request.productImageUrl()),
-                normalizeNullable(request.productSiteUrl()),
-                normalizeNullable(request.productName()),
-                normalizeNullable(request.productMallName()),
-                normalizeNullable(request.brand()),
-                request.listPrice(),
-                request.discountRate(),
-                request.discountPrice(),
-                request.baseShippingFee(),
-                request.freeShippingCondition(),
-                request.fetchedAt()
-        );
-
-        return AdminCurationRawProductResponse.of(rawProduct);
+        try {
+            rawProduct.updateAdminFields(
+                    hasText(request.source()) ? targetSource : null,
+                    request.category(),
+                    request.productId(),
+                    normalizeNullable(request.productImageUrl()),
+                    normalizeNullable(request.productSiteUrl()),
+                    normalizeNullable(request.productName()),
+                    normalizeNullable(request.productMallName()),
+                    normalizeNullable(request.brand()),
+                    request.listPrice(),
+                    request.discountRate(),
+                    request.discountPrice(),
+                    request.baseShippingFee(),
+                    request.freeShippingCondition(),
+                    request.fetchedAt()
+            );
+            CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
+            return AdminCurationRawProductResponse.of(saved);
+        } catch (DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+        }
     }
 
     @Override
@@ -138,6 +166,19 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
     private String normalize(String value) {
         return value == null ? null : value.trim();
+    }
+
+    private String normalizeSource(String source) {
+        String normalized = normalize(source);
+        if (!hasText(normalized)) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        String canonical = normalized.toLowerCase(Locale.ROOT);
+        if (!SOURCE_PATTERN.matcher(canonical).matches()) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        return canonical;
     }
 
     private String normalizeNullable(String value) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -95,7 +95,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
         );
 
         try {
-            CurationRawProduct saved = curationRawProductRepository.save(rawProduct);
+            CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
             return AdminCurationRawProductResponse.of(saved);
         } catch (DataIntegrityViolationException e) {
             throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
@@ -146,6 +146,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
             curationRawProductColorRepository.deleteAllByCurationRawProduct(rawProduct);
             rawProduct.clearFurnitureTags();
             curationRawProductRepository.delete(rawProduct);
+            curationRawProductRepository.flush();
         } catch (DataIntegrityViolationException e) {
             throw new GeneralException(ErrorCode.FOREIGN_KEY_CONSTRAINT_FAIL);
         }

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     // 회원관련
     USERNAME_DUPLICATE(HttpStatus.BAD_REQUEST,40009,"username이 중복되었습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 40021, "이미 가입된 이메일입니다."),
+    DUPLICATE_CURATION_RAW_PRODUCT(HttpStatus.BAD_REQUEST, 40022, "이미 동일한 원본 상품(source/category/product_id)이 존재합니다."),
 
     // 소셜 회원가입 관련
     SIGNUP_TOKEN_INVALID(HttpStatus.BAD_REQUEST, 40020, "회원가입 토큰이 유효하지 않습니다."),
@@ -125,6 +126,7 @@ public enum ErrorCode {
 
     // House_taste
     NOT_FOUND_HOUSE_TASTE(HttpStatus.NOT_FOUND, 40423, "집 취향을 찾을 수 없습니다."),
+    NOT_FOUND_CURATION_RAW_PRODUCT(HttpStatus.NOT_FOUND, 40424, "원본 상품 객체를 찾을 수 없습니다."),
 
 
     /**

--- a/src/main/java/or/sopt/houme/global/api/handler/FurnitureException.java
+++ b/src/main/java/or/sopt/houme/global/api/handler/FurnitureException.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.global.api.handler;
+
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+
+public class FurnitureException extends GeneralException {
+    public FurnitureException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -395,6 +395,32 @@
         <div class="card">
             <div class="card-header">RAW 상품 전체 조회</div>
             <div class="card-body">
+                <div class="row g-2 mb-3">
+                    <div class="col-md-4">
+                        <label for="rawFilterCategory" class="form-label">카테고리</label>
+                        <select class="form-select" id="rawFilterCategory">
+                            <option value="">전체</option>
+                            <option value="MINI_ELECTRONICS">MINI_ELECTRONICS</option>
+                            <option value="FURNITURE">FURNITURE</option>
+                            <option value="LIGHTING">LIGHTING</option>
+                            <option value="LIVING_GOODS">LIVING_GOODS</option>
+                            <option value="HOME_FABRIC">HOME_FABRIC</option>
+                            <option value="ACCESSORY">ACCESSORY</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label for="rawFilterMinListPrice" class="form-label">최소 가격(listPrice)</label>
+                        <input type="number" class="form-control" id="rawFilterMinListPrice" min="0" placeholder="예: 100000">
+                    </div>
+                    <div class="col-md-3">
+                        <label for="rawFilterMaxListPrice" class="form-label">최대 가격(listPrice)</label>
+                        <input type="number" class="form-control" id="rawFilterMaxListPrice" min="0" placeholder="예: 500000">
+                    </div>
+                    <div class="col-md-2 d-grid gap-2">
+                        <button id="apply-raw-filters-button" class="btn btn-outline-primary">필터 적용</button>
+                        <button id="reset-raw-filters-button" class="btn btn-outline-secondary">필터 초기화</button>
+                    </div>
+                </div>
                 <button id="get-raw-products-button" class="btn btn-secondary">RAW 상품 목록 보기</button>
                 <div id="get-raw-products-result" class="api-result"></div>
             </div>
@@ -505,6 +531,11 @@
         totalPages: 0,
         hasNext: false,
         hasPrevious: false
+    };
+    let rawProductsFilterState = {
+        category: null,
+        minListPrice: null,
+        maxListPrice: null
     };
 
     window.onload = function() {
@@ -878,7 +909,33 @@
                 resultDiv.setAttribute('data-open', 'false');
                 return;
             }
-            fetchRawProducts();
+            if (!applyRawProductFiltersFromInputs(resultDiv)) {
+                return;
+            }
+            fetchRawProducts(0, rawProductsPageState.size);
+            resultDiv.setAttribute('data-open', 'true');
+        });
+
+        document.getElementById('apply-raw-filters-button').addEventListener('click', function() {
+            const resultDiv = document.getElementById('get-raw-products-result');
+            if (!applyRawProductFiltersFromInputs(resultDiv)) {
+                return;
+            }
+            fetchRawProducts(0, rawProductsPageState.size);
+            resultDiv.setAttribute('data-open', 'true');
+        });
+
+        document.getElementById('reset-raw-filters-button').addEventListener('click', function() {
+            const resultDiv = document.getElementById('get-raw-products-result');
+            document.getElementById('rawFilterCategory').value = '';
+            document.getElementById('rawFilterMinListPrice').value = '';
+            document.getElementById('rawFilterMaxListPrice').value = '';
+            rawProductsFilterState = {
+                category: null,
+                minListPrice: null,
+                maxListPrice: null
+            };
+            fetchRawProducts(0, rawProductsPageState.size);
             resultDiv.setAttribute('data-open', 'true');
         });
 
@@ -1366,12 +1423,53 @@
         });
     }
 
+    function applyRawProductFiltersFromInputs(resultDiv) {
+        const category = parseStringValue(document.getElementById('rawFilterCategory').value);
+        const minListPrice = parseNumberValue(document.getElementById('rawFilterMinListPrice').value);
+        const maxListPrice = parseNumberValue(document.getElementById('rawFilterMaxListPrice').value);
+
+        if (minListPrice != null && minListPrice < 0) {
+            resultDiv.innerHTML = '<div class="alert alert-danger">최소 가격은 0 이상이어야 합니다.</div>';
+            return false;
+        }
+        if (maxListPrice != null && maxListPrice < 0) {
+            resultDiv.innerHTML = '<div class="alert alert-danger">최대 가격은 0 이상이어야 합니다.</div>';
+            return false;
+        }
+        if (minListPrice != null && maxListPrice != null && minListPrice > maxListPrice) {
+            resultDiv.innerHTML = '<div class="alert alert-danger">최소 가격은 최대 가격보다 클 수 없습니다.</div>';
+            return false;
+        }
+
+        rawProductsFilterState = {
+            category,
+            minListPrice,
+            maxListPrice
+        };
+        return true;
+    }
+
     function fetchRawProducts(page = rawProductsPageState.page, size = rawProductsPageState.size) {
         const accessToken = localStorage.getItem('accessToken');
         const resultDiv = document.getElementById('get-raw-products-result');
         const targetPage = Math.max(0, page);
         const targetSize = Math.max(1, size);
-        const endpoint = `/api/v1/admin/curation-raw-products?page=${targetPage}&size=${targetSize}`;
+        const queryParams = new URLSearchParams({
+            page: String(targetPage),
+            size: String(targetSize)
+        });
+
+        if (rawProductsFilterState.category) {
+            queryParams.set('category', rawProductsFilterState.category);
+        }
+        if (rawProductsFilterState.minListPrice != null) {
+            queryParams.set('minListPrice', String(rawProductsFilterState.minListPrice));
+        }
+        if (rawProductsFilterState.maxListPrice != null) {
+            queryParams.set('maxListPrice', String(rawProductsFilterState.maxListPrice));
+        }
+
+        const endpoint = `/api/v1/admin/curation-raw-products?${queryParams.toString()}`;
         testApiCall(accessToken, resultDiv, endpoint, 'GET', null, displayRawProductsAsTable);
     }
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1089,7 +1089,7 @@
 
         const thead = document.createElement('thead');
         const headRow = document.createElement('tr');
-        ['ID', 'source', 'category', 'productId', '상품명', '몰명', 'fetchedAt', '작업'].forEach(header => {
+        ['ID', '이미지', 'source', 'category', 'productId', '상품명', '몰명', 'fetchedAt', '작업'].forEach(header => {
             const th = document.createElement('th');
             th.textContent = header;
             headRow.appendChild(th);
@@ -1103,6 +1103,7 @@
             const rawProductId = Number(product.id);
 
             appendCell(row, product.id);
+            appendImageCell(row, product.productImageUrl, product.productName, product.productSiteUrl);
             appendCell(row, product.source);
             appendCell(row, product.category);
             appendCell(row, product.productId);
@@ -1377,6 +1378,40 @@
     function appendCell(row, value) {
         const td = document.createElement('td');
         td.textContent = value == null ? '' : String(value);
+        row.appendChild(td);
+    }
+
+    function appendImageCell(row, imageUrl, altText, siteUrl) {
+        const td = document.createElement('td');
+        const normalizedImageUrl = parseStringValue(imageUrl);
+        const normalizedSiteUrl = parseStringValue(siteUrl);
+
+        if (!normalizedImageUrl) {
+            td.textContent = '-';
+            row.appendChild(td);
+            return;
+        }
+
+        const img = document.createElement('img');
+        img.src = normalizedImageUrl;
+        img.alt = altText ? `${altText} 이미지` : '상품 이미지';
+        img.loading = 'lazy';
+        img.style.width = '72px';
+        img.style.height = '72px';
+        img.style.objectFit = 'cover';
+        img.style.borderRadius = '6px';
+
+        if (normalizedSiteUrl) {
+            const anchor = document.createElement('a');
+            anchor.href = normalizedSiteUrl;
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+            anchor.appendChild(img);
+            td.appendChild(anchor);
+        } else {
+            td.appendChild(img);
+        }
+
         row.appendChild(td);
     }
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -864,13 +864,14 @@
         });
 
         document.getElementById('get-raw-products-button').addEventListener('click', function() {
-            const accessToken = localStorage.getItem('accessToken');
             const resultDiv = document.getElementById('get-raw-products-result');
-            if (resultDiv.innerHTML) {
+            if (resultDiv.getAttribute('data-open') === 'true') {
                 resultDiv.innerHTML = '';
+                resultDiv.setAttribute('data-open', 'false');
                 return;
             }
-            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'GET', null, displayRawProductsAsTable);
+            fetchRawProducts();
+            resultDiv.setAttribute('data-open', 'true');
         });
 
         document.getElementById('raw-product-detail-form').addEventListener('submit', function(event) {
@@ -924,7 +925,7 @@
             if (!confirm(`RAW 상품 ID ${rawProductId}를 정말로 삭제하시겠습니까?`)) return;
             testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'DELETE', null, () => {
                 resultDiv.innerHTML = '<div class="alert alert-success">RAW 상품이 삭제되었습니다.</div>';
-                document.getElementById('get-raw-products-button').click();
+                fetchRawProducts();
             });
         });
     };
@@ -1048,33 +1049,73 @@
 
     function displayRawProductsAsTable(data, resultDiv) {
         const products = data && data.data && Array.isArray(data.data.products) ? data.data.products : [];
+        resultDiv.setAttribute('data-open', 'true');
         if (products.length === 0) {
             resultDiv.innerHTML = '<div class="alert alert-info">등록된 RAW 상품이 없습니다.</div>';
             return;
         }
 
-        let tableHTML = '<div class="table-responsive"><table class="table table-hover align-middle"><thead><tr>' +
-            '<th>ID</th><th>source</th><th>category</th><th>productId</th><th>상품명</th><th>몰명</th><th>fetchedAt</th><th>작업</th>' +
-            '</tr></thead><tbody>';
+        resultDiv.innerHTML = '';
+
+        const tableWrapper = document.createElement('div');
+        tableWrapper.className = 'table-responsive';
+
+        const table = document.createElement('table');
+        table.className = 'table table-hover align-middle';
+
+        const thead = document.createElement('thead');
+        const headRow = document.createElement('tr');
+        ['ID', 'source', 'category', 'productId', '상품명', '몰명', 'fetchedAt', '작업'].forEach(header => {
+            const th = document.createElement('th');
+            th.textContent = header;
+            headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+
+        const tbody = document.createElement('tbody');
 
         products.forEach(product => {
-            tableHTML += `<tr>
-                <td>${product.id ?? ''}</td>
-                <td>${product.source ?? ''}</td>
-                <td>${product.category ?? ''}</td>
-                <td>${product.productId ?? ''}</td>
-                <td>${product.productName ?? ''}</td>
-                <td>${product.productMallName ?? ''}</td>
-                <td>${product.fetchedAt ?? ''}</td>
-                <td>
-                    <button class="btn btn-sm btn-info me-1" onclick="loadRawProductDetail(${product.id})">상세</button>
-                    <button class="btn btn-sm btn-danger" onclick="deleteRawProductById(${product.id})">삭제</button>
-                </td>
-            </tr>`;
+            const row = document.createElement('tr');
+            const rawProductId = Number(product.id);
+
+            appendCell(row, product.id);
+            appendCell(row, product.source);
+            appendCell(row, product.category);
+            appendCell(row, product.productId);
+            appendCell(row, product.productName);
+            appendCell(row, product.productMallName);
+            appendCell(row, product.fetchedAt);
+
+            const actionCell = document.createElement('td');
+            const detailButton = document.createElement('button');
+            detailButton.className = 'btn btn-sm btn-info me-1';
+            detailButton.textContent = '상세';
+            detailButton.disabled = Number.isNaN(rawProductId);
+            detailButton.addEventListener('click', () => loadRawProductDetail(rawProductId));
+
+            const deleteButton = document.createElement('button');
+            deleteButton.className = 'btn btn-sm btn-danger';
+            deleteButton.textContent = '삭제';
+            deleteButton.disabled = Number.isNaN(rawProductId);
+            deleteButton.addEventListener('click', () => deleteRawProductById(rawProductId));
+
+            actionCell.appendChild(detailButton);
+            actionCell.appendChild(deleteButton);
+            row.appendChild(actionCell);
+            tbody.appendChild(row);
         });
 
-        tableHTML += '</tbody></table></div>';
-        resultDiv.innerHTML = tableHTML;
+        table.appendChild(thead);
+        table.appendChild(tbody);
+        tableWrapper.appendChild(table);
+        resultDiv.appendChild(tableWrapper);
+
+        if (data && data.data && typeof data.data.totalElements === 'number') {
+            const meta = document.createElement('div');
+            meta.className = 'mt-2 text-muted';
+            meta.textContent = `page=${data.data.page}, size=${data.data.size}, total=${data.data.totalElements}`;
+            resultDiv.appendChild(meta);
+        }
     }
 
     function displayTagsAsTable(data, resultDiv) {
@@ -1279,8 +1320,21 @@
         const resultDiv = document.getElementById('get-raw-products-result');
         testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'DELETE', null, () => {
             alert('RAW 상품이 삭제되었습니다.');
-            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'GET', null, displayRawProductsAsTable);
+            fetchRawProducts();
         });
+    }
+
+    function fetchRawProducts(page = 0, size = 50) {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('get-raw-products-result');
+        const endpoint = `/api/v1/admin/curation-raw-products?page=${page}&size=${size}`;
+        testApiCall(accessToken, resultDiv, endpoint, 'GET', null, displayRawProductsAsTable);
+    }
+
+    function appendCell(row, value) {
+        const td = document.createElement('td');
+        td.textContent = value == null ? '' : String(value);
+        row.appendChild(td);
     }
 
     function parseNumberValue(value) {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -499,6 +499,14 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <script>
+    let rawProductsPageState = {
+        page: 0,
+        size: 50,
+        totalPages: 0,
+        hasNext: false,
+        hasPrevious: false
+    };
+
     window.onload = function() {
         const urlParams = new URLSearchParams(window.location.search);
         const token = urlParams.get('token');
@@ -1048,7 +1056,23 @@
     }
 
     function displayRawProductsAsTable(data, resultDiv) {
-        const products = data && data.data && Array.isArray(data.data.products) ? data.data.products : [];
+        const payload = data && data.data ? data.data : {};
+        const products = Array.isArray(payload.products) ? payload.products : [];
+        const page = Number.isInteger(payload.page) ? payload.page : rawProductsPageState.page;
+        const size = Number.isInteger(payload.size) ? payload.size : rawProductsPageState.size;
+        const totalPages = Number.isInteger(payload.totalPages) ? payload.totalPages : 0;
+        const totalElements = typeof payload.totalElements === 'number' ? payload.totalElements : products.length;
+        const hasNext = Boolean(payload.hasNext);
+        const hasPrevious = Boolean(payload.hasPrevious);
+
+        rawProductsPageState = {
+            page,
+            size,
+            totalPages,
+            hasNext,
+            hasPrevious
+        };
+
         resultDiv.setAttribute('data-open', 'true');
         if (products.length === 0) {
             resultDiv.innerHTML = '<div class="alert alert-info">등록된 RAW 상품이 없습니다.</div>';
@@ -1110,12 +1134,29 @@
         tableWrapper.appendChild(table);
         resultDiv.appendChild(tableWrapper);
 
-        if (data && data.data && typeof data.data.totalElements === 'number') {
-            const meta = document.createElement('div');
-            meta.className = 'mt-2 text-muted';
-            meta.textContent = `page=${data.data.page}, size=${data.data.size}, total=${data.data.totalElements}`;
-            resultDiv.appendChild(meta);
-        }
+        const meta = document.createElement('div');
+        meta.className = 'mt-2 text-muted';
+        meta.textContent = `page=${page + 1}/${Math.max(totalPages, 1)}, size=${size}, total=${totalElements}`;
+        resultDiv.appendChild(meta);
+
+        const pagination = document.createElement('div');
+        pagination.className = 'd-flex align-items-center gap-2 mt-2';
+
+        const prevButton = document.createElement('button');
+        prevButton.className = 'btn btn-outline-secondary btn-sm';
+        prevButton.textContent = '이전';
+        prevButton.disabled = !hasPrevious;
+        prevButton.addEventListener('click', () => fetchRawProducts(page - 1, size));
+
+        const nextButton = document.createElement('button');
+        nextButton.className = 'btn btn-outline-secondary btn-sm';
+        nextButton.textContent = '다음';
+        nextButton.disabled = !hasNext;
+        nextButton.addEventListener('click', () => fetchRawProducts(page + 1, size));
+
+        pagination.appendChild(prevButton);
+        pagination.appendChild(nextButton);
+        resultDiv.appendChild(pagination);
     }
 
     function displayTagsAsTable(data, resultDiv) {
@@ -1324,10 +1365,12 @@
         });
     }
 
-    function fetchRawProducts(page = 0, size = 50) {
+    function fetchRawProducts(page = rawProductsPageState.page, size = rawProductsPageState.size) {
         const accessToken = localStorage.getItem('accessToken');
         const resultDiv = document.getElementById('get-raw-products-result');
-        const endpoint = `/api/v1/admin/curation-raw-products?page=${page}&size=${size}`;
+        const targetPage = Math.max(0, page);
+        const targetSize = Math.max(1, size);
+        const endpoint = `/api/v1/admin/curation-raw-products?page=${targetPage}&size=${targetSize}`;
         testApiCall(accessToken, resultDiv, endpoint, 'GET', null, displayRawProductsAsTable);
     }
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -96,6 +96,11 @@
                 <i class="fas fa-images"></i>무드보드 관리
             </a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="raw-product-management">
+                <i class="fas fa-box-open"></i>RAW 상품 관리
+            </a>
+        </li>
     </ul>
 </div>
 
@@ -380,6 +385,113 @@
             <div class="card-body">
                 <button id="get-all-moodboards-button" class="btn btn-secondary">전체 무드보드 보기</button>
                 <div id="get-all-moodboards-result" class="api-result"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- RAW 상품 관리 섹션 -->
+    <div id="raw-product-management" class="content-section">
+        <h2>RAW 상품 관리</h2>
+        <div class="card">
+            <div class="card-header">RAW 상품 전체 조회</div>
+            <div class="card-body">
+                <button id="get-raw-products-button" class="btn btn-secondary">RAW 상품 목록 보기</button>
+                <div id="get-raw-products-result" class="api-result"></div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">RAW 상품 상세 조회</div>
+            <div class="card-body">
+                <form id="raw-product-detail-form">
+                    <div class="mb-3">
+                        <label for="rawProductDetailId" class="form-label">RAW 상품 ID</label>
+                        <input type="number" class="form-control" id="rawProductDetailId" required>
+                    </div>
+                    <button type="submit" class="btn btn-info">상세 조회</button>
+                </form>
+                <div id="raw-product-detail-result" class="api-result"></div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">RAW 상품 등록</div>
+            <div class="card-body">
+                <form id="raw-product-create-form">
+                    <div class="mb-3"><label for="rawCreateSource" class="form-label">source</label><input type="text" class="form-control" id="rawCreateSource" placeholder="예: soozip, ohouse" required></div>
+                    <div class="mb-3">
+                        <label for="rawCreateCategory" class="form-label">category</label>
+                        <select class="form-select" id="rawCreateCategory" required>
+                            <option value="" selected disabled>카테고리를 선택하세요...</option>
+                            <option value="MINI_ELECTRONICS">MINI_ELECTRONICS</option>
+                            <option value="FURNITURE">FURNITURE</option>
+                            <option value="LIGHTING">LIGHTING</option>
+                            <option value="LIVING_GOODS">LIVING_GOODS</option>
+                            <option value="HOME_FABRIC">HOME_FABRIC</option>
+                            <option value="ACCESSORY">ACCESSORY</option>
+                        </select>
+                    </div>
+                    <div class="mb-3"><label for="rawCreateProductId" class="form-label">productId</label><input type="number" class="form-control" id="rawCreateProductId" required></div>
+                    <div class="mb-3"><label for="rawCreateProductImageUrl" class="form-label">productImageUrl</label><input type="url" class="form-control" id="rawCreateProductImageUrl" required></div>
+                    <div class="mb-3"><label for="rawCreateProductSiteUrl" class="form-label">productSiteUrl</label><input type="url" class="form-control" id="rawCreateProductSiteUrl" required></div>
+                    <div class="mb-3"><label for="rawCreateProductName" class="form-label">productName</label><input type="text" class="form-control" id="rawCreateProductName" required></div>
+                    <div class="mb-3"><label for="rawCreateProductMallName" class="form-label">productMallName</label><input type="text" class="form-control" id="rawCreateProductMallName"></div>
+                    <div class="mb-3"><label for="rawCreateBrand" class="form-label">brand</label><input type="text" class="form-control" id="rawCreateBrand"></div>
+                    <div class="mb-3"><label for="rawCreateListPrice" class="form-label">listPrice</label><input type="number" class="form-control" id="rawCreateListPrice"></div>
+                    <div class="mb-3"><label for="rawCreateDiscountRate" class="form-label">discountRate</label><input type="number" class="form-control" id="rawCreateDiscountRate"></div>
+                    <div class="mb-3"><label for="rawCreateDiscountPrice" class="form-label">discountPrice</label><input type="number" class="form-control" id="rawCreateDiscountPrice"></div>
+                    <div class="mb-3"><label for="rawCreateBaseShippingFee" class="form-label">baseShippingFee</label><input type="number" class="form-control" id="rawCreateBaseShippingFee"></div>
+                    <div class="mb-3"><label for="rawCreateFreeShippingCondition" class="form-label">freeShippingCondition</label><input type="number" class="form-control" id="rawCreateFreeShippingCondition"></div>
+                    <div class="mb-3"><label for="rawCreateFetchedAt" class="form-label">fetchedAt</label><input type="datetime-local" class="form-control" id="rawCreateFetchedAt"></div>
+                    <button type="submit" class="btn btn-primary">RAW 상품 등록</button>
+                </form>
+                <div id="raw-product-create-result" class="api-result"></div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">RAW 상품 수정</div>
+            <div class="card-body">
+                <form id="raw-product-update-form">
+                    <div class="mb-3"><label for="rawUpdateId" class="form-label">수정 대상 RAW 상품 ID</label><input type="number" class="form-control" id="rawUpdateId" required></div>
+                    <div class="mb-3"><label for="rawUpdateSource" class="form-label">source</label><input type="text" class="form-control" id="rawUpdateSource"></div>
+                    <div class="mb-3">
+                        <label for="rawUpdateCategory" class="form-label">category</label>
+                        <select class="form-select" id="rawUpdateCategory">
+                            <option value="" selected>미변경</option>
+                            <option value="MINI_ELECTRONICS">MINI_ELECTRONICS</option>
+                            <option value="FURNITURE">FURNITURE</option>
+                            <option value="LIGHTING">LIGHTING</option>
+                            <option value="LIVING_GOODS">LIVING_GOODS</option>
+                            <option value="HOME_FABRIC">HOME_FABRIC</option>
+                            <option value="ACCESSORY">ACCESSORY</option>
+                        </select>
+                    </div>
+                    <div class="mb-3"><label for="rawUpdateProductId" class="form-label">productId</label><input type="number" class="form-control" id="rawUpdateProductId"></div>
+                    <div class="mb-3"><label for="rawUpdateProductImageUrl" class="form-label">productImageUrl</label><input type="url" class="form-control" id="rawUpdateProductImageUrl"></div>
+                    <div class="mb-3"><label for="rawUpdateProductSiteUrl" class="form-label">productSiteUrl</label><input type="url" class="form-control" id="rawUpdateProductSiteUrl"></div>
+                    <div class="mb-3"><label for="rawUpdateProductName" class="form-label">productName</label><input type="text" class="form-control" id="rawUpdateProductName"></div>
+                    <div class="mb-3"><label for="rawUpdateProductMallName" class="form-label">productMallName</label><input type="text" class="form-control" id="rawUpdateProductMallName"></div>
+                    <div class="mb-3"><label for="rawUpdateBrand" class="form-label">brand</label><input type="text" class="form-control" id="rawUpdateBrand"></div>
+                    <div class="mb-3"><label for="rawUpdateListPrice" class="form-label">listPrice</label><input type="number" class="form-control" id="rawUpdateListPrice"></div>
+                    <div class="mb-3"><label for="rawUpdateDiscountRate" class="form-label">discountRate</label><input type="number" class="form-control" id="rawUpdateDiscountRate"></div>
+                    <div class="mb-3"><label for="rawUpdateDiscountPrice" class="form-label">discountPrice</label><input type="number" class="form-control" id="rawUpdateDiscountPrice"></div>
+                    <div class="mb-3"><label for="rawUpdateBaseShippingFee" class="form-label">baseShippingFee</label><input type="number" class="form-control" id="rawUpdateBaseShippingFee"></div>
+                    <div class="mb-3"><label for="rawUpdateFreeShippingCondition" class="form-label">freeShippingCondition</label><input type="number" class="form-control" id="rawUpdateFreeShippingCondition"></div>
+                    <div class="mb-3"><label for="rawUpdateFetchedAt" class="form-label">fetchedAt</label><input type="datetime-local" class="form-control" id="rawUpdateFetchedAt"></div>
+                    <button type="submit" class="btn btn-warning">RAW 상품 수정</button>
+                </form>
+                <div id="raw-product-update-result" class="api-result"></div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">RAW 상품 삭제</div>
+            <div class="card-body">
+                <form id="raw-product-delete-form">
+                    <div class="mb-3">
+                        <label for="rawDeleteId" class="form-label">삭제할 RAW 상품 ID</label>
+                        <input type="number" class="form-control" id="rawDeleteId" required>
+                    </div>
+                    <button type="submit" class="btn btn-danger">RAW 상품 삭제</button>
+                </form>
+                <div id="raw-product-delete-result" class="api-result"></div>
             </div>
         </div>
     </div>
@@ -750,6 +862,71 @@
             }
             testApiCall(accessToken, resultDiv, '/api/v1/admin/moodboards', 'GET', null, displayMoodboards);
         });
+
+        document.getElementById('get-raw-products-button').addEventListener('click', function() {
+            const accessToken = localStorage.getItem('accessToken');
+            const resultDiv = document.getElementById('get-raw-products-result');
+            if (resultDiv.innerHTML) {
+                resultDiv.innerHTML = '';
+                return;
+            }
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'GET', null, displayRawProductsAsTable);
+        });
+
+        document.getElementById('raw-product-detail-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            const accessToken = localStorage.getItem('accessToken');
+            const resultDiv = document.getElementById('raw-product-detail-result');
+            const rawProductId = document.getElementById('rawProductDetailId').value;
+            if (!rawProductId) {
+                resultDiv.innerHTML = '<div class="alert alert-danger">RAW 상품 ID를 입력해주세요.</div>';
+                return;
+            }
+            testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'GET', null);
+        });
+
+        document.getElementById('raw-product-create-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            const accessToken = localStorage.getItem('accessToken');
+            const resultDiv = document.getElementById('raw-product-create-result');
+            const payload = buildRawProductCreatePayload();
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'POST', payload);
+        });
+
+        document.getElementById('raw-product-update-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            const accessToken = localStorage.getItem('accessToken');
+            const resultDiv = document.getElementById('raw-product-update-result');
+            const rawProductId = document.getElementById('rawUpdateId').value;
+            if (!rawProductId) {
+                resultDiv.innerHTML = '<div class="alert alert-danger">수정할 RAW 상품 ID를 입력해주세요.</div>';
+                return;
+            }
+
+            const payload = buildRawProductUpdatePayload();
+            if (Object.keys(payload).length === 0) {
+                resultDiv.innerHTML = '<div class="alert alert-danger">수정할 값을 최소 1개 이상 입력해주세요.</div>';
+                return;
+            }
+
+            testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'PATCH', payload);
+        });
+
+        document.getElementById('raw-product-delete-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            const accessToken = localStorage.getItem('accessToken');
+            const resultDiv = document.getElementById('raw-product-delete-result');
+            const rawProductId = document.getElementById('rawDeleteId').value;
+            if (!rawProductId) {
+                resultDiv.innerHTML = '<div class="alert alert-danger">삭제할 RAW 상품 ID를 입력해주세요.</div>';
+                return;
+            }
+            if (!confirm(`RAW 상품 ID ${rawProductId}를 정말로 삭제하시겠습니까?`)) return;
+            testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'DELETE', null, () => {
+                resultDiv.innerHTML = '<div class="alert alert-success">RAW 상품이 삭제되었습니다.</div>';
+                document.getElementById('get-raw-products-button').click();
+            });
+        });
     };
 
     function displayMoodboards(data, resultDiv) {
@@ -866,6 +1043,37 @@
             tableHTML += `<tr><td>${furniture.furnitureId}</td><td>${furniture.furnitureNameKr}</td><td>${tagsHTML}</td><td>${actionsHTML}</td></tr>`;
         });
         tableHTML += '</tbody></table>';
+        resultDiv.innerHTML = tableHTML;
+    }
+
+    function displayRawProductsAsTable(data, resultDiv) {
+        const products = data && data.data && Array.isArray(data.data.products) ? data.data.products : [];
+        if (products.length === 0) {
+            resultDiv.innerHTML = '<div class="alert alert-info">등록된 RAW 상품이 없습니다.</div>';
+            return;
+        }
+
+        let tableHTML = '<div class="table-responsive"><table class="table table-hover align-middle"><thead><tr>' +
+            '<th>ID</th><th>source</th><th>category</th><th>productId</th><th>상품명</th><th>몰명</th><th>fetchedAt</th><th>작업</th>' +
+            '</tr></thead><tbody>';
+
+        products.forEach(product => {
+            tableHTML += `<tr>
+                <td>${product.id ?? ''}</td>
+                <td>${product.source ?? ''}</td>
+                <td>${product.category ?? ''}</td>
+                <td>${product.productId ?? ''}</td>
+                <td>${product.productName ?? ''}</td>
+                <td>${product.productMallName ?? ''}</td>
+                <td>${product.fetchedAt ?? ''}</td>
+                <td>
+                    <button class="btn btn-sm btn-info me-1" onclick="loadRawProductDetail(${product.id})">상세</button>
+                    <button class="btn btn-sm btn-danger" onclick="deleteRawProductById(${product.id})">삭제</button>
+                </td>
+            </tr>`;
+        });
+
+        tableHTML += '</tbody></table></div>';
         resultDiv.innerHTML = tableHTML;
     }
 
@@ -1057,6 +1265,90 @@
             alert('가구 타입이 삭제되었습니다.');
             document.getElementById('get-furniture-types-button').click(); // 목록 새로고침
         });
+    }
+
+    function loadRawProductDetail(rawProductId) {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('raw-product-detail-result');
+        testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'GET', null);
+    }
+
+    function deleteRawProductById(rawProductId) {
+        if (!confirm(`RAW 상품 ID ${rawProductId}를 정말로 삭제하시겠습니까?`)) return;
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('get-raw-products-result');
+        testApiCall(accessToken, resultDiv, `/api/v1/admin/curation-raw-products/${rawProductId}`, 'DELETE', null, () => {
+            alert('RAW 상품이 삭제되었습니다.');
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'GET', null, displayRawProductsAsTable);
+        });
+    }
+
+    function parseNumberValue(value) {
+        if (value == null) return null;
+        const trimmed = String(value).trim();
+        if (trimmed.length === 0) return null;
+        const parsed = Number(trimmed);
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+
+    function parseStringValue(value) {
+        if (value == null) return null;
+        const trimmed = String(value).trim();
+        return trimmed.length === 0 ? null : trimmed;
+    }
+
+    function buildRawProductCreatePayload() {
+        return {
+            source: parseStringValue(document.getElementById('rawCreateSource').value),
+            category: parseStringValue(document.getElementById('rawCreateCategory').value),
+            productId: parseNumberValue(document.getElementById('rawCreateProductId').value),
+            productImageUrl: parseStringValue(document.getElementById('rawCreateProductImageUrl').value),
+            productSiteUrl: parseStringValue(document.getElementById('rawCreateProductSiteUrl').value),
+            productName: parseStringValue(document.getElementById('rawCreateProductName').value),
+            productMallName: parseStringValue(document.getElementById('rawCreateProductMallName').value),
+            brand: parseStringValue(document.getElementById('rawCreateBrand').value),
+            listPrice: parseNumberValue(document.getElementById('rawCreateListPrice').value),
+            discountRate: parseNumberValue(document.getElementById('rawCreateDiscountRate').value),
+            discountPrice: parseNumberValue(document.getElementById('rawCreateDiscountPrice').value),
+            baseShippingFee: parseNumberValue(document.getElementById('rawCreateBaseShippingFee').value),
+            freeShippingCondition: parseNumberValue(document.getElementById('rawCreateFreeShippingCondition').value),
+            fetchedAt: parseStringValue(document.getElementById('rawCreateFetchedAt').value)
+        };
+    }
+
+    function buildRawProductUpdatePayload() {
+        const payload = {};
+        const source = parseStringValue(document.getElementById('rawUpdateSource').value);
+        const category = parseStringValue(document.getElementById('rawUpdateCategory').value);
+        const productId = parseNumberValue(document.getElementById('rawUpdateProductId').value);
+        const productImageUrl = parseStringValue(document.getElementById('rawUpdateProductImageUrl').value);
+        const productSiteUrl = parseStringValue(document.getElementById('rawUpdateProductSiteUrl').value);
+        const productName = parseStringValue(document.getElementById('rawUpdateProductName').value);
+        const productMallName = parseStringValue(document.getElementById('rawUpdateProductMallName').value);
+        const brand = parseStringValue(document.getElementById('rawUpdateBrand').value);
+        const listPrice = parseNumberValue(document.getElementById('rawUpdateListPrice').value);
+        const discountRate = parseNumberValue(document.getElementById('rawUpdateDiscountRate').value);
+        const discountPrice = parseNumberValue(document.getElementById('rawUpdateDiscountPrice').value);
+        const baseShippingFee = parseNumberValue(document.getElementById('rawUpdateBaseShippingFee').value);
+        const freeShippingCondition = parseNumberValue(document.getElementById('rawUpdateFreeShippingCondition').value);
+        const fetchedAt = parseStringValue(document.getElementById('rawUpdateFetchedAt').value);
+
+        if (source !== null) payload.source = source;
+        if (category !== null) payload.category = category;
+        if (productId !== null) payload.productId = productId;
+        if (productImageUrl !== null) payload.productImageUrl = productImageUrl;
+        if (productSiteUrl !== null) payload.productSiteUrl = productSiteUrl;
+        if (productName !== null) payload.productName = productName;
+        if (productMallName !== null) payload.productMallName = productMallName;
+        if (brand !== null) payload.brand = brand;
+        if (listPrice !== null) payload.listPrice = listPrice;
+        if (discountRate !== null) payload.discountRate = discountRate;
+        if (discountPrice !== null) payload.discountPrice = discountPrice;
+        if (baseShippingFee !== null) payload.baseShippingFee = baseShippingFee;
+        if (freeShippingCondition !== null) payload.freeShippingCondition = freeShippingCondition;
+        if (fetchedAt !== null) payload.fetchedAt = fetchedAt;
+
+        return payload;
     }
 
     // --- Loading helpers (skeleton UI) and loader-aware API call ---

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -3,23 +3,32 @@ package or.sopt.houme.domain.furniture.service.admin;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +44,30 @@ class AdminCurationRawProductServiceImplTest {
 
     @InjectMocks
     private AdminCurationRawProductServiceImpl adminCurationRawProductService;
+
+    @Test
+    @DisplayName("getAll()은 페이지 메타데이터와 상품 목록을 함께 반환한다")
+    void getAll_success() {
+        CurationRawProduct rawProduct = CurationRawProduct.of(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                3003L,
+                "https://cdn.houme.kr/image3.jpg",
+                "https://soozip.co.kr/product/3003",
+                "목록 상품",
+                "SOOZIP",
+                LocalDateTime.now()
+        );
+
+        when(curationRawProductRepository.findAllByOrderByIdDesc(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(rawProduct)));
+
+        AdminCurationRawProductListResponse response = adminCurationRawProductService.getAll(0, 20);
+
+        assertEquals(1, response.products().size());
+        assertEquals(0, response.page());
+        assertEquals(1L, response.totalElements());
+    }
 
     @Test
     @DisplayName("create()는 신규 원본 상품을 저장한다")
@@ -104,7 +137,8 @@ class AdminCurationRawProductServiceImplTest {
         when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
                 .thenReturn(Optional.of(existing));
 
-        assertThrows(GeneralException.class, () -> adminCurationRawProductService.create(request));
+        GeneralException exception = assertThrows(GeneralException.class, () -> adminCurationRawProductService.create(request));
+        assertEquals(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT, exception.getErrorCode());
     }
 
     @Test
@@ -125,7 +159,53 @@ class AdminCurationRawProductServiceImplTest {
 
         adminCurationRawProductService.delete(1L);
 
-        verify(curationRawProductColorRepository).deleteAllByCurationRawProduct(rawProduct);
-        verify(curationRawProductRepository).delete(rawProduct);
+        InOrder inOrder = inOrder(curationRawProductColorRepository, curationRawProductRepository);
+        inOrder.verify(curationRawProductColorRepository).deleteAllByCurationRawProduct(rawProduct);
+        inOrder.verify(curationRawProductRepository).delete(rawProduct);
+    }
+
+    @Test
+    @DisplayName("update()는 DB 유니크 제약 위반 시 중복 예외를 반환한다")
+    void update_duplicateConstraint_throwsDuplicateError() {
+        CurationRawProduct rawProduct = CurationRawProduct.of(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                4004L,
+                "https://cdn.houme.kr/image4.jpg",
+                "https://soozip.co.kr/product/4004",
+                "수정 대상 상품",
+                "SOOZIP",
+                LocalDateTime.now()
+        );
+
+        AdminCurationRawProductUpdateRequest request = new AdminCurationRawProductUpdateRequest(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                4004L,
+                "https://cdn.houme.kr/image4.jpg",
+                "https://soozip.co.kr/product/4004",
+                "수정된 상품명",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(curationRawProductRepository.findById(10L)).thenReturn(Optional.of(rawProduct));
+        when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 4004L))
+                .thenReturn(Optional.empty());
+        when(curationRawProductRepository.saveAndFlush(rawProduct))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> adminCurationRawProductService.update(10L, request)
+        );
+
+        assertEquals(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT, exception.getErrorCode());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -91,7 +91,7 @@ class AdminCurationRawProductServiceImplTest {
 
         when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
                 .thenReturn(Optional.empty());
-        when(curationRawProductRepository.save(any(CurationRawProduct.class)))
+        when(curationRawProductRepository.saveAndFlush(any(CurationRawProduct.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
         AdminCurationRawProductResponse response = adminCurationRawProductService.create(request);
@@ -100,7 +100,7 @@ class AdminCurationRawProductServiceImplTest {
         assertEquals(SoozipCategory.FURNITURE, response.category());
         assertEquals(1001L, response.productId());
         assertEquals("테스트 침대", response.productName());
-        verify(curationRawProductRepository).save(any(CurationRawProduct.class));
+        verify(curationRawProductRepository).saveAndFlush(any(CurationRawProduct.class));
     }
 
     @Test
@@ -162,6 +162,7 @@ class AdminCurationRawProductServiceImplTest {
         InOrder inOrder = inOrder(curationRawProductColorRepository, curationRawProductRepository);
         inOrder.verify(curationRawProductColorRepository).deleteAllByCurationRawProduct(rawProduct);
         inOrder.verify(curationRawProductRepository).delete(rawProduct);
+        inOrder.verify(curationRawProductRepository).flush();
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -59,14 +59,31 @@ class AdminCurationRawProductServiceImplTest {
                 LocalDateTime.now()
         );
 
-        when(curationRawProductRepository.findAllByOrderByIdDesc(any(Pageable.class)))
+        when(curationRawProductRepository.findAllByFilters(any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(rawProduct)));
 
-        AdminCurationRawProductListResponse response = adminCurationRawProductService.getAll(0, 20);
+        AdminCurationRawProductListResponse response = adminCurationRawProductService.getAll(
+                0,
+                20,
+                SoozipCategory.FURNITURE,
+                100000L,
+                500000L
+        );
 
         assertEquals(1, response.products().size());
         assertEquals(0, response.page());
         assertEquals(1L, response.totalElements());
+    }
+
+    @Test
+    @DisplayName("getAll()은 최소 가격이 최대 가격보다 크면 예외를 던진다")
+    void getAll_invalidPriceRange_throwsException() {
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> adminCurationRawProductService.getAll(0, 20, null, 500000L, 100000L)
+        );
+
+        assertEquals(ErrorCode.NOT_VALID_EXCEPTION, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -1,0 +1,131 @@
+package or.sopt.houme.domain.furniture.service.admin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.global.api.GeneralException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminCurationRawProductServiceImpl 테스트")
+class AdminCurationRawProductServiceImplTest {
+
+    @Mock
+    private CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    private CurationRawProductColorRepository curationRawProductColorRepository;
+
+    @InjectMocks
+    private AdminCurationRawProductServiceImpl adminCurationRawProductService;
+
+    @Test
+    @DisplayName("create()는 신규 원본 상품을 저장한다")
+    void create_success() {
+        AdminCurationRawProductCreateRequest request = new AdminCurationRawProductCreateRequest(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                1001L,
+                "https://cdn.houme.kr/image.jpg",
+                "https://soozip.co.kr/product/1001",
+                "테스트 침대",
+                "SOOZIP",
+                "테스트브랜드",
+                100000L,
+                10,
+                90000L,
+                3000L,
+                50000L,
+                LocalDateTime.of(2026, 2, 1, 10, 0)
+        );
+
+        when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
+                .thenReturn(Optional.empty());
+        when(curationRawProductRepository.save(any(CurationRawProduct.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        AdminCurationRawProductResponse response = adminCurationRawProductService.create(request);
+
+        assertEquals("soozip", response.source());
+        assertEquals(SoozipCategory.FURNITURE, response.category());
+        assertEquals(1001L, response.productId());
+        assertEquals("테스트 침대", response.productName());
+        verify(curationRawProductRepository).save(any(CurationRawProduct.class));
+    }
+
+    @Test
+    @DisplayName("create()는 중복된 source/category/productId 조합이면 예외를 던진다")
+    void create_duplicate_throwsException() {
+        AdminCurationRawProductCreateRequest request = new AdminCurationRawProductCreateRequest(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                1001L,
+                "https://cdn.houme.kr/image.jpg",
+                "https://soozip.co.kr/product/1001",
+                "테스트 침대",
+                "SOOZIP",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        CurationRawProduct existing = CurationRawProduct.of(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                1001L,
+                "https://cdn.houme.kr/image.jpg",
+                "https://soozip.co.kr/product/1001",
+                "기존 침대",
+                "SOOZIP",
+                LocalDateTime.now()
+        );
+
+        when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
+                .thenReturn(Optional.of(existing));
+
+        assertThrows(GeneralException.class, () -> adminCurationRawProductService.create(request));
+    }
+
+    @Test
+    @DisplayName("delete()는 색상 데이터를 먼저 삭제한 뒤 원본 상품을 삭제한다")
+    void delete_success() {
+        CurationRawProduct rawProduct = CurationRawProduct.of(
+                "soozip",
+                SoozipCategory.FURNITURE,
+                2002L,
+                "https://cdn.houme.kr/image2.jpg",
+                "https://soozip.co.kr/product/2002",
+                "삭제 대상 침대",
+                "SOOZIP",
+                LocalDateTime.now()
+        );
+
+        when(curationRawProductRepository.findById(1L)).thenReturn(Optional.of(rawProduct));
+
+        adminCurationRawProductService.delete(1L);
+
+        verify(curationRawProductColorRepository).deleteAllByCurationRawProduct(rawProduct);
+        verify(curationRawProductRepository).delete(rawProduct);
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #431

## 📝 Summary

- `curation_raw_product` 어드민 CRUD API 5종을 추가했습니다.
  - `GET /api/v1/admin/curation-raw-products`
  - `GET /api/v1/admin/curation-raw-products/{curationRawProductId}`
  - `POST /api/v1/admin/curation-raw-products`
  - `PATCH /api/v1/admin/curation-raw-products/{curationRawProductId}`
  - `DELETE /api/v1/admin/curation-raw-products/{curationRawProductId}`
- 요청/응답 DTO와 어드민 서비스 계층을 추가했습니다.
- 삭제 시 FK 충돌을 방지하기 위해 `curation_raw_product_colors` 선삭제 로직을 반영했습니다.
- `source/category/product_id` 중복 입력 방지 및 원본 상품 not found 에러코드를 추가했습니다.
- 서비스 단위 테스트를 추가했습니다.
- 어드민 대시보드(`admin/dashboard`)에 RAW 상품 관리 view를 추가했습니다.
  - 목록 조회/상세 조회/등록/수정/삭제 UI
  - 테이블 렌더링 및 액션 버튼(상세/삭제)
  - 신규 CRUD API 연동

## 🙏 Question & PR point

- 기존 대시보드 구조(단일 Thymeleaf + inline JS)를 유지한 상태에서 섹션만 확장했습니다.
- PATCH는 부분 수정(전달된 필드만 반영)으로 동작합니다.
- 중복 체크는 어플리케이션 레벨 선검증 + DB 제약(유니크) 이중 안전장치로 처리했습니다.

## 📬 Postman

- 서버 실행 후 아래 예시로 검증 가능합니다.
- `GET /api/v1/admin/curation-raw-products`
- `POST /api/v1/admin/curation-raw-products`

```json
{
  "source": "soozip",
  "category": "FURNITURE",
  "productId": 999999,
  "productImageUrl": "https://example.com/image.jpg",
  "productSiteUrl": "https://example.com/product/999999",
  "productName": "테스트 상품"
}
```

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/8def5649-9a28-410b-a5af-330938e59d12" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자용 RAW 상품 관리 기능 추가 — 목록(페이지네이션), 상세, 생성, 수정(부분·일괄 지원), 삭제 UI/API 제공
  * 관리자에서 소스·카테고리·상품ID·이미지·가격·브랜드·페치시간 등 일괄 또는 부분 업데이트 가능
  * 페이징 응답 포맷 및 목록 응답 DTO 추가

* **Bug Fixes / Validation**
  * 소스 입력 형식 검증 강화 및 정규화 적용
  * 중복/미존재 상황에 대한 명확한 오류 코드 추가

* **Chores**
  * 관련 연관 데이터 일괄 삭제 기능 추가

* **Tests**
  * 관리자 서비스 단위 테스트 추가(목록/생성/중복 예외/삭제 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->