### PR TITLE
[FEATURE] 스타일로 만들기 어드민 API + VIEW 구현 

### DIFF
--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
@@ -55,11 +55,6 @@ public class Banner extends BaseEntity {
     @Comment("스타일 답변 칩 목록 JSON")
     private String styleAnswerChipsJson;
 
-    @Builder.Default
-    @Column(name = "is_exposed", nullable = false)
-    @Comment("노출 여부")
-    private Boolean isExposed = true;
-
     @OneToMany(mappedBy = "banner", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<BannerCurationRawProduct> bannerRawProducts = new ArrayList<>();
@@ -69,8 +64,7 @@ public class Banner extends BaseEntity {
             String bannerTitle,
             String styleQuestion,
             String stylePrompt,
-            String styleAnswerChipsJson,
-            Boolean isExposed
+            String styleAnswerChipsJson
     ) {
         return Banner.builder()
                 .bannerImageUrl(bannerImageUrl)
@@ -78,7 +72,6 @@ public class Banner extends BaseEntity {
                 .styleQuestion(styleQuestion)
                 .stylePrompt(stylePrompt)
                 .styleAnswerChipsJson(styleAnswerChipsJson)
-                .isExposed(isExposed == null ? Boolean.TRUE : isExposed)
                 .build();
     }
 
@@ -87,15 +80,13 @@ public class Banner extends BaseEntity {
             String bannerTitle,
             String styleQuestion,
             String stylePrompt,
-            String styleAnswerChipsJson,
-            Boolean isExposed
+            String styleAnswerChipsJson
     ) {
         this.bannerImageUrl = bannerImageUrl;
         this.bannerTitle = bannerTitle;
         this.styleQuestion = styleQuestion;
         this.stylePrompt = stylePrompt;
         this.styleAnswerChipsJson = styleAnswerChipsJson;
-        this.isExposed = isExposed;
     }
 
     public void replaceRawProducts(List<BannerCurationRawProduct> mappings) {

--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
@@ -3,6 +3,8 @@ package or.sopt.houme.domain.banner.model.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,6 +36,11 @@ public class Banner extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "banner_type", length = 20)
+    @Comment("콘텐츠 타입(BANNER, STYLE)")
+    private BannerType bannerType;
+
     @Column(name = "banner_image_url", nullable = false, length = 2048)
     @Comment("배너 대표 이미지 URL")
     private String bannerImageUrl;
@@ -42,7 +49,11 @@ public class Banner extends BaseEntity {
     @Comment("배너 타이틀")
     private String bannerTitle;
 
-    @Column(name = "style_question", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "style_description", columnDefinition = "TEXT")
+    @Comment("스타일 설명")
+    private String styleDescription;
+
+    @Column(name = "style_question", columnDefinition = "TEXT")
     @Comment("스타일 질문")
     private String styleQuestion;
 
@@ -51,7 +62,7 @@ public class Banner extends BaseEntity {
     private String stylePrompt;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "style_answer_chips_json", columnDefinition = "jsonb", nullable = false)
+    @Column(name = "style_answer_chips_json", columnDefinition = "jsonb")
     @Comment("스타일 답변 칩 목록 JSON")
     private String styleAnswerChipsJson;
 
@@ -60,15 +71,19 @@ public class Banner extends BaseEntity {
     private List<BannerCurationRawProduct> bannerRawProducts = new ArrayList<>();
 
     public static Banner create(
+            BannerType bannerType,
             String bannerImageUrl,
             String bannerTitle,
+            String styleDescription,
             String styleQuestion,
             String stylePrompt,
             String styleAnswerChipsJson
     ) {
         return Banner.builder()
+                .bannerType(bannerType)
                 .bannerImageUrl(bannerImageUrl)
                 .bannerTitle(bannerTitle)
+                .styleDescription(styleDescription)
                 .styleQuestion(styleQuestion)
                 .stylePrompt(stylePrompt)
                 .styleAnswerChipsJson(styleAnswerChipsJson)
@@ -76,14 +91,18 @@ public class Banner extends BaseEntity {
     }
 
     public void update(
+            BannerType bannerType,
             String bannerImageUrl,
             String bannerTitle,
+            String styleDescription,
             String styleQuestion,
             String stylePrompt,
             String styleAnswerChipsJson
     ) {
+        this.bannerType = bannerType;
         this.bannerImageUrl = bannerImageUrl;
         this.bannerTitle = bannerTitle;
+        this.styleDescription = styleDescription;
         this.styleQuestion = styleQuestion;
         this.stylePrompt = stylePrompt;
         this.styleAnswerChipsJson = styleAnswerChipsJson;

--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
@@ -1,0 +1,105 @@
+package or.sopt.houme.domain.banner.model.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.houme.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "banners")
+@Comment("스타일 배너 본체 정보")
+public class Banner extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "banner_image_url", nullable = false, length = 2048)
+    @Comment("배너 대표 이미지 URL")
+    private String bannerImageUrl;
+
+    @Column(name = "banner_title", nullable = false)
+    @Comment("배너 타이틀")
+    private String bannerTitle;
+
+    @Column(name = "style_question", nullable = false, columnDefinition = "TEXT")
+    @Comment("스타일 질문")
+    private String styleQuestion;
+
+    @Column(name = "style_prompt", nullable = false, columnDefinition = "TEXT")
+    @Comment("이미지 생성용 스타일 프롬프트")
+    private String stylePrompt;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "style_answer_chips_json", columnDefinition = "jsonb", nullable = false)
+    @Comment("스타일 답변 칩 목록 JSON")
+    private String styleAnswerChipsJson;
+
+    @Builder.Default
+    @Column(name = "is_exposed", nullable = false)
+    @Comment("노출 여부")
+    private Boolean isExposed = true;
+
+    @OneToMany(mappedBy = "banner", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<BannerCurationRawProduct> bannerRawProducts = new ArrayList<>();
+
+    public static Banner create(
+            String bannerImageUrl,
+            String bannerTitle,
+            String styleQuestion,
+            String stylePrompt,
+            String styleAnswerChipsJson,
+            Boolean isExposed
+    ) {
+        return Banner.builder()
+                .bannerImageUrl(bannerImageUrl)
+                .bannerTitle(bannerTitle)
+                .styleQuestion(styleQuestion)
+                .stylePrompt(stylePrompt)
+                .styleAnswerChipsJson(styleAnswerChipsJson)
+                .isExposed(isExposed == null ? Boolean.TRUE : isExposed)
+                .build();
+    }
+
+    public void update(
+            String bannerImageUrl,
+            String bannerTitle,
+            String styleQuestion,
+            String stylePrompt,
+            String styleAnswerChipsJson,
+            Boolean isExposed
+    ) {
+        this.bannerImageUrl = bannerImageUrl;
+        this.bannerTitle = bannerTitle;
+        this.styleQuestion = styleQuestion;
+        this.stylePrompt = stylePrompt;
+        this.styleAnswerChipsJson = styleAnswerChipsJson;
+        this.isExposed = isExposed;
+    }
+
+    public void replaceRawProducts(List<BannerCurationRawProduct> mappings) {
+        this.bannerRawProducts.clear();
+        this.bannerRawProducts.addAll(mappings);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/BannerCurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/BannerCurationRawProduct.java
@@ -1,0 +1,60 @@
+package or.sopt.houme.domain.banner.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+        name = "banner_curation_raw_products",
+        indexes = {
+                @Index(name = "idx_banner_raw_product_banner_id", columnList = "banner_id"),
+                @Index(name = "idx_banner_raw_product_raw_product_id", columnList = "curation_raw_product_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_banner_raw_product",
+                        columnNames = {"banner_id", "curation_raw_product_id"}
+                )
+        }
+)
+@Comment("배너와 원본 상품의 매핑 테이블")
+public class BannerCurationRawProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "banner_id", nullable = false)
+    private Banner banner;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "curation_raw_product_id", nullable = false)
+    private CurationRawProduct curationRawProduct;
+
+    public static BannerCurationRawProduct of(Banner banner, CurationRawProduct curationRawProduct) {
+        return BannerCurationRawProduct.builder()
+                .banner(banner)
+                .curationRawProduct(curationRawProduct)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/BannerType.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/BannerType.java
@@ -1,0 +1,6 @@
+package or.sopt.houme.domain.banner.model.entity;
+
+public enum BannerType {
+    BANNER,
+    STYLE
+}

--- a/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.banner.model.vo;
+
+public record BannerStyleAnswerChip(
+        Integer order,
+        String label,
+        Long curationRawProductId
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/banner/repository/BannerCurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/banner/repository/BannerCurationRawProductRepository.java
@@ -1,0 +1,22 @@
+package or.sopt.houme.domain.banner.repository;
+
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BannerCurationRawProductRepository extends JpaRepository<BannerCurationRawProduct, Long> {
+
+    @Query("""
+            select mapping
+            from BannerCurationRawProduct mapping
+            join fetch mapping.curationRawProduct rawProduct
+            where mapping.banner.id in :bannerIds
+            order by mapping.id asc
+            """)
+    List<BannerCurationRawProduct> findAllByBannerIdInWithRawProduct(@Param("bannerIds") List<Long> bannerIds);
+}

--- a/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepository.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.banner.repository;
 
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,15 +19,28 @@ public interface BannerRepository extends JpaRepository<Banner, Long> {
             left join fetch banner.bannerRawProducts mapping
             left join fetch mapping.curationRawProduct rawProduct
             where banner.id = :bannerId
+              and (
+                  banner.bannerType = :bannerType
+                  or (:includeLegacyBanner = true and banner.bannerType is null)
+              )
             """)
-    Optional<Banner> findByIdWithRawProducts(@Param("bannerId") Long bannerId);
+    Optional<Banner> findByIdWithRawProducts(
+            @Param("bannerId") Long bannerId,
+            @Param("bannerType") BannerType bannerType,
+            @Param("includeLegacyBanner") boolean includeLegacyBanner
+    );
 
     @Query("""
             select distinct banner
             from Banner banner
             left join fetch banner.bannerRawProducts mapping
             left join fetch mapping.curationRawProduct rawProduct
+            where banner.bannerType = :bannerType
+               or (:includeLegacyBanner = true and banner.bannerType is null)
             order by banner.id desc
             """)
-    List<Banner> findAllWithRawProducts();
+    List<Banner> findAllWithRawProducts(
+            @Param("bannerType") BannerType bannerType,
+            @Param("includeLegacyBanner") boolean includeLegacyBanner
+    );
 }

--- a/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,32 @@
+package or.sopt.houme.domain.banner.repository;
+
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    @Query("""
+            select distinct banner
+            from Banner banner
+            left join fetch banner.bannerRawProducts mapping
+            left join fetch mapping.curationRawProduct rawProduct
+            where banner.id = :bannerId
+            """)
+    Optional<Banner> findByIdWithRawProducts(@Param("bannerId") Long bannerId);
+
+    @Query("""
+            select distinct banner
+            from Banner banner
+            left join fetch banner.bannerRawProducts mapping
+            left join fetch mapping.curationRawProduct rawProduct
+            order by banner.id desc
+            """)
+    List<Banner> findAllWithRawProducts();
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -61,4 +61,19 @@ public interface CurationRawProductRepository extends JpaRepository<CurationRawP
             @Param("furnitureTag") FurnitureTag furnitureTag,
             @Param("productIds") List<Long> productIds
     );
+
+    @Query("""
+            select rawProduct
+            from CurationRawProduct rawProduct
+            where (:keyword is null
+                    or lower(rawProduct.productName) like lower(concat('%', :keyword, '%'))
+                    or lower(coalesce(rawProduct.brand, '')) like lower(concat('%', :keyword, '%'))
+                    or lower(rawProduct.source) like lower(concat('%', :keyword, '%'))
+                    or str(rawProduct.productId) like concat('%', :keyword, '%'))
+            order by rawProduct.id desc
+            """)
+    Page<CurationRawProduct> searchByKeyword(
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
@@ -27,13 +27,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/banners")
-@Tag(name = "어드민 스타일 배너 API")
+@Tag(name = "어드민 배너 API")
 public class AdminBannerController {
 
     private final AdminBannerService adminBannerService;
 
     @PostMapping("/image-upload-url")
-    @Operation(summary = "스타일 배너 이미지 업로드용 presigned url 생성 API")
+    @Operation(summary = "배너 이미지 업로드용 presigned url 생성 API")
     public ResponseEntity<ApiResponse<AdminBannerImageUploadResponse>> createBannerImageUploadUrl(
             @Valid @RequestBody AdminBannerImageUploadRequest request,
             @RequestParam("contentType") String contentType
@@ -42,7 +42,7 @@ public class AdminBannerController {
     }
 
     @PostMapping
-    @Operation(summary = "스타일 배너 생성 API")
+    @Operation(summary = "배너 생성 API")
     public ResponseEntity<ApiResponse<AdminBannerResponse>> createBanner(
             @Valid @RequestBody AdminBannerCreateRequest request
     ) {
@@ -50,19 +50,19 @@ public class AdminBannerController {
     }
 
     @GetMapping
-    @Operation(summary = "스타일 배너 목록 조회 API")
+    @Operation(summary = "배너 목록 조회 API")
     public ResponseEntity<ApiResponse<AdminBannerListResponse>> getBanners() {
         return ResponseEntity.ok(ApiResponse.ok(adminBannerService.getAll()));
     }
 
     @GetMapping("/{bannerId}")
-    @Operation(summary = "스타일 배너 상세 조회 API")
+    @Operation(summary = "배너 상세 조회 API")
     public ResponseEntity<ApiResponse<AdminBannerResponse>> getBanner(@PathVariable Long bannerId) {
         return ResponseEntity.ok(ApiResponse.ok(adminBannerService.getById(bannerId)));
     }
 
     @PatchMapping("/{bannerId}")
-    @Operation(summary = "스타일 배너 수정 API")
+    @Operation(summary = "배너 수정 API")
     public ResponseEntity<ApiResponse<AdminBannerResponse>> updateBanner(
             @PathVariable Long bannerId,
             @Valid @RequestBody AdminBannerUpdateRequest request
@@ -74,11 +74,11 @@ public class AdminBannerController {
     @Operation(summary = "스타일 배너 삭제 API")
     public ResponseEntity<ApiResponse<String>> deleteBanner(@PathVariable Long bannerId) {
         adminBannerService.delete(bannerId);
-        return ResponseEntity.ok(ApiResponse.ok("스타일 배너가 삭제되었습니다."));
+        return ResponseEntity.ok(ApiResponse.ok("배너가 삭제되었습니다."));
     }
 
     @GetMapping("/raw-products/search")
-    @Operation(summary = "스타일 배너용 RAW 상품 검색 API")
+    @Operation(summary = "배너용 RAW 상품 검색 API")
     public ResponseEntity<ApiResponse<AdminBannerRawProductSearchResponse>> searchRawProducts(
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "20") int size

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
@@ -29,6 +31,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminBannerController {
 
     private final AdminBannerService adminBannerService;
+
+    @PostMapping("/image-upload-url")
+    @Operation(summary = "스타일 배너 이미지 업로드용 presigned url 생성 API")
+    public ResponseEntity<ApiResponse<AdminBannerImageUploadResponse>> createBannerImageUploadUrl(
+            @Valid @RequestBody AdminBannerImageUploadRequest request,
+            @RequestParam("contentType") String contentType
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.createImageUploadUrl(request, contentType)));
+    }
 
     @PostMapping
     @Operation(summary = "스타일 배너 생성 API")

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
@@ -1,0 +1,77 @@
+package or.sopt.houme.domain.user.presentation.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+import or.sopt.houme.domain.user.service.admin.AdminBannerService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/banners")
+@Tag(name = "어드민 스타일 배너 API")
+public class AdminBannerController {
+
+    private final AdminBannerService adminBannerService;
+
+    @PostMapping
+    @Operation(summary = "스타일 배너 생성 API")
+    public ResponseEntity<ApiResponse<AdminBannerResponse>> createBanner(
+            @Valid @RequestBody AdminBannerCreateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.create(request)));
+    }
+
+    @GetMapping
+    @Operation(summary = "스타일 배너 목록 조회 API")
+    public ResponseEntity<ApiResponse<AdminBannerListResponse>> getBanners() {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.getAll()));
+    }
+
+    @GetMapping("/{bannerId}")
+    @Operation(summary = "스타일 배너 상세 조회 API")
+    public ResponseEntity<ApiResponse<AdminBannerResponse>> getBanner(@PathVariable Long bannerId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.getById(bannerId)));
+    }
+
+    @PatchMapping("/{bannerId}")
+    @Operation(summary = "스타일 배너 수정 API")
+    public ResponseEntity<ApiResponse<AdminBannerResponse>> updateBanner(
+            @PathVariable Long bannerId,
+            @Valid @RequestBody AdminBannerUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.update(bannerId, request)));
+    }
+
+    @DeleteMapping("/{bannerId}")
+    @Operation(summary = "스타일 배너 삭제 API")
+    public ResponseEntity<ApiResponse<String>> deleteBanner(@PathVariable Long bannerId) {
+        adminBannerService.delete(bannerId);
+        return ResponseEntity.ok(ApiResponse.ok("스타일 배너가 삭제되었습니다."));
+    }
+
+    @GetMapping("/raw-products/search")
+    @Operation(summary = "스타일 배너용 RAW 상품 검색 API")
+    public ResponseEntity<ApiResponse<AdminBannerRawProductSearchResponse>> searchRawProducts(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminBannerService.searchRawProducts(keyword, size)));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerController.java
@@ -14,6 +14,7 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.respon
 import or.sopt.houme.domain.user.service.admin.AdminBannerService;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/banners")
 @Tag(name = "어드민 배너 API")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminBannerController {
 
     private final AdminBannerService adminBannerService;

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleController.java
@@ -1,0 +1,88 @@
+package or.sopt.houme.domain.user.presentation.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleResponse;
+import or.sopt.houme.domain.user.service.admin.AdminStyleService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/styles")
+@Tag(name = "어드민 스타일 API")
+public class AdminStyleController {
+
+    private final AdminStyleService adminStyleService;
+
+    @PostMapping("/image-upload-url")
+    @Operation(summary = "스타일 이미지 업로드용 presigned url 생성 API")
+    public ResponseEntity<ApiResponse<AdminBannerImageUploadResponse>> createStyleImageUploadUrl(
+            @Valid @RequestBody AdminBannerImageUploadRequest request,
+            @RequestParam("contentType") String contentType
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.createImageUploadUrl(request, contentType)));
+    }
+
+    @PostMapping
+    @Operation(summary = "스타일 생성 API")
+    public ResponseEntity<ApiResponse<AdminStyleResponse>> createStyle(
+            @Valid @RequestBody AdminStyleCreateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.create(request)));
+    }
+
+    @GetMapping
+    @Operation(summary = "스타일 목록 조회 API")
+    public ResponseEntity<ApiResponse<AdminStyleListResponse>> getStyles() {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.getAll()));
+    }
+
+    @GetMapping("/{styleId}")
+    @Operation(summary = "스타일 상세 조회 API")
+    public ResponseEntity<ApiResponse<AdminStyleResponse>> getStyle(@PathVariable Long styleId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.getById(styleId)));
+    }
+
+    @PatchMapping("/{styleId}")
+    @Operation(summary = "스타일 수정 API")
+    public ResponseEntity<ApiResponse<AdminStyleResponse>> updateStyle(
+            @PathVariable Long styleId,
+            @Valid @RequestBody AdminStyleUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.update(styleId, request)));
+    }
+
+    @DeleteMapping("/{styleId}")
+    @Operation(summary = "스타일 삭제 API")
+    public ResponseEntity<ApiResponse<String>> deleteStyle(@PathVariable Long styleId) {
+        adminStyleService.delete(styleId);
+        return ResponseEntity.ok(ApiResponse.ok("스타일이 삭제되었습니다."));
+    }
+
+    @GetMapping("/raw-products/search")
+    @Operation(summary = "스타일용 RAW 상품 검색 API")
+    public ResponseEntity<ApiResponse<AdminBannerRawProductSearchResponse>> searchRawProducts(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminStyleService.searchRawProducts(keyword, size)));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleController.java
@@ -14,6 +14,7 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.respons
 import or.sopt.houme.domain.user.service.admin.AdminStyleService;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/styles")
 @Tag(name = "어드민 스타일 API")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminStyleController {
 
     private final AdminStyleService adminStyleService;

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
@@ -1,0 +1,19 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AdminBannerCreateRequest(
+        @NotBlank String bannerImageUrl,
+        @NotBlank String bannerTitle,
+        @NotBlank String styleQuestion,
+        @NotBlank String stylePrompt,
+        @NotNull @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,
+        @NotNull List<Long> mappedRawProductIds,
+        @NotNull Boolean isExposed
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record AdminBannerCreateRequest(
         @NotBlank String bannerImageUrl,
         @NotBlank String bannerTitle,
+        @NotBlank String styleDescription,
         @NotBlank String styleQuestion,
         @NotBlank String stylePrompt,
         @NotNull @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerCreateRequest.java
@@ -13,7 +13,6 @@ public record AdminBannerCreateRequest(
         @NotBlank String styleQuestion,
         @NotBlank String stylePrompt,
         @NotNull @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,
-        @NotNull List<Long> mappedRawProductIds,
-        @NotNull Boolean isExposed
+        @NotNull List<Long> mappedRawProductIds
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerImageUploadRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerImageUploadRequest.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminBannerImageUploadRequest(
+        @NotBlank String imageExtension
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminBannerStyleAnswerChipRequest(
+        @NotNull Integer order,
+        @NotBlank String label,
+        @NotNull Long curationRawProductId
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
@@ -1,9 +1,13 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record AdminBannerStyleAnswerChipRequest(
+        @Min(1)
+        @Max(4)
         @NotNull Integer order,
         @NotBlank String label,
         @NotNull Long curationRawProductId

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
@@ -11,7 +11,6 @@ public record AdminBannerUpdateRequest(
         String styleQuestion,
         String stylePrompt,
         @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,
-        List<Long> mappedRawProductIds,
-        Boolean isExposed
+        List<Long> mappedRawProductIds
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
@@ -1,0 +1,17 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AdminBannerUpdateRequest(
+        String bannerImageUrl,
+        String bannerTitle,
+        String styleQuestion,
+        String stylePrompt,
+        @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,
+        List<Long> mappedRawProductIds,
+        Boolean isExposed
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerUpdateRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record AdminBannerUpdateRequest(
         String bannerImageUrl,
         String bannerTitle,
+        String styleDescription,
         String styleQuestion,
         String stylePrompt,
         @Size(max = 4) List<@Valid AdminBannerStyleAnswerChipRequest> styleAnswerChips,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerImageUploadResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerImageUploadResponse.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+public record AdminBannerImageUploadResponse(
+        String uploadUrl,
+        String publicUrl
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerListResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+import java.util.List;
+
+public record AdminBannerListResponse(
+        List<AdminBannerResponse> banners
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerMappedRawProductResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerMappedRawProductResponse.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+public record AdminBannerMappedRawProductResponse(
+        Long id,
+        String source,
+        SoozipCategory category,
+        Long productId,
+        String productName,
+        String productImageUrl,
+        String brand
+) {
+    public static AdminBannerMappedRawProductResponse of(CurationRawProduct rawProduct) {
+        return new AdminBannerMappedRawProductResponse(
+                rawProduct.getId(),
+                rawProduct.getSource(),
+                rawProduct.getCategory(),
+                rawProduct.getProductId(),
+                rawProduct.getProductName(),
+                rawProduct.getProductImageUrl(),
+                rawProduct.getBrand()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerRawProductSearchResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerRawProductSearchResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+import java.util.List;
+
+public record AdminBannerRawProductSearchResponse(
+        List<AdminBannerMappedRawProductResponse> rawProducts
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerResponse.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminBannerResponse(
+        Long id,
+        String bannerImageUrl,
+        String bannerTitle,
+        String styleQuestion,
+        String stylePrompt,
+        Boolean isExposed,
+        List<AdminBannerStyleAnswerChipResponse> styleAnswerChips,
+        List<AdminBannerMappedRawProductResponse> mappedRawProducts,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerResponse.java
@@ -9,7 +9,6 @@ public record AdminBannerResponse(
         String bannerTitle,
         String styleQuestion,
         String stylePrompt,
-        Boolean isExposed,
         List<AdminBannerStyleAnswerChipResponse> styleAnswerChips,
         List<AdminBannerMappedRawProductResponse> mappedRawProducts,
         LocalDateTime createdAt,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+
+public record AdminBannerStyleAnswerChipResponse(
+        Integer order,
+        String label,
+        Long curationRawProductId,
+        String curationRawProductName,
+        String curationRawProductImageUrl
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/request/AdminStyleCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/request/AdminStyleCreateRequest.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record AdminStyleCreateRequest(
+        @NotBlank String bannerImageUrl,
+        @NotBlank String bannerTitle,
+        @NotBlank String styleDescription,
+        @NotBlank String stylePrompt,
+        @NotNull List<Long> mappedRawProductIds
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/request/AdminStyleUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/request/AdminStyleUpdateRequest.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request;
+
+import java.util.List;
+
+public record AdminStyleUpdateRequest(
+        String bannerImageUrl,
+        String bannerTitle,
+        String styleDescription,
+        String stylePrompt,
+        List<Long> mappedRawProductIds
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/response/AdminStyleListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/response/AdminStyleListResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response;
+
+import java.util.List;
+
+public record AdminStyleListResponse(
+        List<AdminStyleResponse> styles
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/response/AdminStyleResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/style/response/AdminStyleResponse.java
@@ -1,16 +1,16 @@
-package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response;
+
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record AdminBannerResponse(
+public record AdminStyleResponse(
         Long id,
         String bannerImageUrl,
         String bannerTitle,
         String styleDescription,
-        String styleQuestion,
         String stylePrompt,
-        List<AdminBannerStyleAnswerChipResponse> styleAnswerChips,
         List<AdminBannerMappedRawProductResponse> mappedRawProducts,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerService.java
@@ -1,0 +1,21 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+
+public interface AdminBannerService {
+    AdminBannerResponse create(AdminBannerCreateRequest request);
+
+    AdminBannerListResponse getAll();
+
+    AdminBannerResponse getById(Long bannerId);
+
+    AdminBannerResponse update(Long bannerId, AdminBannerUpdateRequest request);
+
+    void delete(Long bannerId);
+
+    AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size);
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerService.java
@@ -1,12 +1,16 @@
 package or.sopt.houme.domain.user.service.admin;
 
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
 
 public interface AdminBannerService {
+    AdminBannerImageUploadResponse createImageUploadUrl(AdminBannerImageUploadRequest request, String contentType);
+
     AdminBannerResponse create(AdminBannerCreateRequest request);
 
     AdminBannerListResponse getAll();

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -1,0 +1,322 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
+import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerStyleAnswerChipResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminBannerServiceImpl implements AdminBannerService {
+
+    private static final int MAX_STYLE_ANSWER_CHIPS = 4;
+    private static final int MAX_SEARCH_SIZE = 50;
+    private static final TypeReference<List<BannerStyleAnswerChip>> STYLE_ANSWER_CHIP_TYPE = new TypeReference<>() {};
+
+    private final BannerRepository bannerRepository;
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public AdminBannerResponse create(AdminBannerCreateRequest request) {
+        List<BannerStyleAnswerChip> styleAnswerChips = normalizeStyleAnswerChips(request.styleAnswerChips());
+        Map<Long, CurationRawProduct> requiredRawProducts = loadRequiredRawProducts(
+                extractAllRawProductIds(styleAnswerChips, request.mappedRawProductIds())
+        );
+
+        Banner banner = Banner.create(
+                normalizeRequired(request.bannerImageUrl()),
+                normalizeRequired(request.bannerTitle()),
+                normalizeRequired(request.styleQuestion()),
+                normalizeRequired(request.stylePrompt()),
+                toStyleAnswerChipsJson(styleAnswerChips),
+                request.isExposed()
+        );
+        banner.replaceRawProducts(buildMappings(banner, request.mappedRawProductIds(), requiredRawProducts));
+        Banner savedBanner = bannerRepository.saveAndFlush(banner);
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId())
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
+        return buildResponse(savedWithRawProducts, requiredRawProducts);
+    }
+
+    @Override
+    public AdminBannerListResponse getAll() {
+        List<Banner> banners = bannerRepository.findAllWithRawProducts();
+        return new AdminBannerListResponse(buildResponses(banners));
+    }
+
+    @Override
+    public AdminBannerResponse getById(Long bannerId) {
+        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
+        return buildResponses(List.of(banner)).getFirst();
+    }
+
+    @Override
+    @Transactional
+    public AdminBannerResponse update(Long bannerId, AdminBannerUpdateRequest request) {
+        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
+
+        List<BannerStyleAnswerChip> currentChips = parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
+        List<BannerStyleAnswerChip> targetChips = request.styleAnswerChips() != null
+                ? normalizeStyleAnswerChips(request.styleAnswerChips())
+                : currentChips;
+
+        List<Long> currentMappedRawProductIds = banner.getBannerRawProducts().stream()
+                .map(BannerCurationRawProduct::getCurationRawProduct)
+                .filter(Objects::nonNull)
+                .map(CurationRawProduct::getId)
+                .toList();
+        List<Long> targetMappedRawProductIds = request.mappedRawProductIds() != null
+                ? request.mappedRawProductIds()
+                : currentMappedRawProductIds;
+
+        Map<Long, CurationRawProduct> requiredRawProducts = loadRequiredRawProducts(
+                extractAllRawProductIds(targetChips, targetMappedRawProductIds)
+        );
+
+        banner.update(
+                request.bannerImageUrl() != null ? normalizeRequired(request.bannerImageUrl()) : banner.getBannerImageUrl(),
+                request.bannerTitle() != null ? normalizeRequired(request.bannerTitle()) : banner.getBannerTitle(),
+                request.styleQuestion() != null ? normalizeRequired(request.styleQuestion()) : banner.getStyleQuestion(),
+                request.stylePrompt() != null ? normalizeRequired(request.stylePrompt()) : banner.getStylePrompt(),
+                toStyleAnswerChipsJson(targetChips),
+                request.isExposed() != null ? request.isExposed() : banner.getIsExposed()
+        );
+        banner.replaceRawProducts(buildMappings(banner, targetMappedRawProductIds, requiredRawProducts));
+
+        Banner savedBanner = bannerRepository.saveAndFlush(banner);
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId())
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
+        return buildResponse(savedWithRawProducts, requiredRawProducts);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long bannerId) {
+        Banner banner = bannerRepository.findById(bannerId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
+        bannerRepository.delete(banner);
+        bannerRepository.flush();
+    }
+
+    @Override
+    public AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size) {
+        String normalizedKeyword = normalizeOptional(keyword);
+        int normalizedSize = Math.min(Math.max(size, 1), MAX_SEARCH_SIZE);
+        List<AdminBannerMappedRawProductResponse> rawProducts = curationRawProductRepository.searchByKeyword(
+                        normalizedKeyword,
+                        PageRequest.of(0, normalizedSize)
+                ).getContent().stream()
+                .map(AdminBannerMappedRawProductResponse::of)
+                .toList();
+        return new AdminBannerRawProductSearchResponse(rawProducts);
+    }
+
+    private List<AdminBannerResponse> buildResponses(List<Banner> banners) {
+        Map<Long, CurationRawProduct> rawProductMap = loadRequiredRawProducts(
+                banners.stream()
+                        .flatMap(banner -> extractAllRawProductIds(
+                                parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson()),
+                                banner.getBannerRawProducts().stream()
+                                        .map(BannerCurationRawProduct::getCurationRawProduct)
+                                        .filter(Objects::nonNull)
+                                        .map(CurationRawProduct::getId)
+                                        .toList()
+                        ).stream())
+                        .toList()
+        );
+        return banners.stream()
+                .map(banner -> buildResponse(banner, rawProductMap))
+                .toList();
+    }
+
+    private AdminBannerResponse buildResponse(Banner banner, Map<Long, CurationRawProduct> rawProductMap) {
+        List<BannerStyleAnswerChip> styleAnswerChips = parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
+        List<AdminBannerStyleAnswerChipResponse> chipResponses = styleAnswerChips.stream()
+                .map(chip -> {
+                    CurationRawProduct rawProduct = rawProductMap.get(chip.curationRawProductId());
+                    return new AdminBannerStyleAnswerChipResponse(
+                            chip.order(),
+                            chip.label(),
+                            chip.curationRawProductId(),
+                            rawProduct != null ? rawProduct.getProductName() : null,
+                            rawProduct != null ? rawProduct.getProductImageUrl() : null
+                    );
+                })
+                .toList();
+
+        List<AdminBannerMappedRawProductResponse> mappedRawProducts = banner.getBannerRawProducts().stream()
+                .map(BannerCurationRawProduct::getCurationRawProduct)
+                .filter(Objects::nonNull)
+                .map(rawProduct -> rawProductMap.getOrDefault(rawProduct.getId(), rawProduct))
+                .map(AdminBannerMappedRawProductResponse::of)
+                .toList();
+
+        return new AdminBannerResponse(
+                banner.getId(),
+                banner.getBannerImageUrl(),
+                banner.getBannerTitle(),
+                banner.getStyleQuestion(),
+                banner.getStylePrompt(),
+                banner.getIsExposed(),
+                chipResponses,
+                mappedRawProducts,
+                banner.getCreatedAt(),
+                banner.getUpdatedAt()
+        );
+    }
+
+    private List<BannerCurationRawProduct> buildMappings(
+            Banner banner,
+            List<Long> mappedRawProductIds,
+            Map<Long, CurationRawProduct> rawProductMap
+    ) {
+        return deduplicateIds(mappedRawProductIds).stream()
+                .map(rawProductId -> BannerCurationRawProduct.of(banner, rawProductMap.get(rawProductId)))
+                .toList();
+    }
+
+    private Map<Long, CurationRawProduct> loadRequiredRawProducts(List<Long> rawProductIds) {
+        List<Long> normalizedRawProductIds = deduplicateIds(rawProductIds);
+        if (normalizedRawProductIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<CurationRawProduct> rawProducts = curationRawProductRepository.findAllById(normalizedRawProductIds);
+        Map<Long, CurationRawProduct> rawProductMap = rawProducts.stream()
+                .collect(Collectors.toMap(CurationRawProduct::getId, rawProduct -> rawProduct, (left, right) -> left, LinkedHashMap::new));
+
+        if (rawProductMap.size() != normalizedRawProductIds.size()) {
+            throw new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT);
+        }
+        return rawProductMap;
+    }
+
+    private List<Long> extractAllRawProductIds(List<BannerStyleAnswerChip> styleAnswerChips, List<Long> mappedRawProductIds) {
+        List<Long> rawProductIds = new ArrayList<>();
+        if (styleAnswerChips != null) {
+            rawProductIds.addAll(styleAnswerChips.stream()
+                    .map(BannerStyleAnswerChip::curationRawProductId)
+                    .toList());
+        }
+        if (mappedRawProductIds != null) {
+            rawProductIds.addAll(mappedRawProductIds);
+        }
+        return rawProductIds;
+    }
+
+    private List<BannerStyleAnswerChip> normalizeStyleAnswerChips(List<AdminBannerStyleAnswerChipRequest> requests) {
+        if (requests == null) {
+            return List.of();
+        }
+        if (requests.size() > MAX_STYLE_ANSWER_CHIPS) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        List<BannerStyleAnswerChip> chips = requests.stream()
+                .map(request -> new BannerStyleAnswerChip(
+                        request.order(),
+                        normalizeRequired(request.label()),
+                        request.curationRawProductId()
+                ))
+                .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
+                .toList();
+
+        Set<Integer> orders = new LinkedHashSet<>();
+        for (BannerStyleAnswerChip chip : chips) {
+            if (chip.order() == null || chip.order() < 1) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+            if (!orders.add(chip.order())) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+            if (chip.curationRawProductId() == null) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+        }
+        return chips;
+    }
+
+    private String toStyleAnswerChipsJson(List<BannerStyleAnswerChip> chips) {
+        try {
+            return objectMapper.writeValueAsString(chips == null ? List.of() : chips);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    private List<BannerStyleAnswerChip> parseStyleAnswerChipsJson(String styleAnswerChipsJson) {
+        if (styleAnswerChipsJson == null || styleAnswerChipsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<BannerStyleAnswerChip> chips = objectMapper.readValue(styleAnswerChipsJson, STYLE_ANSWER_CHIP_TYPE);
+            return chips == null ? List.of() : chips.stream()
+                    .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
+                    .toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    private List<Long> deduplicateIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ids.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        ArrayList::new
+                ));
+    }
+
+    private String normalizeRequired(String value) {
+        String normalized = normalizeOptional(value);
+        if (normalized == null) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        return normalized;
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -1,98 +1,73 @@
 package or.sopt.houme.domain.user.service.admin;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.banner.model.entity.Banner;
-import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
-import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerStyleAnswerChipResponse;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
-import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
-import or.sopt.houme.global.util.S3PresignedUtil;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminBannerServiceImpl implements AdminBannerService {
 
-    private static final int MAX_STYLE_ANSWER_CHIPS = 4;
-    private static final int MAX_SEARCH_SIZE = 50;
-    private static final TypeReference<List<BannerStyleAnswerChip>> STYLE_ANSWER_CHIP_TYPE = new TypeReference<>() {};
-
     private final BannerRepository bannerRepository;
-    private final CurationRawProductRepository curationRawProductRepository;
-    private final ObjectMapper objectMapper;
-    private final S3PresignedUtil s3PresignedUtil;
+    private final AdminBannerSupport adminBannerSupport;
 
     @Override
     public AdminBannerImageUploadResponse createImageUploadUrl(AdminBannerImageUploadRequest request, String contentType) {
-        S3PresignedUrlResponseDTO presignedUrl = s3PresignedUtil.createPresignedUrl(
-                normalizeRequired(request.imageExtension()),
-                "banner",
-                contentType
-        );
-        return new AdminBannerImageUploadResponse(presignedUrl.uploadUrl(), presignedUrl.publicUrl());
+        return adminBannerSupport.createImageUploadUrl(request, contentType, "banner");
     }
 
     @Override
     @Transactional
     public AdminBannerResponse create(AdminBannerCreateRequest request) {
-        List<BannerStyleAnswerChip> styleAnswerChips = normalizeStyleAnswerChips(request.styleAnswerChips());
-        Map<Long, CurationRawProduct> requiredRawProducts = loadRequiredRawProducts(
-                extractAllRawProductIds(styleAnswerChips, request.mappedRawProductIds())
+        List<BannerStyleAnswerChip> styleAnswerChips = adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips());
+        Map<Long, CurationRawProduct> requiredRawProducts = adminBannerSupport.loadRequiredRawProducts(
+                adminBannerSupport.extractAllRawProductIds(styleAnswerChips, request.mappedRawProductIds())
         );
 
         Banner banner = Banner.create(
-                normalizeRequired(request.bannerImageUrl()),
-                normalizeRequired(request.bannerTitle()),
-                normalizeRequired(request.styleQuestion()),
-                normalizeRequired(request.stylePrompt()),
-                toStyleAnswerChipsJson(styleAnswerChips)
+                BannerType.BANNER,
+                adminBannerSupport.normalizeRequired(request.bannerImageUrl()),
+                adminBannerSupport.normalizeRequired(request.bannerTitle()),
+                adminBannerSupport.normalizeRequired(request.styleDescription()),
+                adminBannerSupport.normalizeRequired(request.styleQuestion()),
+                adminBannerSupport.normalizeRequired(request.stylePrompt()),
+                adminBannerSupport.toStyleAnswerChipsJson(styleAnswerChips)
         );
-        banner.replaceRawProducts(buildMappings(banner, request.mappedRawProductIds(), requiredRawProducts));
+        banner.replaceRawProducts(adminBannerSupport.buildMappings(banner, request.mappedRawProductIds(), requiredRawProducts));
         Banner savedBanner = bannerRepository.saveAndFlush(banner);
-        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId())
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId(), BannerType.BANNER, true)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
         return buildResponse(savedWithRawProducts, requiredRawProducts);
     }
 
     @Override
     public AdminBannerListResponse getAll() {
-        List<Banner> banners = bannerRepository.findAllWithRawProducts();
+        List<Banner> banners = bannerRepository.findAllWithRawProducts(BannerType.BANNER, true);
         return new AdminBannerListResponse(buildResponses(banners));
     }
 
     @Override
     public AdminBannerResponse getById(Long bannerId) {
-        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId)
+        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId, BannerType.BANNER, true)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
         return buildResponses(List.of(banner)).getFirst();
     }
@@ -100,38 +75,36 @@ public class AdminBannerServiceImpl implements AdminBannerService {
     @Override
     @Transactional
     public AdminBannerResponse update(Long bannerId, AdminBannerUpdateRequest request) {
-        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId)
+        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId, BannerType.BANNER, true)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
 
-        List<BannerStyleAnswerChip> currentChips = parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
+        List<BannerStyleAnswerChip> currentChips = adminBannerSupport.parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
         List<BannerStyleAnswerChip> targetChips = request.styleAnswerChips() != null
-                ? normalizeStyleAnswerChips(request.styleAnswerChips())
+                ? adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips())
                 : currentChips;
 
-        List<Long> currentMappedRawProductIds = banner.getBannerRawProducts().stream()
-                .map(BannerCurationRawProduct::getCurationRawProduct)
-                .filter(Objects::nonNull)
-                .map(CurationRawProduct::getId)
-                .toList();
+        List<Long> currentMappedRawProductIds = adminBannerSupport.extractMappedRawProductIds(banner);
         List<Long> targetMappedRawProductIds = request.mappedRawProductIds() != null
                 ? request.mappedRawProductIds()
                 : currentMappedRawProductIds;
 
-        Map<Long, CurationRawProduct> requiredRawProducts = loadRequiredRawProducts(
-                extractAllRawProductIds(targetChips, targetMappedRawProductIds)
+        Map<Long, CurationRawProduct> requiredRawProducts = adminBannerSupport.loadRequiredRawProducts(
+                adminBannerSupport.extractAllRawProductIds(targetChips, targetMappedRawProductIds)
         );
 
         banner.update(
-                request.bannerImageUrl() != null ? normalizeRequired(request.bannerImageUrl()) : banner.getBannerImageUrl(),
-                request.bannerTitle() != null ? normalizeRequired(request.bannerTitle()) : banner.getBannerTitle(),
-                request.styleQuestion() != null ? normalizeRequired(request.styleQuestion()) : banner.getStyleQuestion(),
-                request.stylePrompt() != null ? normalizeRequired(request.stylePrompt()) : banner.getStylePrompt(),
-                toStyleAnswerChipsJson(targetChips)
+                BannerType.BANNER,
+                request.bannerImageUrl() != null ? adminBannerSupport.normalizeRequired(request.bannerImageUrl()) : banner.getBannerImageUrl(),
+                request.bannerTitle() != null ? adminBannerSupport.normalizeRequired(request.bannerTitle()) : banner.getBannerTitle(),
+                request.styleDescription() != null ? adminBannerSupport.normalizeRequired(request.styleDescription()) : banner.getStyleDescription(),
+                request.styleQuestion() != null ? adminBannerSupport.normalizeRequired(request.styleQuestion()) : banner.getStyleQuestion(),
+                request.stylePrompt() != null ? adminBannerSupport.normalizeRequired(request.stylePrompt()) : banner.getStylePrompt(),
+                adminBannerSupport.toStyleAnswerChipsJson(targetChips)
         );
-        banner.replaceRawProducts(buildMappings(banner, targetMappedRawProductIds, requiredRawProducts));
+        banner.replaceRawProducts(adminBannerSupport.buildMappings(banner, targetMappedRawProductIds, requiredRawProducts));
 
         Banner savedBanner = bannerRepository.saveAndFlush(banner);
-        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId())
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedBanner.getId(), BannerType.BANNER, true)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
         return buildResponse(savedWithRawProducts, requiredRawProducts);
     }
@@ -139,7 +112,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
     @Override
     @Transactional
     public void delete(Long bannerId) {
-        Banner banner = bannerRepository.findById(bannerId)
+        Banner banner = bannerRepository.findByIdWithRawProducts(bannerId, BannerType.BANNER, true)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_BANNER));
         bannerRepository.delete(banner);
         bannerRepository.flush();
@@ -147,37 +120,18 @@ public class AdminBannerServiceImpl implements AdminBannerService {
 
     @Override
     public AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size) {
-        String normalizedKeyword = normalizeOptional(keyword);
-        int normalizedSize = Math.min(Math.max(size, 1), MAX_SEARCH_SIZE);
-        List<AdminBannerMappedRawProductResponse> rawProducts = curationRawProductRepository.searchByKeyword(
-                        normalizedKeyword,
-                        PageRequest.of(0, normalizedSize)
-                ).getContent().stream()
-                .map(AdminBannerMappedRawProductResponse::of)
-                .toList();
-        return new AdminBannerRawProductSearchResponse(rawProducts);
+        return adminBannerSupport.searchRawProducts(keyword, size);
     }
 
     private List<AdminBannerResponse> buildResponses(List<Banner> banners) {
-        Map<Long, CurationRawProduct> rawProductMap = loadRequiredRawProducts(
-                banners.stream()
-                        .flatMap(banner -> extractAllRawProductIds(
-                                parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson()),
-                                banner.getBannerRawProducts().stream()
-                                        .map(BannerCurationRawProduct::getCurationRawProduct)
-                                        .filter(Objects::nonNull)
-                                        .map(CurationRawProduct::getId)
-                                        .toList()
-                        ).stream())
-                        .toList()
-        );
+        Map<Long, CurationRawProduct> rawProductMap = adminBannerSupport.loadRequiredRawProductsForBanners(banners);
         return banners.stream()
                 .map(banner -> buildResponse(banner, rawProductMap))
                 .toList();
     }
 
     private AdminBannerResponse buildResponse(Banner banner, Map<Long, CurationRawProduct> rawProductMap) {
-        List<BannerStyleAnswerChip> styleAnswerChips = parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
+        List<BannerStyleAnswerChip> styleAnswerChips = adminBannerSupport.parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
         List<AdminBannerStyleAnswerChipResponse> chipResponses = styleAnswerChips.stream()
                 .map(chip -> {
                     CurationRawProduct rawProduct = rawProductMap.get(chip.curationRawProductId());
@@ -191,144 +145,17 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 })
                 .toList();
 
-        List<AdminBannerMappedRawProductResponse> mappedRawProducts = banner.getBannerRawProducts().stream()
-                .map(BannerCurationRawProduct::getCurationRawProduct)
-                .filter(Objects::nonNull)
-                .map(rawProduct -> rawProductMap.getOrDefault(rawProduct.getId(), rawProduct))
-                .map(AdminBannerMappedRawProductResponse::of)
-                .toList();
-
         return new AdminBannerResponse(
                 banner.getId(),
                 banner.getBannerImageUrl(),
                 banner.getBannerTitle(),
+                banner.getStyleDescription(),
                 banner.getStyleQuestion(),
                 banner.getStylePrompt(),
                 chipResponses,
-                mappedRawProducts,
+                adminBannerSupport.toMappedRawProductResponses(banner, rawProductMap),
                 banner.getCreatedAt(),
                 banner.getUpdatedAt()
         );
-    }
-
-    private List<BannerCurationRawProduct> buildMappings(
-            Banner banner,
-            List<Long> mappedRawProductIds,
-            Map<Long, CurationRawProduct> rawProductMap
-    ) {
-        return deduplicateIds(mappedRawProductIds).stream()
-                .map(rawProductId -> BannerCurationRawProduct.of(banner, rawProductMap.get(rawProductId)))
-                .toList();
-    }
-
-    private Map<Long, CurationRawProduct> loadRequiredRawProducts(List<Long> rawProductIds) {
-        List<Long> normalizedRawProductIds = deduplicateIds(rawProductIds);
-        if (normalizedRawProductIds.isEmpty()) {
-            return Map.of();
-        }
-
-        List<CurationRawProduct> rawProducts = curationRawProductRepository.findAllById(normalizedRawProductIds);
-        Map<Long, CurationRawProduct> rawProductMap = rawProducts.stream()
-                .collect(Collectors.toMap(CurationRawProduct::getId, rawProduct -> rawProduct, (left, right) -> left, LinkedHashMap::new));
-
-        if (rawProductMap.size() != normalizedRawProductIds.size()) {
-            throw new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT);
-        }
-        return rawProductMap;
-    }
-
-    private List<Long> extractAllRawProductIds(List<BannerStyleAnswerChip> styleAnswerChips, List<Long> mappedRawProductIds) {
-        List<Long> rawProductIds = new ArrayList<>();
-        if (styleAnswerChips != null) {
-            rawProductIds.addAll(styleAnswerChips.stream()
-                    .map(BannerStyleAnswerChip::curationRawProductId)
-                    .toList());
-        }
-        if (mappedRawProductIds != null) {
-            rawProductIds.addAll(mappedRawProductIds);
-        }
-        return rawProductIds;
-    }
-
-    private List<BannerStyleAnswerChip> normalizeStyleAnswerChips(List<AdminBannerStyleAnswerChipRequest> requests) {
-        if (requests == null) {
-            return List.of();
-        }
-        if (requests.size() > MAX_STYLE_ANSWER_CHIPS) {
-            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-        }
-
-        List<BannerStyleAnswerChip> chips = requests.stream()
-                .map(request -> new BannerStyleAnswerChip(
-                        request.order(),
-                        normalizeRequired(request.label()),
-                        request.curationRawProductId()
-                ))
-                .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
-                .toList();
-
-        Set<Integer> orders = new LinkedHashSet<>();
-        for (BannerStyleAnswerChip chip : chips) {
-            if (chip.order() == null || chip.order() < 1) {
-                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-            }
-            if (!orders.add(chip.order())) {
-                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-            }
-            if (chip.curationRawProductId() == null) {
-                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-            }
-        }
-        return chips;
-    }
-
-    private String toStyleAnswerChipsJson(List<BannerStyleAnswerChip> chips) {
-        try {
-            return objectMapper.writeValueAsString(chips == null ? List.of() : chips);
-        } catch (JsonProcessingException e) {
-            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
-        }
-    }
-
-    private List<BannerStyleAnswerChip> parseStyleAnswerChipsJson(String styleAnswerChipsJson) {
-        if (styleAnswerChipsJson == null || styleAnswerChipsJson.isBlank()) {
-            return List.of();
-        }
-        try {
-            List<BannerStyleAnswerChip> chips = objectMapper.readValue(styleAnswerChipsJson, STYLE_ANSWER_CHIP_TYPE);
-            return chips == null ? List.of() : chips.stream()
-                    .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
-                    .toList();
-        } catch (JsonProcessingException e) {
-            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
-        }
-    }
-
-    private List<Long> deduplicateIds(List<Long> ids) {
-        if (ids == null || ids.isEmpty()) {
-            return List.of();
-        }
-        return ids.stream()
-                .filter(Objects::nonNull)
-                .collect(Collectors.collectingAndThen(
-                        Collectors.toCollection(LinkedHashSet::new),
-                        ArrayList::new
-                ));
-    }
-
-    private String normalizeRequired(String value) {
-        String normalized = normalizeOptional(value);
-        if (normalized == null) {
-            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-        }
-        return normalized;
-    }
-
-    private String normalizeOptional(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -11,8 +11,10 @@ import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
@@ -20,6 +22,8 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.respon
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerStyleAnswerChipResponse;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
+import or.sopt.houme.global.util.S3PresignedUtil;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +50,17 @@ public class AdminBannerServiceImpl implements AdminBannerService {
     private final BannerRepository bannerRepository;
     private final CurationRawProductRepository curationRawProductRepository;
     private final ObjectMapper objectMapper;
+    private final S3PresignedUtil s3PresignedUtil;
+
+    @Override
+    public AdminBannerImageUploadResponse createImageUploadUrl(AdminBannerImageUploadRequest request, String contentType) {
+        S3PresignedUrlResponseDTO presignedUrl = s3PresignedUtil.createPresignedUrl(
+                normalizeRequired(request.imageExtension()),
+                "banner",
+                contentType
+        );
+        return new AdminBannerImageUploadResponse(presignedUrl.uploadUrl(), presignedUrl.publicUrl());
+    }
 
     @Override
     @Transactional
@@ -60,8 +75,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 normalizeRequired(request.bannerTitle()),
                 normalizeRequired(request.styleQuestion()),
                 normalizeRequired(request.stylePrompt()),
-                toStyleAnswerChipsJson(styleAnswerChips),
-                request.isExposed()
+                toStyleAnswerChipsJson(styleAnswerChips)
         );
         banner.replaceRawProducts(buildMappings(banner, request.mappedRawProductIds(), requiredRawProducts));
         Banner savedBanner = bannerRepository.saveAndFlush(banner);
@@ -112,8 +126,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 request.bannerTitle() != null ? normalizeRequired(request.bannerTitle()) : banner.getBannerTitle(),
                 request.styleQuestion() != null ? normalizeRequired(request.styleQuestion()) : banner.getStyleQuestion(),
                 request.stylePrompt() != null ? normalizeRequired(request.stylePrompt()) : banner.getStylePrompt(),
-                toStyleAnswerChipsJson(targetChips),
-                request.isExposed() != null ? request.isExposed() : banner.getIsExposed()
+                toStyleAnswerChipsJson(targetChips)
         );
         banner.replaceRawProducts(buildMappings(banner, targetMappedRawProductIds, requiredRawProducts));
 
@@ -191,7 +204,6 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 banner.getBannerTitle(),
                 banner.getStyleQuestion(),
                 banner.getStylePrompt(),
-                banner.getIsExposed(),
                 chipResponses,
                 mappedRawProducts,
                 banner.getCreatedAt(),

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
@@ -117,11 +117,16 @@ public class AdminBannerSupport {
         }
 
         List<BannerStyleAnswerChip> chips = requests.stream()
-                .map(request -> new BannerStyleAnswerChip(
-                        request.order(),
-                        normalizeRequired(request.label()),
-                        request.curationRawProductId()
-                ))
+                .map(request -> {
+                    if (request == null || request.order() == null || request.curationRawProductId() == null) {
+                        throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+                    }
+                    return new BannerStyleAnswerChip(
+                            request.order(),
+                            normalizeRequired(request.label()),
+                            request.curationRawProductId()
+                    );
+                })
                 .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
                 .toList();
 
@@ -199,8 +204,10 @@ public class AdminBannerSupport {
         if (ids == null || ids.isEmpty()) {
             return List.of();
         }
+        if (ids.stream().anyMatch(Objects::isNull)) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
         return ids.stream()
-                .filter(Objects::nonNull)
                 .collect(Collectors.collectingAndThen(
                         Collectors.toCollection(LinkedHashSet::new),
                         ArrayList::new

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
@@ -1,0 +1,225 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
+import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
+import or.sopt.houme.global.util.S3PresignedUtil;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AdminBannerSupport {
+
+    private static final int MAX_STYLE_ANSWER_CHIPS = 4;
+    private static final int MAX_SEARCH_SIZE = 50;
+    private static final TypeReference<List<BannerStyleAnswerChip>> STYLE_ANSWER_CHIP_TYPE = new TypeReference<>() {};
+
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final ObjectMapper objectMapper;
+    private final S3PresignedUtil s3PresignedUtil;
+
+    public AdminBannerImageUploadResponse createImageUploadUrl(
+            AdminBannerImageUploadRequest request,
+            String contentType,
+            String directory
+    ) {
+        S3PresignedUrlResponseDTO presignedUrl = s3PresignedUtil.createPresignedUrl(
+                normalizeRequired(request.imageExtension()),
+                directory,
+                contentType
+        );
+        return new AdminBannerImageUploadResponse(presignedUrl.uploadUrl(), presignedUrl.publicUrl());
+    }
+
+    public AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size) {
+        String normalizedKeyword = normalizeOptional(keyword);
+        int normalizedSize = Math.min(Math.max(size, 1), MAX_SEARCH_SIZE);
+        List<AdminBannerMappedRawProductResponse> rawProducts = curationRawProductRepository.searchByKeyword(
+                        normalizedKeyword,
+                        PageRequest.of(0, normalizedSize)
+                ).getContent().stream()
+                .map(AdminBannerMappedRawProductResponse::of)
+                .toList();
+        return new AdminBannerRawProductSearchResponse(rawProducts);
+    }
+
+    public Map<Long, CurationRawProduct> loadRequiredRawProducts(List<Long> rawProductIds) {
+        List<Long> normalizedRawProductIds = deduplicateIds(rawProductIds);
+        if (normalizedRawProductIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<CurationRawProduct> rawProducts = curationRawProductRepository.findAllById(normalizedRawProductIds);
+        Map<Long, CurationRawProduct> rawProductMap = rawProducts.stream()
+                .collect(Collectors.toMap(CurationRawProduct::getId, rawProduct -> rawProduct, (left, right) -> left, LinkedHashMap::new));
+
+        if (rawProductMap.size() != normalizedRawProductIds.size()) {
+            throw new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT);
+        }
+        return rawProductMap;
+    }
+
+    public List<Long> extractAllRawProductIds(List<BannerStyleAnswerChip> styleAnswerChips, List<Long> mappedRawProductIds) {
+        List<Long> rawProductIds = new ArrayList<>();
+        if (styleAnswerChips != null) {
+            rawProductIds.addAll(styleAnswerChips.stream()
+                    .map(BannerStyleAnswerChip::curationRawProductId)
+                    .toList());
+        }
+        if (mappedRawProductIds != null) {
+            rawProductIds.addAll(mappedRawProductIds);
+        }
+        return rawProductIds;
+    }
+
+    public List<Long> extractMappedRawProductIds(Banner banner) {
+        if (banner == null) {
+            return List.of();
+        }
+        return banner.getBannerRawProducts().stream()
+                .map(BannerCurationRawProduct::getCurationRawProduct)
+                .filter(Objects::nonNull)
+                .map(CurationRawProduct::getId)
+                .toList();
+    }
+
+    public List<BannerStyleAnswerChip> normalizeStyleAnswerChips(List<AdminBannerStyleAnswerChipRequest> requests) {
+        if (requests == null) {
+            return List.of();
+        }
+        if (requests.size() > MAX_STYLE_ANSWER_CHIPS) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        List<BannerStyleAnswerChip> chips = requests.stream()
+                .map(request -> new BannerStyleAnswerChip(
+                        request.order(),
+                        normalizeRequired(request.label()),
+                        request.curationRawProductId()
+                ))
+                .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
+                .toList();
+
+        Set<Integer> orders = new LinkedHashSet<>();
+        for (BannerStyleAnswerChip chip : chips) {
+            if (chip.order() == null || chip.order() < 1) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+            if (!orders.add(chip.order())) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+            if (chip.curationRawProductId() == null) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+        }
+        return chips;
+    }
+
+    public String toStyleAnswerChipsJson(List<BannerStyleAnswerChip> chips) {
+        try {
+            return objectMapper.writeValueAsString(chips == null ? List.of() : chips);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    public List<BannerStyleAnswerChip> parseStyleAnswerChipsJson(String styleAnswerChipsJson) {
+        if (styleAnswerChipsJson == null || styleAnswerChipsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<BannerStyleAnswerChip> chips = objectMapper.readValue(styleAnswerChipsJson, STYLE_ANSWER_CHIP_TYPE);
+            return chips == null ? List.of() : chips.stream()
+                    .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
+                    .toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    public List<BannerCurationRawProduct> buildMappings(
+            Banner banner,
+            List<Long> mappedRawProductIds,
+            Map<Long, CurationRawProduct> rawProductMap
+    ) {
+        return deduplicateIds(mappedRawProductIds).stream()
+                .map(rawProductId -> BannerCurationRawProduct.of(banner, rawProductMap.get(rawProductId)))
+                .toList();
+    }
+
+    public Map<Long, CurationRawProduct> loadRequiredRawProductsForBanners(List<Banner> banners) {
+        return loadRequiredRawProducts(
+                banners.stream()
+                        .flatMap(banner -> extractAllRawProductIds(
+                                parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson()),
+                                extractMappedRawProductIds(banner)
+                        ).stream())
+                        .toList()
+        );
+    }
+
+    public List<AdminBannerMappedRawProductResponse> toMappedRawProductResponses(
+            Banner banner,
+            Map<Long, CurationRawProduct> rawProductMap
+    ) {
+        return banner.getBannerRawProducts().stream()
+                .map(BannerCurationRawProduct::getCurationRawProduct)
+                .filter(Objects::nonNull)
+                .map(rawProduct -> rawProductMap.getOrDefault(rawProduct.getId(), rawProduct))
+                .map(AdminBannerMappedRawProductResponse::of)
+                .toList();
+    }
+
+    public List<Long> deduplicateIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ids.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        ArrayList::new
+                ));
+    }
+
+    public String normalizeRequired(String value) {
+        String normalized = normalizeOptional(value);
+        if (normalized == null) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        return normalized;
+    }
+
+    public String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleService.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleResponse;
+
+public interface AdminStyleService {
+
+    AdminBannerImageUploadResponse createImageUploadUrl(AdminBannerImageUploadRequest request, String contentType);
+
+    AdminStyleResponse create(AdminStyleCreateRequest request);
+
+    AdminStyleListResponse getAll();
+
+    AdminStyleResponse getById(Long styleId);
+
+    AdminStyleResponse update(Long styleId, AdminStyleUpdateRequest request);
+
+    void delete(Long styleId);
+
+    AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size);
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
@@ -1,0 +1,133 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminStyleServiceImpl implements AdminStyleService {
+
+    private final BannerRepository bannerRepository;
+    private final AdminBannerSupport adminBannerSupport;
+
+    @Override
+    public AdminBannerImageUploadResponse createImageUploadUrl(AdminBannerImageUploadRequest request, String contentType) {
+        return adminBannerSupport.createImageUploadUrl(request, contentType, "style");
+    }
+
+    @Override
+    @Transactional
+    public AdminStyleResponse create(AdminStyleCreateRequest request) {
+        Map<Long, CurationRawProduct> requiredRawProducts = adminBannerSupport.loadRequiredRawProducts(request.mappedRawProductIds());
+
+        Banner style = Banner.create(
+                BannerType.STYLE,
+                adminBannerSupport.normalizeRequired(request.bannerImageUrl()),
+                adminBannerSupport.normalizeRequired(request.bannerTitle()),
+                adminBannerSupport.normalizeRequired(request.styleDescription()),
+                null,
+                adminBannerSupport.normalizeRequired(request.stylePrompt()),
+                null
+        );
+        style.replaceRawProducts(adminBannerSupport.buildMappings(style, request.mappedRawProductIds(), requiredRawProducts));
+
+        Banner savedStyle = bannerRepository.saveAndFlush(style);
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedStyle.getId(), BannerType.STYLE, false)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
+        return buildResponse(savedWithRawProducts, requiredRawProducts);
+    }
+
+    @Override
+    public AdminStyleListResponse getAll() {
+        List<Banner> styles = bannerRepository.findAllWithRawProducts(BannerType.STYLE, false);
+        return new AdminStyleListResponse(buildResponses(styles));
+    }
+
+    @Override
+    public AdminStyleResponse getById(Long styleId) {
+        Banner style = bannerRepository.findByIdWithRawProducts(styleId, BannerType.STYLE, false)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
+        return buildResponses(List.of(style)).getFirst();
+    }
+
+    @Override
+    @Transactional
+    public AdminStyleResponse update(Long styleId, AdminStyleUpdateRequest request) {
+        Banner style = bannerRepository.findByIdWithRawProducts(styleId, BannerType.STYLE, false)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
+
+        List<Long> targetMappedRawProductIds = request.mappedRawProductIds() != null
+                ? request.mappedRawProductIds()
+                : adminBannerSupport.extractMappedRawProductIds(style);
+
+        Map<Long, CurationRawProduct> requiredRawProducts = adminBannerSupport.loadRequiredRawProducts(targetMappedRawProductIds);
+
+        style.update(
+                BannerType.STYLE,
+                request.bannerImageUrl() != null ? adminBannerSupport.normalizeRequired(request.bannerImageUrl()) : style.getBannerImageUrl(),
+                request.bannerTitle() != null ? adminBannerSupport.normalizeRequired(request.bannerTitle()) : style.getBannerTitle(),
+                request.styleDescription() != null ? adminBannerSupport.normalizeRequired(request.styleDescription()) : style.getStyleDescription(),
+                null,
+                request.stylePrompt() != null ? adminBannerSupport.normalizeRequired(request.stylePrompt()) : style.getStylePrompt(),
+                null
+        );
+        style.replaceRawProducts(adminBannerSupport.buildMappings(style, targetMappedRawProductIds, requiredRawProducts));
+
+        Banner savedStyle = bannerRepository.saveAndFlush(style);
+        Banner savedWithRawProducts = bannerRepository.findByIdWithRawProducts(savedStyle.getId(), BannerType.STYLE, false)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
+        return buildResponse(savedWithRawProducts, requiredRawProducts);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long styleId) {
+        Banner style = bannerRepository.findByIdWithRawProducts(styleId, BannerType.STYLE, false)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
+        bannerRepository.delete(style);
+        bannerRepository.flush();
+    }
+
+    @Override
+    public AdminBannerRawProductSearchResponse searchRawProducts(String keyword, int size) {
+        return adminBannerSupport.searchRawProducts(keyword, size);
+    }
+
+    private List<AdminStyleResponse> buildResponses(List<Banner> styles) {
+        Map<Long, CurationRawProduct> rawProductMap = adminBannerSupport.loadRequiredRawProductsForBanners(styles);
+        return styles.stream()
+                .map(style -> buildResponse(style, rawProductMap))
+                .toList();
+    }
+
+    private AdminStyleResponse buildResponse(Banner style, Map<Long, CurationRawProduct> rawProductMap) {
+        return new AdminStyleResponse(
+                style.getId(),
+                style.getBannerImageUrl(),
+                style.getBannerTitle(),
+                style.getStyleDescription(),
+                style.getStylePrompt(),
+                adminBannerSupport.toMappedRawProductResponses(style, rawProductMap),
+                style.getCreatedAt(),
+                style.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -127,6 +127,7 @@ public enum ErrorCode {
     // House_taste
     NOT_FOUND_HOUSE_TASTE(HttpStatus.NOT_FOUND, 40423, "집 취향을 찾을 수 없습니다."),
     NOT_FOUND_CURATION_RAW_PRODUCT(HttpStatus.NOT_FOUND, 40424, "원본 상품 객체를 찾을 수 없습니다."),
+    NOT_FOUND_BANNER(HttpStatus.NOT_FOUND, 40425, "배너 객체를 찾을 수 없습니다."),
 
 
     /**

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -128,6 +128,7 @@ public enum ErrorCode {
     NOT_FOUND_HOUSE_TASTE(HttpStatus.NOT_FOUND, 40423, "집 취향을 찾을 수 없습니다."),
     NOT_FOUND_CURATION_RAW_PRODUCT(HttpStatus.NOT_FOUND, 40424, "원본 상품 객체를 찾을 수 없습니다."),
     NOT_FOUND_BANNER(HttpStatus.NOT_FOUND, 40425, "배너 객체를 찾을 수 없습니다."),
+    NOT_FOUND_STYLE(HttpStatus.NOT_FOUND, 40426, "스타일 객체를 찾을 수 없습니다."),
 
 
     /**

--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -69,6 +69,168 @@
             background-color: #6c757d;
             border-color: #6c757d;
         }
+        .banner-editor-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 16px;
+        }
+        .banner-editor-grid .full-span {
+            grid-column: 1 / -1;
+        }
+        .banner-chip-editor {
+            border: 1px solid #e5e7eb;
+            border-radius: 14px;
+            padding: 16px;
+            background: #fafbfc;
+        }
+        .banner-chip-editor-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 12px;
+        }
+        .banner-chip-editor-title {
+            font-size: 0.95rem;
+            font-weight: 700;
+            color: #1f2937;
+        }
+        .banner-search-results {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 12px;
+        }
+        .banner-search-result-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+        }
+        .banner-selected-product,
+        .banner-mapped-products {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 12px;
+        }
+        .banner-selected-product-chip,
+        .banner-mapped-product-chip,
+        .banner-card-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: #eaf3ff;
+            color: #0f4c81;
+            font-size: 0.87rem;
+            font-weight: 600;
+        }
+        .banner-card-chip button,
+        .banner-selected-product-chip button,
+        .banner-mapped-product-chip button {
+            border: none;
+            background: transparent;
+            color: inherit;
+            padding: 0;
+            font-weight: 700;
+        }
+        .banner-list {
+            display: grid;
+            gap: 16px;
+        }
+        .banner-card {
+            display: grid;
+            grid-template-columns: 180px minmax(0, 1fr) auto;
+            gap: 20px;
+            padding: 20px;
+            border: 1px solid #e5e7eb;
+            border-radius: 18px;
+            background: #fff;
+        }
+        .banner-card-image {
+            width: 180px;
+            height: 120px;
+            border-radius: 14px;
+            object-fit: cover;
+            background: #e5e7eb;
+        }
+        .banner-card-body {
+            display: grid;
+            gap: 12px;
+        }
+        .banner-card-title-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .banner-card-title {
+            font-size: 1.1rem;
+            font-weight: 800;
+            color: #111827;
+        }
+        .banner-card-meta {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px 18px;
+            font-size: 0.92rem;
+            color: #4b5563;
+        }
+        .banner-card-block {
+            display: grid;
+            gap: 8px;
+        }
+        .banner-card-label {
+            font-size: 0.78rem;
+            font-weight: 700;
+            color: #6b7280;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+        .banner-card-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .banner-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 700;
+        }
+        .banner-badge.exposed {
+            background: #dcfce7;
+            color: #166534;
+        }
+        .banner-badge.hidden {
+            background: #fee2e2;
+            color: #991b1b;
+        }
+        @media (max-width: 1200px) {
+            .banner-editor-grid,
+            .banner-card-meta {
+                grid-template-columns: 1fr;
+            }
+            .banner-card {
+                grid-template-columns: 1fr;
+            }
+            .banner-card-image {
+                width: 100%;
+                height: 220px;
+            }
+            .banner-card-actions {
+                flex-direction: row;
+                flex-wrap: wrap;
+            }
+        }
     </style>
 </head>
 <body>
@@ -99,6 +261,11 @@
         <li class="nav-item">
             <a class="nav-link" href="#" data-target="raw-product-management">
                 <i class="fas fa-box-open"></i>RAW 상품 관리
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="banner-management">
+                <i class="fas fa-image"></i>스타일 배너 관리
             </a>
         </li>
     </ul>
@@ -521,6 +688,89 @@
             </div>
         </div>
     </div>
+
+    <div id="banner-management" class="content-section">
+        <h2>스타일 배너 관리</h2>
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>스타일 배너 목록</span>
+                <button id="get-banners-button" class="btn btn-secondary btn-sm">배너 목록 새로고침</button>
+            </div>
+            <div class="card-body">
+                <div id="banner-list-result" class="api-result"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">스타일 배너 등록 / 수정</div>
+            <div class="card-body">
+                <form id="banner-form">
+                    <div class="banner-editor-grid">
+                        <div>
+                            <label for="bannerEditId" class="form-label">수정 대상 배너 ID</label>
+                            <input type="text" class="form-control" id="bannerEditId" placeholder="목록에서 수정 선택 시 자동 입력" readonly>
+                        </div>
+                        <div>
+                            <label for="bannerIsExposed" class="form-label">노출 여부</label>
+                            <select class="form-select" id="bannerIsExposed">
+                                <option value="true">노출</option>
+                                <option value="false">숨김</option>
+                            </select>
+                        </div>
+                        <div class="full-span">
+                            <label for="bannerImageUrl" class="form-label">배너 이미지 URL</label>
+                            <input type="url" class="form-control" id="bannerImageUrl" placeholder="https://..." required>
+                        </div>
+                        <div>
+                            <label for="bannerTitle" class="form-label">배너 타이틀</label>
+                            <input type="text" class="form-control" id="bannerTitle" required>
+                        </div>
+                        <div>
+                            <label for="bannerStyleQuestion" class="form-label">스타일 질문</label>
+                            <input type="text" class="form-control" id="bannerStyleQuestion" required>
+                        </div>
+                        <div class="full-span">
+                            <label for="bannerStylePrompt" class="form-label">이미지 생성 스타일 프롬프트</label>
+                            <textarea class="form-control" id="bannerStylePrompt" rows="4" required></textarea>
+                        </div>
+                    </div>
+
+                    <div class="mt-4">
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h5 class="mb-0">스타일 답변 칩</h5>
+                            <span class="text-muted small">최대 4개</span>
+                        </div>
+                        <div id="banner-chip-editors" class="d-grid gap-3"></div>
+                    </div>
+
+                    <div class="mt-4">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <h5 class="mb-0">배너에 매핑된 가구</h5>
+                            <span class="text-muted small">검색 후 추가 / 제거</span>
+                        </div>
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-10">
+                                <label for="bannerMappedRawProductKeyword" class="form-label">RAW 상품 검색</label>
+                                <input type="text" class="form-control" id="bannerMappedRawProductKeyword" placeholder="상품명, 브랜드, source, productId 검색">
+                            </div>
+                            <div class="col-md-2 d-grid">
+                                <button type="button" id="search-banner-mapped-raw-products-button" class="btn btn-outline-primary">검색</button>
+                            </div>
+                        </div>
+                        <div id="bannerMappedRawProductSearchResult" class="banner-search-results"></div>
+                        <div id="bannerMappedRawProductsSelected" class="banner-mapped-products"></div>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2 mt-4">
+                        <button type="submit" id="create-banner-button" class="btn btn-primary">배너 등록</button>
+                        <button type="button" id="update-banner-button" class="btn btn-warning">배너 수정</button>
+                        <button type="button" id="reset-banner-form-button" class="btn btn-outline-secondary">폼 초기화</button>
+                    </div>
+                </form>
+                <div id="banner-form-result" class="api-result"></div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
@@ -537,6 +787,8 @@
         minListPrice: null,
         maxListPrice: null
     };
+    const BANNER_CHIP_MAX_COUNT = 4;
+    let bannerAdminState = createInitialBannerAdminState();
 
     window.onload = function() {
         const urlParams = new URLSearchParams(window.location.search);
@@ -550,6 +802,7 @@
         populateTagDropdown();
         populateMoodboardTagDropdown();
         populateFurnitureTypeDropdown();
+        initializeBannerManagement();
 
         // Sidebar navigation
         document.querySelectorAll('#sidebar .nav-link').forEach(link => {
@@ -993,7 +1246,515 @@
                 fetchRawProducts();
             });
         });
+
+        document.getElementById('get-banners-button').addEventListener('click', function() {
+            loadBanners();
+        });
+
+        document.getElementById('banner-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            createBanner();
+        });
+
+        document.getElementById('update-banner-button').addEventListener('click', function() {
+            updateBanner();
+        });
+
+        document.getElementById('reset-banner-form-button').addEventListener('click', function() {
+            resetBannerForm();
+        });
+
+        document.getElementById('search-banner-mapped-raw-products-button').addEventListener('click', function() {
+            searchBannerMappedRawProducts();
+        });
+
+        document.getElementById('bannerMappedRawProductKeyword').addEventListener('keydown', function(event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                searchBannerMappedRawProducts();
+            }
+        });
     };
+
+    function createInitialBannerAdminState() {
+        return {
+            editingBannerId: null,
+            selectedMappedRawProducts: [],
+            chipSelections: Array.from({ length: BANNER_CHIP_MAX_COUNT }, (_, index) => ({
+                order: index + 1,
+                rawProduct: null
+            }))
+        };
+    }
+
+    function initializeBannerManagement() {
+        renderBannerChipEditors();
+        renderBannerMappedRawProducts();
+        loadBanners();
+    }
+
+    function renderBannerChipEditors() {
+        const container = document.getElementById('banner-chip-editors');
+        container.innerHTML = '';
+
+        for (let index = 0; index < BANNER_CHIP_MAX_COUNT; index += 1) {
+            const selection = bannerAdminState.chipSelections[index];
+            const chipEditor = document.createElement('div');
+            chipEditor.className = 'banner-chip-editor';
+            chipEditor.innerHTML = `
+                <div class="banner-chip-editor-header">
+                    <span class="banner-chip-editor-title">답변 칩 ${index + 1}</span>
+                    <span class="text-muted small">순서 ${selection.order}</span>
+                </div>
+                <div class="row g-3">
+                    <div class="col-md-2">
+                        <label class="form-label" for="bannerChipOrder-${index}">순서</label>
+                        <input type="number" class="form-control" id="bannerChipOrder-${index}" min="1" max="4" value="${selection.order}">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="bannerChipLabel-${index}">칩 문구</label>
+                        <input type="text" class="form-control" id="bannerChipLabel-${index}" placeholder="예: 모니터 받침대가 결합된 책상">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="bannerChipRawKeyword-${index}">연결 RAW 상품 검색</label>
+                        <input type="text" class="form-control" id="bannerChipRawKeyword-${index}" placeholder="상품명, 브랜드, source, productId">
+                    </div>
+                    <div class="col-md-2 d-grid">
+                        <label class="form-label d-none d-md-block">검색</label>
+                        <button type="button" class="btn btn-outline-primary" id="searchBannerChipButton-${index}">검색</button>
+                    </div>
+                </div>
+                <div id="bannerChipSearchResult-${index}" class="banner-search-results"></div>
+                <div id="bannerChipSelected-${index}" class="banner-selected-product"></div>
+            `;
+            container.appendChild(chipEditor);
+
+            document.getElementById(`searchBannerChipButton-${index}`).addEventListener('click', function() {
+                searchBannerChipRawProducts(index);
+            });
+
+            document.getElementById(`bannerChipRawKeyword-${index}`).addEventListener('keydown', function(event) {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    searchBannerChipRawProducts(index);
+                }
+            });
+        }
+
+        renderAllChipSelections();
+    }
+
+    function renderAllChipSelections() {
+        for (let index = 0; index < BANNER_CHIP_MAX_COUNT; index += 1) {
+            renderBannerChipSelection(index);
+        }
+    }
+
+    function renderBannerChipSelection(index) {
+        const resultContainer = document.getElementById(`bannerChipSelected-${index}`);
+        const selection = bannerAdminState.chipSelections[index];
+        if (!resultContainer || !selection) return;
+
+        resultContainer.innerHTML = '';
+        if (!selection.rawProduct) {
+            const empty = document.createElement('div');
+            empty.className = 'text-muted small';
+            empty.textContent = '선택된 RAW 상품이 없습니다.';
+            resultContainer.appendChild(empty);
+            return;
+        }
+
+        const chip = document.createElement('div');
+        chip.className = 'banner-selected-product-chip';
+        chip.innerHTML = `
+            <span>${escapeHtml(selection.rawProduct.productName)} (#${selection.rawProduct.id})</span>
+            <button type="button" data-banner-chip-clear="${index}" aria-label="선택 해제">×</button>
+        `;
+        chip.querySelector('button').addEventListener('click', function() {
+            bannerAdminState.chipSelections[index].rawProduct = null;
+            renderBannerChipSelection(index);
+        });
+        resultContainer.appendChild(chip);
+    }
+
+    function searchBannerChipRawProducts(index) {
+        const keyword = parseStringValue(document.getElementById(`bannerChipRawKeyword-${index}`).value);
+        const resultContainer = document.getElementById(`bannerChipSearchResult-${index}`);
+        if (!resultContainer) return;
+        if (!keyword) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색어를 입력해주세요.</div>';
+            return;
+        }
+
+        fetchBannerRawProducts(keyword, 8)
+            .then(rawProducts => {
+                renderBannerChipSearchResults(index, rawProducts);
+            })
+            .catch(error => {
+                resultContainer.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+            });
+    }
+
+    function renderBannerChipSearchResults(index, rawProducts) {
+        const resultContainer = document.getElementById(`bannerChipSearchResult-${index}`);
+        resultContainer.innerHTML = '';
+
+        if (!Array.isArray(rawProducts) || rawProducts.length === 0) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색 결과가 없습니다.</div>';
+            return;
+        }
+
+        rawProducts.forEach(rawProduct => {
+            const item = document.createElement('div');
+            item.className = 'banner-search-result-item';
+            item.innerHTML = `
+                <div>
+                    <div class="fw-semibold">${escapeHtml(rawProduct.productName)}</div>
+                    <div class="text-muted small">${escapeHtml(rawProduct.source || '-')} · productId ${rawProduct.productId ?? '-'} · raw #${rawProduct.id}</div>
+                </div>
+            `;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'btn btn-sm btn-primary';
+            button.textContent = '선택';
+            button.addEventListener('click', function() {
+                bannerAdminState.chipSelections[index].rawProduct = rawProduct;
+                renderBannerChipSelection(index);
+                resultContainer.innerHTML = '';
+            });
+            item.appendChild(button);
+            resultContainer.appendChild(item);
+        });
+    }
+
+    function searchBannerMappedRawProducts() {
+        const keyword = parseStringValue(document.getElementById('bannerMappedRawProductKeyword').value);
+        const resultContainer = document.getElementById('bannerMappedRawProductSearchResult');
+        if (!keyword) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색어를 입력해주세요.</div>';
+            return;
+        }
+
+        fetchBannerRawProducts(keyword, 12)
+            .then(rawProducts => {
+                renderBannerMappedRawProductSearchResults(rawProducts);
+            })
+            .catch(error => {
+                resultContainer.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+            });
+    }
+
+    function renderBannerMappedRawProductSearchResults(rawProducts) {
+        const resultContainer = document.getElementById('bannerMappedRawProductSearchResult');
+        resultContainer.innerHTML = '';
+
+        if (!Array.isArray(rawProducts) || rawProducts.length === 0) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색 결과가 없습니다.</div>';
+            return;
+        }
+
+        rawProducts.forEach(rawProduct => {
+            const item = document.createElement('div');
+            item.className = 'banner-search-result-item';
+            item.innerHTML = `
+                <div>
+                    <div class="fw-semibold">${escapeHtml(rawProduct.productName)}</div>
+                    <div class="text-muted small">${escapeHtml(rawProduct.source || '-')} · productId ${rawProduct.productId ?? '-'} · raw #${rawProduct.id}</div>
+                </div>
+            `;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'btn btn-sm btn-outline-primary';
+            button.textContent = bannerAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id)
+                ? '선택됨'
+                : '추가';
+            button.disabled = bannerAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id);
+            button.addEventListener('click', function() {
+                addBannerMappedRawProduct(rawProduct);
+                renderBannerMappedRawProductSearchResults(rawProducts);
+            });
+            item.appendChild(button);
+            resultContainer.appendChild(item);
+        });
+    }
+
+    function addBannerMappedRawProduct(rawProduct) {
+        if (bannerAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id)) {
+            return;
+        }
+        bannerAdminState.selectedMappedRawProducts.push(rawProduct);
+        renderBannerMappedRawProducts();
+    }
+
+    function removeBannerMappedRawProduct(rawProductId) {
+        bannerAdminState.selectedMappedRawProducts = bannerAdminState.selectedMappedRawProducts
+            .filter(product => product.id !== rawProductId);
+        renderBannerMappedRawProducts();
+    }
+
+    function renderBannerMappedRawProducts() {
+        const container = document.getElementById('bannerMappedRawProductsSelected');
+        if (!container) return;
+        container.innerHTML = '';
+
+        if (bannerAdminState.selectedMappedRawProducts.length === 0) {
+            container.innerHTML = '<div class="text-muted small">아직 배너에 매핑된 가구가 없습니다.</div>';
+            return;
+        }
+
+        bannerAdminState.selectedMappedRawProducts.forEach(rawProduct => {
+            const chip = document.createElement('div');
+            chip.className = 'banner-mapped-product-chip';
+            chip.innerHTML = `
+                <span>${escapeHtml(rawProduct.productName)} (#${rawProduct.id})</span>
+                <button type="button" aria-label="제거">×</button>
+            `;
+            chip.querySelector('button').addEventListener('click', function() {
+                removeBannerMappedRawProduct(rawProduct.id);
+            });
+            container.appendChild(chip);
+        });
+    }
+
+    function fetchBannerRawProducts(keyword, size = 10) {
+        const accessToken = localStorage.getItem('accessToken');
+        if (!accessToken) {
+            return Promise.reject(new Error('액세스 토큰을 찾을 수 없습니다.'));
+        }
+        const queryParams = new URLSearchParams();
+        if (keyword) {
+            queryParams.set('keyword', keyword);
+        }
+        queryParams.set('size', String(size));
+
+        return fetch(`/api/v1/admin/banners/raw-products/search?${queryParams.toString()}`, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + accessToken,
+                'Content-Type': 'application/json'
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => { throw new Error(err.msg || '서버 오류'); });
+                }
+                return response.json();
+            })
+            .then(data => (data && data.data && Array.isArray(data.data.rawProducts)) ? data.data.rawProducts : []);
+    }
+
+    function loadBanners() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('banner-list-result');
+        testApiCall(accessToken, resultDiv, '/api/v1/admin/banners', 'GET', null, displayBanners);
+    }
+
+    function displayBanners(data, resultDiv) {
+        const banners = data && data.data && Array.isArray(data.data.banners) ? data.data.banners : [];
+        if (banners.length === 0) {
+            resultDiv.innerHTML = '<div class="alert alert-info">등록된 스타일 배너가 없습니다.</div>';
+            return;
+        }
+
+        resultDiv.innerHTML = '';
+        const list = document.createElement('div');
+        list.className = 'banner-list';
+
+        banners.forEach(banner => {
+            const card = document.createElement('div');
+            card.className = 'banner-card';
+            const mappedRawProducts = Array.isArray(banner.mappedRawProducts) ? banner.mappedRawProducts : [];
+            const styleAnswerChips = Array.isArray(banner.styleAnswerChips) ? banner.styleAnswerChips : [];
+            const chipHtml = styleAnswerChips.length > 0
+                ? styleAnswerChips.map(chip => `<span class="banner-card-chip">${escapeHtml(chip.label)} · #${chip.curationRawProductId}</span>`).join('')
+                : '<span class="text-muted small">등록된 스타일 답변이 없습니다.</span>';
+            const mappedHtml = mappedRawProducts.length > 0
+                ? mappedRawProducts.map(product => `<span class="banner-card-chip">${escapeHtml(product.productName)} · #${product.id}</span>`).join('')
+                : '<span class="text-muted small">매핑된 가구가 없습니다.</span>';
+
+            card.innerHTML = `
+                <img class="banner-card-image" src="${escapeHtml(banner.bannerImageUrl)}" alt="${escapeHtml(banner.bannerTitle)}">
+                <div class="banner-card-body">
+                    <div class="banner-card-title-row">
+                        <span class="banner-card-title">${escapeHtml(banner.bannerTitle)}</span>
+                        <span class="banner-badge ${banner.isExposed ? 'exposed' : 'hidden'}">${banner.isExposed ? '노출' : '숨김'}</span>
+                        <span class="text-muted small">#${banner.id}</span>
+                    </div>
+                    <div class="banner-card-meta">
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">스타일 질문</span>
+                            <span>${escapeHtml(banner.styleQuestion)}</span>
+                        </div>
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">이미지 생성 프롬프트</span>
+                            <span>${escapeHtml(banner.stylePrompt)}</span>
+                        </div>
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">스타일 답변 칩</span>
+                            <div class="d-flex flex-wrap gap-2">${chipHtml}</div>
+                        </div>
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">배너에 매핑된 가구</span>
+                            <div class="d-flex flex-wrap gap-2">${mappedHtml}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="banner-card-actions">
+                    <button type="button" class="btn btn-sm btn-info" data-banner-edit="${banner.id}">수정</button>
+                    <button type="button" class="btn btn-sm btn-danger" data-banner-delete="${banner.id}">삭제</button>
+                </div>
+            `;
+
+            card.querySelector('[data-banner-edit]').addEventListener('click', function() {
+                populateBannerForm(banner);
+            });
+            card.querySelector('[data-banner-delete]').addEventListener('click', function() {
+                deleteBanner(banner.id);
+            });
+            list.appendChild(card);
+        });
+
+        resultDiv.appendChild(list);
+    }
+
+    function populateBannerForm(banner) {
+        bannerAdminState = createInitialBannerAdminState();
+        bannerAdminState.editingBannerId = banner.id;
+
+        document.getElementById('bannerEditId').value = banner.id;
+        document.getElementById('bannerImageUrl').value = banner.bannerImageUrl ?? '';
+        document.getElementById('bannerTitle').value = banner.bannerTitle ?? '';
+        document.getElementById('bannerStyleQuestion').value = banner.styleQuestion ?? '';
+        document.getElementById('bannerStylePrompt').value = banner.stylePrompt ?? '';
+        document.getElementById('bannerIsExposed').value = String(Boolean(banner.isExposed));
+        document.getElementById('bannerMappedRawProductKeyword').value = '';
+        document.getElementById('bannerMappedRawProductSearchResult').innerHTML = '';
+
+        const styleAnswerChips = Array.isArray(banner.styleAnswerChips) ? banner.styleAnswerChips : [];
+        styleAnswerChips.slice(0, BANNER_CHIP_MAX_COUNT).forEach((chip, index) => {
+            bannerAdminState.chipSelections[index] = {
+                order: chip.order ?? index + 1,
+                rawProduct: chip.curationRawProductId != null ? {
+                    id: chip.curationRawProductId,
+                    productName: chip.curationRawProductName ?? `RAW #${chip.curationRawProductId}`,
+                    productImageUrl: chip.curationRawProductImageUrl ?? null,
+                    source: null,
+                    productId: null,
+                    brand: null
+                } : null
+            };
+        });
+
+        renderBannerChipEditors();
+        styleAnswerChips.slice(0, BANNER_CHIP_MAX_COUNT).forEach((chip, index) => {
+            document.getElementById(`bannerChipOrder-${index}`).value = chip.order ?? index + 1;
+            document.getElementById(`bannerChipLabel-${index}`).value = chip.label ?? '';
+        });
+
+        bannerAdminState.selectedMappedRawProducts = (Array.isArray(banner.mappedRawProducts) ? banner.mappedRawProducts : []).map(product => ({
+            id: product.id,
+            source: product.source,
+            category: product.category,
+            productId: product.productId,
+            productName: product.productName,
+            productImageUrl: product.productImageUrl,
+            brand: product.brand
+        }));
+        renderBannerMappedRawProducts();
+        document.getElementById('banner-form-result').innerHTML = '<div class="alert alert-info">배너 수정 모드로 전환했습니다.</div>';
+    }
+
+    function resetBannerForm() {
+        bannerAdminState = createInitialBannerAdminState();
+        document.getElementById('banner-form').reset();
+        document.getElementById('bannerEditId').value = '';
+        document.getElementById('bannerIsExposed').value = 'true';
+        document.getElementById('bannerMappedRawProductSearchResult').innerHTML = '';
+        document.getElementById('banner-form-result').innerHTML = '';
+        renderBannerChipEditors();
+        renderBannerMappedRawProducts();
+    }
+
+    function buildBannerPayload() {
+        const styleAnswerChips = [];
+        for (let index = 0; index < BANNER_CHIP_MAX_COUNT; index += 1) {
+            const order = parseNumberValue(document.getElementById(`bannerChipOrder-${index}`).value);
+            const label = parseStringValue(document.getElementById(`bannerChipLabel-${index}`).value);
+            const rawProduct = bannerAdminState.chipSelections[index].rawProduct;
+
+            if (!label && !rawProduct && order == null) {
+                continue;
+            }
+
+            if (!label || !rawProduct || order == null) {
+                throw new Error(`스타일 답변 칩 ${index + 1}의 문구, 순서, RAW 상품을 모두 입력해주세요.`);
+            }
+
+            styleAnswerChips.push({
+                order,
+                label,
+                curationRawProductId: rawProduct.id
+            });
+        }
+
+        return {
+            bannerImageUrl: parseStringValue(document.getElementById('bannerImageUrl').value),
+            bannerTitle: parseStringValue(document.getElementById('bannerTitle').value),
+            styleQuestion: parseStringValue(document.getElementById('bannerStyleQuestion').value),
+            stylePrompt: parseStringValue(document.getElementById('bannerStylePrompt').value),
+            isExposed: document.getElementById('bannerIsExposed').value === 'true',
+            styleAnswerChips,
+            mappedRawProductIds: bannerAdminState.selectedMappedRawProducts.map(product => product.id)
+        };
+    }
+
+    function createBanner() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('banner-form-result');
+        try {
+            const payload = buildBannerPayload();
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/banners', 'POST', payload, function(data, target) {
+                target.innerHTML = '<div class="alert alert-success">스타일 배너가 등록되었습니다.</div>';
+                resetBannerForm();
+                loadBanners();
+            });
+        } catch (error) {
+            resultDiv.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function updateBanner() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('banner-form-result');
+        if (!bannerAdminState.editingBannerId) {
+            resultDiv.innerHTML = '<div class="alert alert-danger">수정할 배너를 먼저 선택해주세요.</div>';
+            return;
+        }
+
+        try {
+            const payload = buildBannerPayload();
+            testApiCall(accessToken, resultDiv, `/api/v1/admin/banners/${bannerAdminState.editingBannerId}`, 'PATCH', payload, function(data, target) {
+                target.innerHTML = '<div class="alert alert-success">스타일 배너가 수정되었습니다.</div>';
+                loadBanners();
+            });
+        } catch (error) {
+            resultDiv.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function deleteBanner(bannerId) {
+        if (!confirm(`스타일 배너 ID ${bannerId}를 정말로 삭제하시겠습니까?`)) return;
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('banner-list-result');
+        testApiCall(accessToken, resultDiv, `/api/v1/admin/banners/${bannerId}`, 'DELETE', null, function() {
+            if (bannerAdminState.editingBannerId === bannerId) {
+                resetBannerForm();
+            }
+            loadBanners();
+        });
+    }
 
     function displayMoodboards(data, resultDiv) {
         const moodboards = data.data.dtos; // Corrected to dtos
@@ -1525,6 +2286,15 @@
         if (value == null) return null;
         const trimmed = String(value).trim();
         return trimmed.length === 0 ? null : trimmed;
+    }
+
+    function escapeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     function buildRawProductCreatePayload() {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -290,7 +290,12 @@
         </li>
         <li class="nav-item">
             <a class="nav-link" href="#" data-target="banner-management">
-                <i class="fas fa-image"></i>스타일 배너 관리
+                <i class="fas fa-image"></i>배너 관리
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="style-management">
+                <i class="fas fa-palette"></i>스타일로 시작하기 관리
             </a>
         </li>
     </ul>
@@ -715,10 +720,10 @@
     </div>
 
     <div id="banner-management" class="content-section">
-        <h2>스타일 배너 관리</h2>
+        <h2>배너 관리</h2>
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <span>스타일 배너 목록</span>
+                <span>배너 목록</span>
                 <button id="get-banners-button" class="btn btn-secondary btn-sm">배너 목록 새로고침</button>
             </div>
             <div class="card-body">
@@ -727,7 +732,7 @@
         </div>
 
         <div class="card">
-            <div class="card-header">스타일 배너 등록 / 수정</div>
+            <div class="card-header">배너 등록 / 수정</div>
             <div class="card-body">
                 <form id="banner-form">
                     <div class="banner-editor-grid">
@@ -756,6 +761,10 @@
                         <div>
                             <label for="bannerTitle" class="form-label">배너 타이틀</label>
                             <input type="text" class="form-control" id="bannerTitle" required>
+                        </div>
+                        <div>
+                            <label for="bannerStyleDescription" class="form-label">스타일 설명</label>
+                            <input type="text" class="form-control" id="bannerStyleDescription" required>
                         </div>
                         <div>
                             <label for="bannerStyleQuestion" class="form-label">스타일 질문</label>
@@ -803,6 +812,88 @@
             </div>
         </div>
     </div>
+
+    <div id="style-management" class="content-section">
+        <h2>스타일로 시작하기 관리</h2>
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>스타일 목록</span>
+                <button id="get-styles-button" class="btn btn-secondary btn-sm">스타일 목록 새로고침</button>
+            </div>
+            <div class="card-body">
+                <div id="style-list-result" class="api-result"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">스타일 등록 / 수정</div>
+            <div class="card-body">
+                <form id="style-form">
+                    <div class="banner-editor-grid">
+                        <div>
+                            <label for="styleEditId" class="form-label">수정 대상 스타일 ID</label>
+                            <input type="text" class="form-control" id="styleEditId" placeholder="목록에서 수정 선택 시 자동 입력" readonly>
+                        </div>
+                        <div class="full-span">
+                            <label for="styleImageFile" class="form-label">스타일 이미지 업로드</label>
+                            <div class="banner-image-upload-panel">
+                                <input type="file" class="form-control" id="styleImageFile" accept="image/*">
+                                <input type="hidden" id="styleImageUrl">
+                                <div class="banner-image-upload-actions">
+                                    <button type="button" id="upload-style-image-button" class="btn btn-outline-primary">S3 업로드</button>
+                                    <span id="styleImageUploadStatus" class="text-muted small">이미지를 선택하고 업로드하세요.</span>
+                                </div>
+                                <div id="styleImagePreview" class="banner-image-preview">
+                                    <img id="styleImagePreviewImg" src="" alt="스타일 미리보기">
+                                    <div class="banner-image-preview-meta">
+                                        <strong id="styleImagePreviewName">업로드된 스타일 이미지</strong>
+                                        <a id="styleImagePreviewLink" href="#" target="_blank" rel="noopener noreferrer"></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <label for="styleTitle" class="form-label">스타일 이름</label>
+                            <input type="text" class="form-control" id="styleTitle" required>
+                        </div>
+                        <div>
+                            <label for="styleDescription" class="form-label">스타일 설명</label>
+                            <input type="text" class="form-control" id="styleDescription" required>
+                        </div>
+                        <div class="full-span">
+                            <label for="stylePrompt" class="form-label">스타일 참고 프롬프트</label>
+                            <textarea class="form-control" id="stylePrompt" rows="4" required></textarea>
+                        </div>
+                    </div>
+
+                    <div class="mt-4">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <h5 class="mb-0">스타일에 매핑된 가구</h5>
+                            <span class="text-muted small">검색 후 추가 / 제거</span>
+                        </div>
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-10">
+                                <label for="styleMappedRawProductKeyword" class="form-label">RAW 상품 검색</label>
+                                <input type="text" class="form-control" id="styleMappedRawProductKeyword" placeholder="상품명, 브랜드, source, productId 검색">
+                            </div>
+                            <div class="col-md-2 d-grid">
+                                <button type="button" id="search-style-mapped-raw-products-button" class="btn btn-outline-primary">검색</button>
+                            </div>
+                        </div>
+                        <div id="styleMappedRawProductSearchResult" class="banner-search-results"></div>
+                        <div id="styleMappedRawProductsSelected" class="banner-mapped-products"></div>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2 mt-4">
+                        <button type="submit" id="create-style-button" class="btn btn-primary">스타일 등록</button>
+                        <button type="button" id="update-style-button" class="btn btn-warning">스타일 수정</button>
+                        <button type="button" id="reset-style-form-button" class="btn btn-outline-secondary">폼 초기화</button>
+                    </div>
+                </form>
+                <div id="style-form-result" class="api-result"></div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
@@ -821,6 +912,7 @@
     };
     const BANNER_CHIP_MAX_COUNT = 4;
     let bannerAdminState = createInitialBannerAdminState();
+    let styleAdminState = createInitialStyleAdminState();
 
     window.onload = function() {
         const urlParams = new URLSearchParams(window.location.search);
@@ -835,6 +927,7 @@
         populateMoodboardTagDropdown();
         populateFurnitureTypeDropdown();
         initializeBannerManagement();
+        initializeStyleManagement();
 
         // Sidebar navigation
         document.querySelectorAll('#sidebar .nav-link').forEach(link => {
@@ -1317,6 +1410,47 @@
                 searchBannerMappedRawProducts();
             }
         });
+
+        document.getElementById('get-styles-button').addEventListener('click', function() {
+            loadStyles();
+        });
+
+        document.getElementById('style-form').addEventListener('submit', function(event) {
+            event.preventDefault();
+            createStyle();
+        });
+
+        document.getElementById('update-style-button').addEventListener('click', function() {
+            updateStyle();
+        });
+
+        document.getElementById('reset-style-form-button').addEventListener('click', function() {
+            resetStyleForm();
+        });
+
+        document.getElementById('upload-style-image-button').addEventListener('click', function() {
+            uploadStyleImage();
+        });
+
+        document.getElementById('styleImageFile').addEventListener('change', function() {
+            document.getElementById('styleImageUrl').value = '';
+            if (this.files && this.files.length > 0) {
+                document.getElementById('styleImageUploadStatus').textContent = `${this.files[0].name} 선택됨. 업로드를 진행하세요.`;
+            } else {
+                document.getElementById('styleImageUploadStatus').textContent = '이미지를 선택하고 업로드하세요.';
+            }
+        });
+
+        document.getElementById('search-style-mapped-raw-products-button').addEventListener('click', function() {
+            searchStyleMappedRawProducts();
+        });
+
+        document.getElementById('styleMappedRawProductKeyword').addEventListener('keydown', function(event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                searchStyleMappedRawProducts();
+            }
+        });
     };
 
     function createInitialBannerAdminState() {
@@ -1330,6 +1464,13 @@
         };
     }
 
+    function createInitialStyleAdminState() {
+        return {
+            editingStyleId: null,
+            selectedMappedRawProducts: []
+        };
+    }
+
     function initializeBannerManagement() {
         renderBannerChipEditors();
         renderBannerMappedRawProducts();
@@ -1337,36 +1478,66 @@
         loadBanners();
     }
 
-    function renderBannerImagePreview(imageUrl, label = '업로드된 배너 이미지') {
-        const previewContainer = document.getElementById('bannerImagePreview');
-        const previewImage = document.getElementById('bannerImagePreviewImg');
-        const previewLink = document.getElementById('bannerImagePreviewLink');
-        const previewName = document.getElementById('bannerImagePreviewName');
+    function initializeStyleManagement() {
+        renderStyleMappedRawProducts();
+        renderStyleImagePreview('');
+        loadStyles();
+    }
+
+    function renderManagedImagePreview(config) {
+        const previewContainer = document.getElementById(config.containerId);
+        const previewImage = document.getElementById(config.imageId);
+        const previewLink = document.getElementById(config.linkId);
+        const previewName = document.getElementById(config.nameId);
         if (!previewContainer || !previewImage || !previewLink || !previewName) {
             return;
         }
 
-        if (!imageUrl) {
+        if (!config.imageUrl) {
             previewContainer.classList.remove('visible');
             previewImage.src = '';
             previewLink.href = '#';
             previewLink.textContent = '';
-            previewName.textContent = '업로드된 배너 이미지';
+            previewName.textContent = config.defaultLabel;
             return;
         }
 
         previewContainer.classList.add('visible');
-        previewImage.src = imageUrl;
-        previewLink.href = imageUrl;
-        previewLink.textContent = imageUrl;
-        previewName.textContent = label;
+        previewImage.src = config.imageUrl;
+        previewLink.href = config.imageUrl;
+        previewLink.textContent = config.imageUrl;
+        previewName.textContent = config.label || config.defaultLabel;
     }
 
-    async function uploadBannerImage() {
+    function renderBannerImagePreview(imageUrl, label = '업로드된 배너 이미지') {
+        renderManagedImagePreview({
+            containerId: 'bannerImagePreview',
+            imageId: 'bannerImagePreviewImg',
+            linkId: 'bannerImagePreviewLink',
+            nameId: 'bannerImagePreviewName',
+            imageUrl,
+            label,
+            defaultLabel: '업로드된 배너 이미지'
+        });
+    }
+
+    function renderStyleImagePreview(imageUrl, label = '업로드된 스타일 이미지') {
+        renderManagedImagePreview({
+            containerId: 'styleImagePreview',
+            imageId: 'styleImagePreviewImg',
+            linkId: 'styleImagePreviewLink',
+            nameId: 'styleImagePreviewName',
+            imageUrl,
+            label,
+            defaultLabel: '업로드된 스타일 이미지'
+        });
+    }
+
+    async function uploadManagedImage(config) {
         const accessToken = localStorage.getItem('accessToken');
-        const fileInput = document.getElementById('bannerImageFile');
-        const statusElement = document.getElementById('bannerImageUploadStatus');
-        const hiddenUrlInput = document.getElementById('bannerImageUrl');
+        const fileInput = document.getElementById(config.fileInputId);
+        const statusElement = document.getElementById(config.statusId);
+        const hiddenUrlInput = document.getElementById(config.hiddenUrlInputId);
 
         if (!accessToken) {
             statusElement.textContent = '액세스 토큰이 없습니다.';
@@ -1388,7 +1559,7 @@
         statusElement.textContent = 'Presigned URL을 요청하는 중입니다...';
 
         try {
-            const uploadUrlResponse = await fetch(`/api/v1/admin/banners/image-upload-url?contentType=${encodeURIComponent(imageFile.type || 'application/octet-stream')}`, {
+            const uploadUrlResponse = await fetch(`${config.uploadUrl}?contentType=${encodeURIComponent(imageFile.type || 'application/octet-stream')}`, {
                 method: 'POST',
                 headers: {
                     'Authorization': 'Bearer ' + accessToken,
@@ -1399,7 +1570,7 @@
 
             if (!uploadUrlResponse.ok) {
                 const errorBody = await uploadUrlResponse.json().catch(() => null);
-                throw new Error(errorBody?.msg || '배너 이미지 업로드 URL 발급에 실패했습니다.');
+                throw new Error(errorBody?.msg || `${config.entityName} 이미지 업로드 URL 발급에 실패했습니다.`);
             }
 
             const uploadUrlPayload = await uploadUrlResponse.json();
@@ -1407,7 +1578,7 @@
             const publicUrl = uploadUrlPayload?.data?.publicUrl;
 
             if (!uploadUrl || !publicUrl) {
-                throw new Error('배너 이미지 업로드 URL 응답이 올바르지 않습니다.');
+                throw new Error(`${config.entityName} 이미지 업로드 URL 응답이 올바르지 않습니다.`);
             }
 
             statusElement.textContent = 'S3에 이미지를 업로드하는 중입니다...';
@@ -1423,13 +1594,35 @@
             }
 
             hiddenUrlInput.value = publicUrl;
-            renderBannerImagePreview(publicUrl, imageFile.name);
-            statusElement.textContent = '배너 이미지 업로드가 완료되었습니다.';
+            config.renderPreview(publicUrl, imageFile.name);
+            statusElement.textContent = `${config.entityName} 이미지 업로드가 완료되었습니다.`;
         } catch (error) {
             hiddenUrlInput.value = '';
-            renderBannerImagePreview('');
-            statusElement.textContent = error.message || '배너 이미지 업로드 중 오류가 발생했습니다.';
+            config.renderPreview('');
+            statusElement.textContent = error.message || `${config.entityName} 이미지 업로드 중 오류가 발생했습니다.`;
         }
+    }
+
+    async function uploadBannerImage() {
+        await uploadManagedImage({
+            fileInputId: 'bannerImageFile',
+            statusId: 'bannerImageUploadStatus',
+            hiddenUrlInputId: 'bannerImageUrl',
+            uploadUrl: '/api/v1/admin/banners/image-upload-url',
+            entityName: '배너',
+            renderPreview: renderBannerImagePreview
+        });
+    }
+
+    async function uploadStyleImage() {
+        await uploadManagedImage({
+            fileInputId: 'styleImageFile',
+            statusId: 'styleImageUploadStatus',
+            hiddenUrlInputId: 'styleImageUrl',
+            uploadUrl: '/api/v1/admin/styles/image-upload-url',
+            entityName: '스타일',
+            renderPreview: renderStyleImagePreview
+        });
     }
 
     function renderBannerChipEditors() {
@@ -1657,7 +1850,7 @@
         });
     }
 
-    function fetchBannerRawProducts(keyword, size = 10) {
+    function fetchAdminRawProducts(endpoint, keyword, size = 10) {
         const accessToken = localStorage.getItem('accessToken');
         if (!accessToken) {
             return Promise.reject(new Error('액세스 토큰을 찾을 수 없습니다.'));
@@ -1668,7 +1861,7 @@
         }
         queryParams.set('size', String(size));
 
-        return fetch(`/api/v1/admin/banners/raw-products/search?${queryParams.toString()}`, {
+        return fetch(`${endpoint}?${queryParams.toString()}`, {
             method: 'GET',
             headers: {
                 'Authorization': 'Bearer ' + accessToken,
@@ -1684,6 +1877,14 @@
             .then(data => (data && data.data && Array.isArray(data.data.rawProducts)) ? data.data.rawProducts : []);
     }
 
+    function fetchBannerRawProducts(keyword, size = 10) {
+        return fetchAdminRawProducts('/api/v1/admin/banners/raw-products/search', keyword, size);
+    }
+
+    function fetchStyleRawProducts(keyword, size = 10) {
+        return fetchAdminRawProducts('/api/v1/admin/styles/raw-products/search', keyword, size);
+    }
+
     function loadBanners() {
         const accessToken = localStorage.getItem('accessToken');
         const resultDiv = document.getElementById('banner-list-result');
@@ -1693,7 +1894,7 @@
     function displayBanners(data, resultDiv) {
         const banners = data && data.data && Array.isArray(data.data.banners) ? data.data.banners : [];
         if (banners.length === 0) {
-            resultDiv.innerHTML = '<div class="alert alert-info">등록된 스타일 배너가 없습니다.</div>';
+            resultDiv.innerHTML = '<div class="alert alert-info">등록된 배너가 없습니다.</div>';
             return;
         }
 
@@ -1721,6 +1922,10 @@
                         <span class="text-muted small">#${banner.id}</span>
                     </div>
                     <div class="banner-card-meta">
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">스타일 설명</span>
+                            <span>${escapeHtml(banner.styleDescription)}</span>
+                        </div>
                         <div class="banner-card-block">
                             <span class="banner-card-label">스타일 질문</span>
                             <span>${escapeHtml(banner.styleQuestion)}</span>
@@ -1765,6 +1970,7 @@
         document.getElementById('bannerImageUrl').value = banner.bannerImageUrl ?? '';
         document.getElementById('bannerImageFile').value = '';
         document.getElementById('bannerTitle').value = banner.bannerTitle ?? '';
+        document.getElementById('bannerStyleDescription').value = banner.styleDescription ?? '';
         document.getElementById('bannerStyleQuestion').value = banner.styleQuestion ?? '';
         document.getElementById('bannerStylePrompt').value = banner.stylePrompt ?? '';
         document.getElementById('bannerMappedRawProductKeyword').value = '';
@@ -1849,6 +2055,7 @@
         return {
             bannerImageUrl,
             bannerTitle: parseStringValue(document.getElementById('bannerTitle').value),
+            styleDescription: parseStringValue(document.getElementById('bannerStyleDescription').value),
             styleQuestion: parseStringValue(document.getElementById('bannerStyleQuestion').value),
             stylePrompt: parseStringValue(document.getElementById('bannerStylePrompt').value),
             styleAnswerChips,
@@ -1862,7 +2069,7 @@
         try {
             const payload = buildBannerPayload();
             testApiCall(accessToken, resultDiv, '/api/v1/admin/banners', 'POST', payload, function(data, target) {
-                target.innerHTML = '<div class="alert alert-success">스타일 배너가 등록되었습니다.</div>';
+                target.innerHTML = '<div class="alert alert-success">배너가 등록되었습니다.</div>';
                 resetBannerForm();
                 loadBanners();
             });
@@ -1882,7 +2089,7 @@
         try {
             const payload = buildBannerPayload();
             testApiCall(accessToken, resultDiv, `/api/v1/admin/banners/${bannerAdminState.editingBannerId}`, 'PATCH', payload, function(data, target) {
-                target.innerHTML = '<div class="alert alert-success">스타일 배너가 수정되었습니다.</div>';
+                target.innerHTML = '<div class="alert alert-success">배너가 수정되었습니다.</div>';
                 loadBanners();
             });
         } catch (error) {
@@ -1891,7 +2098,7 @@
     }
 
     function deleteBanner(bannerId) {
-        if (!confirm(`스타일 배너 ID ${bannerId}를 정말로 삭제하시겠습니까?`)) return;
+        if (!confirm(`배너 ID ${bannerId}를 정말로 삭제하시겠습니까?`)) return;
         const accessToken = localStorage.getItem('accessToken');
         const resultDiv = document.getElementById('banner-list-result');
         testApiCall(accessToken, resultDiv, `/api/v1/admin/banners/${bannerId}`, 'DELETE', null, function() {
@@ -1899,6 +2106,262 @@
                 resetBannerForm();
             }
             loadBanners();
+        });
+    }
+
+    function searchStyleMappedRawProducts() {
+        const keyword = parseStringValue(document.getElementById('styleMappedRawProductKeyword').value);
+        const resultContainer = document.getElementById('styleMappedRawProductSearchResult');
+        if (!keyword) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색어를 입력해주세요.</div>';
+            return;
+        }
+
+        fetchStyleRawProducts(keyword, 12)
+            .then(rawProducts => {
+                renderStyleMappedRawProductSearchResults(rawProducts);
+            })
+            .catch(error => {
+                resultContainer.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+            });
+    }
+
+    function renderStyleMappedRawProductSearchResults(rawProducts) {
+        const resultContainer = document.getElementById('styleMappedRawProductSearchResult');
+        resultContainer.innerHTML = '';
+
+        if (!Array.isArray(rawProducts) || rawProducts.length === 0) {
+            resultContainer.innerHTML = '<div class="text-muted small">검색 결과가 없습니다.</div>';
+            return;
+        }
+
+        rawProducts.forEach(rawProduct => {
+            const item = document.createElement('div');
+            item.className = 'banner-search-result-item';
+            item.innerHTML = `
+                <div>
+                    <div class="fw-semibold">${escapeHtml(rawProduct.productName)}</div>
+                    <div class="text-muted small">${escapeHtml(rawProduct.source || '-')} · productId ${rawProduct.productId ?? '-'} · raw #${rawProduct.id}</div>
+                </div>
+            `;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'btn btn-sm btn-outline-primary';
+            button.textContent = styleAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id)
+                ? '선택됨'
+                : '추가';
+            button.disabled = styleAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id);
+            button.addEventListener('click', function() {
+                addStyleMappedRawProduct(rawProduct);
+                renderStyleMappedRawProductSearchResults(rawProducts);
+            });
+            item.appendChild(button);
+            resultContainer.appendChild(item);
+        });
+    }
+
+    function addStyleMappedRawProduct(rawProduct) {
+        if (styleAdminState.selectedMappedRawProducts.some(product => product.id === rawProduct.id)) {
+            return;
+        }
+        styleAdminState.selectedMappedRawProducts.push(rawProduct);
+        renderStyleMappedRawProducts();
+    }
+
+    function removeStyleMappedRawProduct(rawProductId) {
+        styleAdminState.selectedMappedRawProducts = styleAdminState.selectedMappedRawProducts
+            .filter(product => product.id !== rawProductId);
+        renderStyleMappedRawProducts();
+    }
+
+    function renderStyleMappedRawProducts() {
+        const container = document.getElementById('styleMappedRawProductsSelected');
+        if (!container) return;
+        container.innerHTML = '';
+
+        if (styleAdminState.selectedMappedRawProducts.length === 0) {
+            container.innerHTML = '<div class="text-muted small">아직 스타일에 매핑된 가구가 없습니다.</div>';
+            return;
+        }
+
+        styleAdminState.selectedMappedRawProducts.forEach(rawProduct => {
+            const chip = document.createElement('div');
+            chip.className = 'banner-mapped-product-chip';
+            chip.innerHTML = `
+                <span>${escapeHtml(rawProduct.productName)} (#${rawProduct.id})</span>
+                <button type="button" aria-label="제거">×</button>
+            `;
+            chip.querySelector('button').addEventListener('click', function() {
+                removeStyleMappedRawProduct(rawProduct.id);
+            });
+            container.appendChild(chip);
+        });
+    }
+
+    function loadStyles() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('style-list-result');
+        testApiCall(accessToken, resultDiv, '/api/v1/admin/styles', 'GET', null, displayStyles);
+    }
+
+    function displayStyles(data, resultDiv) {
+        const styles = data && data.data && Array.isArray(data.data.styles) ? data.data.styles : [];
+        if (styles.length === 0) {
+            resultDiv.innerHTML = '<div class="alert alert-info">등록된 스타일이 없습니다.</div>';
+            return;
+        }
+
+        resultDiv.innerHTML = '';
+        const list = document.createElement('div');
+        list.className = 'banner-list';
+
+        styles.forEach(style => {
+            const card = document.createElement('div');
+            card.className = 'banner-card';
+            const mappedRawProducts = Array.isArray(style.mappedRawProducts) ? style.mappedRawProducts : [];
+            const mappedHtml = mappedRawProducts.length > 0
+                ? mappedRawProducts.map(product => `<span class="banner-card-chip">${escapeHtml(product.productName)} · #${product.id}</span>`).join('')
+                : '<span class="text-muted small">매핑된 가구가 없습니다.</span>';
+
+            card.innerHTML = `
+                <img class="banner-card-image" src="${escapeHtml(style.bannerImageUrl)}" alt="${escapeHtml(style.bannerTitle)}">
+                <div class="banner-card-body">
+                    <div class="banner-card-title-row">
+                        <span class="banner-card-title">${escapeHtml(style.bannerTitle)}</span>
+                        <span class="text-muted small">#${style.id}</span>
+                    </div>
+                    <div class="banner-card-meta">
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">스타일 설명</span>
+                            <span>${escapeHtml(style.styleDescription)}</span>
+                        </div>
+                        <div class="banner-card-block">
+                            <span class="banner-card-label">스타일 참고 프롬프트</span>
+                            <span>${escapeHtml(style.stylePrompt)}</span>
+                        </div>
+                        <div class="banner-card-block" style="grid-column: 1 / -1;">
+                            <span class="banner-card-label">스타일에 매핑된 가구</span>
+                            <div class="d-flex flex-wrap gap-2">${mappedHtml}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="banner-card-actions">
+                    <button type="button" class="btn btn-sm btn-info" data-style-edit="${style.id}">수정</button>
+                    <button type="button" class="btn btn-sm btn-danger" data-style-delete="${style.id}">삭제</button>
+                </div>
+            `;
+
+            card.querySelector('[data-style-edit]').addEventListener('click', function() {
+                populateStyleForm(style);
+            });
+            card.querySelector('[data-style-delete]').addEventListener('click', function() {
+                deleteStyle(style.id);
+            });
+            list.appendChild(card);
+        });
+
+        resultDiv.appendChild(list);
+    }
+
+    function populateStyleForm(style) {
+        styleAdminState = createInitialStyleAdminState();
+        styleAdminState.editingStyleId = style.id;
+
+        document.getElementById('styleEditId').value = style.id;
+        document.getElementById('styleImageUrl').value = style.bannerImageUrl ?? '';
+        document.getElementById('styleImageFile').value = '';
+        document.getElementById('styleTitle').value = style.bannerTitle ?? '';
+        document.getElementById('styleDescription').value = style.styleDescription ?? '';
+        document.getElementById('stylePrompt').value = style.stylePrompt ?? '';
+        document.getElementById('styleMappedRawProductKeyword').value = '';
+        document.getElementById('styleMappedRawProductSearchResult').innerHTML = '';
+        document.getElementById('styleImageUploadStatus').textContent = style.bannerImageUrl ? '기존 스타일 이미지가 연결되어 있습니다. 새 파일을 업로드하면 교체됩니다.' : '이미지를 선택하고 업로드하세요.';
+        renderStyleImagePreview(style.bannerImageUrl ?? '');
+
+        styleAdminState.selectedMappedRawProducts = (Array.isArray(style.mappedRawProducts) ? style.mappedRawProducts : []).map(product => ({
+            id: product.id,
+            source: product.source,
+            category: product.category,
+            productId: product.productId,
+            productName: product.productName,
+            productImageUrl: product.productImageUrl,
+            brand: product.brand
+        }));
+        renderStyleMappedRawProducts();
+        document.getElementById('style-form-result').innerHTML = '<div class="alert alert-info">스타일 수정 모드로 전환했습니다.</div>';
+    }
+
+    function resetStyleForm() {
+        styleAdminState = createInitialStyleAdminState();
+        document.getElementById('style-form').reset();
+        document.getElementById('styleEditId').value = '';
+        document.getElementById('styleImageUrl').value = '';
+        document.getElementById('styleImageUploadStatus').textContent = '이미지를 선택하고 업로드하세요.';
+        document.getElementById('styleMappedRawProductSearchResult').innerHTML = '';
+        document.getElementById('style-form-result').innerHTML = '';
+        renderStyleImagePreview('');
+        renderStyleMappedRawProducts();
+    }
+
+    function buildStylePayload() {
+        const styleImageUrl = parseStringValue(document.getElementById('styleImageUrl').value);
+        if (!styleImageUrl) {
+            throw new Error('스타일 이미지를 업로드해주세요.');
+        }
+
+        return {
+            bannerImageUrl: styleImageUrl,
+            bannerTitle: parseStringValue(document.getElementById('styleTitle').value),
+            styleDescription: parseStringValue(document.getElementById('styleDescription').value),
+            stylePrompt: parseStringValue(document.getElementById('stylePrompt').value),
+            mappedRawProductIds: styleAdminState.selectedMappedRawProducts.map(product => product.id)
+        };
+    }
+
+    function createStyle() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('style-form-result');
+        try {
+            const payload = buildStylePayload();
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/styles', 'POST', payload, function(data, target) {
+                target.innerHTML = '<div class="alert alert-success">스타일이 등록되었습니다.</div>';
+                resetStyleForm();
+                loadStyles();
+            });
+        } catch (error) {
+            resultDiv.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function updateStyle() {
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('style-form-result');
+        if (!styleAdminState.editingStyleId) {
+            resultDiv.innerHTML = '<div class="alert alert-danger">수정할 스타일을 먼저 선택해주세요.</div>';
+            return;
+        }
+
+        try {
+            const payload = buildStylePayload();
+            testApiCall(accessToken, resultDiv, `/api/v1/admin/styles/${styleAdminState.editingStyleId}`, 'PATCH', payload, function(data, target) {
+                target.innerHTML = '<div class="alert alert-success">스타일이 수정되었습니다.</div>';
+                loadStyles();
+            });
+        } catch (error) {
+            resultDiv.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+
+    function deleteStyle(styleId) {
+        if (!confirm(`스타일 ID ${styleId}를 정말로 삭제하시겠습니까?`)) return;
+        const accessToken = localStorage.getItem('accessToken');
+        const resultDiv = document.getElementById('style-list-result');
+        testApiCall(accessToken, resultDiv, `/api/v1/admin/styles/${styleId}`, 'DELETE', null, function() {
+            if (styleAdminState.editingStyleId === styleId) {
+                resetStyleForm();
+            }
+            loadStyles();
         });
     }
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -750,7 +750,7 @@
                                     <span id="bannerImageUploadStatus" class="text-muted small">이미지를 선택하고 업로드하세요.</span>
                                 </div>
                                 <div id="bannerImagePreview" class="banner-image-preview">
-                                    <img id="bannerImagePreviewImg" src="" alt="배너 미리보기">
+                                    <img id="bannerImagePreviewImg" alt="배너 미리보기">
                                     <div class="banner-image-preview-meta">
                                         <strong id="bannerImagePreviewName">업로드된 배너 이미지</strong>
                                         <a id="bannerImagePreviewLink" href="#" target="_blank" rel="noopener noreferrer"></a>
@@ -844,7 +844,7 @@
                                     <span id="styleImageUploadStatus" class="text-muted small">이미지를 선택하고 업로드하세요.</span>
                                 </div>
                                 <div id="styleImagePreview" class="banner-image-preview">
-                                    <img id="styleImagePreviewImg" src="" alt="스타일 미리보기">
+                                    <img id="styleImagePreviewImg" alt="스타일 미리보기">
                                     <div class="banner-image-preview-meta">
                                         <strong id="styleImagePreviewName">업로드된 스타일 이미지</strong>
                                         <a id="styleImagePreviewLink" href="#" target="_blank" rel="noopener noreferrer"></a>
@@ -1382,6 +1382,10 @@
         });
 
         document.getElementById('update-banner-button').addEventListener('click', function() {
+            const form = document.getElementById('banner-form');
+            if (!form.reportValidity()) {
+                return;
+            }
             updateBanner();
         });
 
@@ -1392,7 +1396,6 @@
             uploadBannerImage();
         });
         document.getElementById('bannerImageFile').addEventListener('change', function() {
-            document.getElementById('bannerImageUrl').value = '';
             if (this.files && this.files.length > 0) {
                 document.getElementById('bannerImageUploadStatus').textContent = `${this.files[0].name} 선택됨. 업로드를 진행하세요.`;
             } else {
@@ -1421,6 +1424,10 @@
         });
 
         document.getElementById('update-style-button').addEventListener('click', function() {
+            const form = document.getElementById('style-form');
+            if (!form.reportValidity()) {
+                return;
+            }
             updateStyle();
         });
 
@@ -1433,7 +1440,6 @@
         });
 
         document.getElementById('styleImageFile').addEventListener('change', function() {
-            document.getElementById('styleImageUrl').value = '';
             if (this.files && this.files.length > 0) {
                 document.getElementById('styleImageUploadStatus').textContent = `${this.files[0].name} 선택됨. 업로드를 진행하세요.`;
             } else {
@@ -1495,7 +1501,7 @@
 
         if (!config.imageUrl) {
             previewContainer.classList.remove('visible');
-            previewImage.src = '';
+            previewImage.removeAttribute('src');
             previewLink.href = '#';
             previewLink.textContent = '';
             previewName.textContent = config.defaultLabel;
@@ -1597,8 +1603,6 @@
             config.renderPreview(publicUrl, imageFile.name);
             statusElement.textContent = `${config.entityName} 이미지 업로드가 완료되었습니다.`;
         } catch (error) {
-            hiddenUrlInput.value = '';
-            config.renderPreview('');
             statusElement.textContent = error.message || `${config.entityName} 이미지 업로드 중 오류가 발생했습니다.`;
         }
     }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -83,6 +83,48 @@
             padding: 16px;
             background: #fafbfc;
         }
+        .banner-image-upload-panel {
+            display: grid;
+            gap: 12px;
+            padding: 14px;
+            border: 1px dashed #cbd5e1;
+            border-radius: 14px;
+            background: #f8fafc;
+        }
+        .banner-image-upload-actions {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        .banner-image-preview {
+            display: none;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+        }
+        .banner-image-preview.visible {
+            display: flex;
+        }
+        .banner-image-preview img {
+            width: 96px;
+            height: 64px;
+            border-radius: 10px;
+            object-fit: cover;
+            background: #e5e7eb;
+        }
+        .banner-image-preview-meta {
+            display: grid;
+            gap: 4px;
+            min-width: 0;
+        }
+        .banner-image-preview-meta a {
+            word-break: break-all;
+            font-size: 0.85rem;
+        }
         .banner-chip-editor-header {
             display: flex;
             align-items: center;
@@ -196,23 +238,6 @@
             display: flex;
             flex-direction: column;
             gap: 8px;
-        }
-        .banner-badge {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 4px 10px;
-            border-radius: 999px;
-            font-size: 0.8rem;
-            font-weight: 700;
-        }
-        .banner-badge.exposed {
-            background: #dcfce7;
-            color: #166534;
-        }
-        .banner-badge.hidden {
-            background: #fee2e2;
-            color: #991b1b;
         }
         @media (max-width: 1200px) {
             .banner-editor-grid,
@@ -710,16 +735,23 @@
                             <label for="bannerEditId" class="form-label">수정 대상 배너 ID</label>
                             <input type="text" class="form-control" id="bannerEditId" placeholder="목록에서 수정 선택 시 자동 입력" readonly>
                         </div>
-                        <div>
-                            <label for="bannerIsExposed" class="form-label">노출 여부</label>
-                            <select class="form-select" id="bannerIsExposed">
-                                <option value="true">노출</option>
-                                <option value="false">숨김</option>
-                            </select>
-                        </div>
                         <div class="full-span">
-                            <label for="bannerImageUrl" class="form-label">배너 이미지 URL</label>
-                            <input type="url" class="form-control" id="bannerImageUrl" placeholder="https://..." required>
+                            <label for="bannerImageFile" class="form-label">배너 이미지 업로드</label>
+                            <div class="banner-image-upload-panel">
+                                <input type="file" class="form-control" id="bannerImageFile" accept="image/*">
+                                <input type="hidden" id="bannerImageUrl">
+                                <div class="banner-image-upload-actions">
+                                    <button type="button" id="upload-banner-image-button" class="btn btn-outline-primary">S3 업로드</button>
+                                    <span id="bannerImageUploadStatus" class="text-muted small">이미지를 선택하고 업로드하세요.</span>
+                                </div>
+                                <div id="bannerImagePreview" class="banner-image-preview">
+                                    <img id="bannerImagePreviewImg" src="" alt="배너 미리보기">
+                                    <div class="banner-image-preview-meta">
+                                        <strong id="bannerImagePreviewName">업로드된 배너 이미지</strong>
+                                        <a id="bannerImagePreviewLink" href="#" target="_blank" rel="noopener noreferrer"></a>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <div>
                             <label for="bannerTitle" class="form-label">배너 타이틀</label>
@@ -1263,6 +1295,17 @@
         document.getElementById('reset-banner-form-button').addEventListener('click', function() {
             resetBannerForm();
         });
+        document.getElementById('upload-banner-image-button').addEventListener('click', function() {
+            uploadBannerImage();
+        });
+        document.getElementById('bannerImageFile').addEventListener('change', function() {
+            document.getElementById('bannerImageUrl').value = '';
+            if (this.files && this.files.length > 0) {
+                document.getElementById('bannerImageUploadStatus').textContent = `${this.files[0].name} 선택됨. 업로드를 진행하세요.`;
+            } else {
+                document.getElementById('bannerImageUploadStatus').textContent = '이미지를 선택하고 업로드하세요.';
+            }
+        });
 
         document.getElementById('search-banner-mapped-raw-products-button').addEventListener('click', function() {
             searchBannerMappedRawProducts();
@@ -1290,7 +1333,103 @@
     function initializeBannerManagement() {
         renderBannerChipEditors();
         renderBannerMappedRawProducts();
+        renderBannerImagePreview('');
         loadBanners();
+    }
+
+    function renderBannerImagePreview(imageUrl, label = '업로드된 배너 이미지') {
+        const previewContainer = document.getElementById('bannerImagePreview');
+        const previewImage = document.getElementById('bannerImagePreviewImg');
+        const previewLink = document.getElementById('bannerImagePreviewLink');
+        const previewName = document.getElementById('bannerImagePreviewName');
+        if (!previewContainer || !previewImage || !previewLink || !previewName) {
+            return;
+        }
+
+        if (!imageUrl) {
+            previewContainer.classList.remove('visible');
+            previewImage.src = '';
+            previewLink.href = '#';
+            previewLink.textContent = '';
+            previewName.textContent = '업로드된 배너 이미지';
+            return;
+        }
+
+        previewContainer.classList.add('visible');
+        previewImage.src = imageUrl;
+        previewLink.href = imageUrl;
+        previewLink.textContent = imageUrl;
+        previewName.textContent = label;
+    }
+
+    async function uploadBannerImage() {
+        const accessToken = localStorage.getItem('accessToken');
+        const fileInput = document.getElementById('bannerImageFile');
+        const statusElement = document.getElementById('bannerImageUploadStatus');
+        const hiddenUrlInput = document.getElementById('bannerImageUrl');
+
+        if (!accessToken) {
+            statusElement.textContent = '액세스 토큰이 없습니다.';
+            return;
+        }
+
+        const imageFile = fileInput.files && fileInput.files[0];
+        if (!imageFile) {
+            statusElement.textContent = '업로드할 이미지를 먼저 선택해주세요.';
+            return;
+        }
+
+        const extension = imageFile.name.includes('.') ? imageFile.name.split('.').pop().toLowerCase() : '';
+        if (!extension) {
+            statusElement.textContent = '파일 확장자를 확인할 수 없습니다.';
+            return;
+        }
+
+        statusElement.textContent = 'Presigned URL을 요청하는 중입니다...';
+
+        try {
+            const uploadUrlResponse = await fetch(`/api/v1/admin/banners/image-upload-url?contentType=${encodeURIComponent(imageFile.type || 'application/octet-stream')}`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer ' + accessToken,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ imageExtension: extension })
+            });
+
+            if (!uploadUrlResponse.ok) {
+                const errorBody = await uploadUrlResponse.json().catch(() => null);
+                throw new Error(errorBody?.msg || '배너 이미지 업로드 URL 발급에 실패했습니다.');
+            }
+
+            const uploadUrlPayload = await uploadUrlResponse.json();
+            const uploadUrl = uploadUrlPayload?.data?.uploadUrl;
+            const publicUrl = uploadUrlPayload?.data?.publicUrl;
+
+            if (!uploadUrl || !publicUrl) {
+                throw new Error('배너 이미지 업로드 URL 응답이 올바르지 않습니다.');
+            }
+
+            statusElement.textContent = 'S3에 이미지를 업로드하는 중입니다...';
+
+            const s3UploadResponse = await fetch(uploadUrl, {
+                method: 'PUT',
+                headers: imageFile.type ? { 'Content-Type': imageFile.type } : {},
+                body: imageFile
+            });
+
+            if (!s3UploadResponse.ok) {
+                throw new Error('S3 이미지 업로드에 실패했습니다.');
+            }
+
+            hiddenUrlInput.value = publicUrl;
+            renderBannerImagePreview(publicUrl, imageFile.name);
+            statusElement.textContent = '배너 이미지 업로드가 완료되었습니다.';
+        } catch (error) {
+            hiddenUrlInput.value = '';
+            renderBannerImagePreview('');
+            statusElement.textContent = error.message || '배너 이미지 업로드 중 오류가 발생했습니다.';
+        }
     }
 
     function renderBannerChipEditors() {
@@ -1579,7 +1718,6 @@
                 <div class="banner-card-body">
                     <div class="banner-card-title-row">
                         <span class="banner-card-title">${escapeHtml(banner.bannerTitle)}</span>
-                        <span class="banner-badge ${banner.isExposed ? 'exposed' : 'hidden'}">${banner.isExposed ? '노출' : '숨김'}</span>
                         <span class="text-muted small">#${banner.id}</span>
                     </div>
                     <div class="banner-card-meta">
@@ -1625,12 +1763,14 @@
 
         document.getElementById('bannerEditId').value = banner.id;
         document.getElementById('bannerImageUrl').value = banner.bannerImageUrl ?? '';
+        document.getElementById('bannerImageFile').value = '';
         document.getElementById('bannerTitle').value = banner.bannerTitle ?? '';
         document.getElementById('bannerStyleQuestion').value = banner.styleQuestion ?? '';
         document.getElementById('bannerStylePrompt').value = banner.stylePrompt ?? '';
-        document.getElementById('bannerIsExposed').value = String(Boolean(banner.isExposed));
         document.getElementById('bannerMappedRawProductKeyword').value = '';
         document.getElementById('bannerMappedRawProductSearchResult').innerHTML = '';
+        document.getElementById('bannerImageUploadStatus').textContent = banner.bannerImageUrl ? '기존 배너 이미지가 연결되어 있습니다. 새 파일을 업로드하면 교체됩니다.' : '이미지를 선택하고 업로드하세요.';
+        renderBannerImagePreview(banner.bannerImageUrl ?? '');
 
         const styleAnswerChips = Array.isArray(banner.styleAnswerChips) ? banner.styleAnswerChips : [];
         styleAnswerChips.slice(0, BANNER_CHIP_MAX_COUNT).forEach((chip, index) => {
@@ -1670,9 +1810,11 @@
         bannerAdminState = createInitialBannerAdminState();
         document.getElementById('banner-form').reset();
         document.getElementById('bannerEditId').value = '';
-        document.getElementById('bannerIsExposed').value = 'true';
+        document.getElementById('bannerImageUrl').value = '';
+        document.getElementById('bannerImageUploadStatus').textContent = '이미지를 선택하고 업로드하세요.';
         document.getElementById('bannerMappedRawProductSearchResult').innerHTML = '';
         document.getElementById('banner-form-result').innerHTML = '';
+        renderBannerImagePreview('');
         renderBannerChipEditors();
         renderBannerMappedRawProducts();
     }
@@ -1699,12 +1841,16 @@
             });
         }
 
+        const bannerImageUrl = parseStringValue(document.getElementById('bannerImageUrl').value);
+        if (!bannerImageUrl) {
+            throw new Error('배너 이미지를 업로드해주세요.');
+        }
+
         return {
-            bannerImageUrl: parseStringValue(document.getElementById('bannerImageUrl').value),
+            bannerImageUrl,
             bannerTitle: parseStringValue(document.getElementById('bannerTitle').value),
             styleQuestion: parseStringValue(document.getElementById('bannerStyleQuestion').value),
             stylePrompt: parseStringValue(document.getElementById('bannerStylePrompt').value),
-            isExposed: document.getElementById('bannerIsExposed').value === 'true',
             styleAnswerChips,
             mappedRawProductIds: bannerAdminState.selectedMappedRawProducts.map(product => product.id)
         };

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
@@ -1,0 +1,157 @@
+package or.sopt.houme.domain.user.presentation.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerStyleAnswerChipResponse;
+import or.sopt.houme.domain.user.service.admin.AdminBannerService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AdminBannerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AdminBannerService adminBannerService;
+
+    @Test
+    @DisplayName("POST /api/v1/admin/banners 요청으로 스타일 배너를 생성할 수 있다")
+    void createBanner_success() throws Exception {
+        AdminBannerCreateRequest request = new AdminBannerCreateRequest(
+                "https://image",
+                "배너 제목",
+                "질문",
+                "prompt",
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
+                List.of(1L),
+                true
+        );
+        when(adminBannerService.create(any(AdminBannerCreateRequest.class))).thenReturn(sampleResponse());
+
+        mockMvc.perform(post("/api/v1/admin/banners")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.bannerTitle").value("배너 제목"))
+                .andExpect(jsonPath("$.data.styleAnswerChips[0].label").value("칩"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/banners 요청으로 스타일 배너 목록을 조회할 수 있다")
+    void getBanners_success() throws Exception {
+        when(adminBannerService.getAll()).thenReturn(new AdminBannerListResponse(List.of(sampleResponse())));
+
+        mockMvc.perform(get("/api/v1/admin/banners"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.banners[0].id").value(1L))
+                .andExpect(jsonPath("$.data.banners[0].mappedRawProducts[0].productName").value("책상 A"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/admin/banners/{id} 요청으로 스타일 배너를 수정할 수 있다")
+    void updateBanner_success() throws Exception {
+        AdminBannerUpdateRequest request = new AdminBannerUpdateRequest(
+                null,
+                "수정 제목",
+                null,
+                null,
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 2L)),
+                List.of(2L),
+                false
+        );
+        AdminBannerResponse response = new AdminBannerResponse(
+                1L,
+                "https://image",
+                "수정 제목",
+                "질문",
+                "prompt",
+                false,
+                List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", 2L, "책상 B", "https://image/2")),
+                List.of(new AdminBannerMappedRawProductResponse(2L, "soozip", null, 22L, "책상 B", "https://image/2", "브랜드")),
+                LocalDateTime.of(2026, 3, 13, 12, 0),
+                LocalDateTime.of(2026, 3, 13, 12, 5)
+        );
+        when(adminBannerService.update(any(Long.class), any(AdminBannerUpdateRequest.class))).thenReturn(response);
+
+        mockMvc.perform(patch("/api/v1/admin/banners/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bannerTitle").value("수정 제목"))
+                .andExpect(jsonPath("$.data.isExposed").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/banners/raw-products/search 요청으로 배너용 RAW 상품을 검색할 수 있다")
+    void searchRawProducts_success() throws Exception {
+        when(adminBannerService.searchRawProducts("책상", 10))
+                .thenReturn(new AdminBannerRawProductSearchResponse(
+                        List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드"))
+                ));
+
+        mockMvc.perform(get("/api/v1/admin/banners/raw-products/search")
+                        .param("keyword", "책상")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rawProducts[0].productName").value("책상 A"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/admin/banners/{id} 요청으로 스타일 배너를 삭제할 수 있다")
+    void deleteBanner_success() throws Exception {
+        doNothing().when(adminBannerService).delete(1L);
+
+        mockMvc.perform(delete("/api/v1/admin/banners/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("스타일 배너가 삭제되었습니다."));
+    }
+
+    private AdminBannerResponse sampleResponse() {
+        return new AdminBannerResponse(
+                1L,
+                "https://image",
+                "배너 제목",
+                "질문",
+                "prompt",
+                true,
+                List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", 1L, "책상 A", "https://image/1")),
+                List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드")),
+                LocalDateTime.of(2026, 3, 13, 12, 0),
+                LocalDateTime.of(2026, 3, 13, 12, 5)
+        );
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
@@ -51,6 +52,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("POST /api/v1/admin/banners 요청으로 배너를 생성할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void createBanner_success() throws Exception {
         AdminBannerCreateRequest request = new AdminBannerCreateRequest(
                 "https://image",
@@ -75,6 +77,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("GET /api/v1/admin/banners 요청으로 배너 목록을 조회할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void getBanners_success() throws Exception {
         when(adminBannerService.getAll()).thenReturn(new AdminBannerListResponse(List.of(sampleResponse())));
 
@@ -86,6 +89,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("PATCH /api/v1/admin/banners/{id} 요청으로 배너를 수정할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void updateBanner_success() throws Exception {
         AdminBannerUpdateRequest request = new AdminBannerUpdateRequest(
                 null,
@@ -120,6 +124,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("POST /api/v1/admin/banners/image-upload-url 요청으로 presigned URL을 생성할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void createBannerImageUploadUrl_success() throws Exception {
         AdminBannerImageUploadRequest request = new AdminBannerImageUploadRequest("png");
         when(adminBannerService.createImageUploadUrl(any(AdminBannerImageUploadRequest.class), any(String.class)))
@@ -136,6 +141,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("GET /api/v1/admin/banners/raw-products/search 요청으로 배너용 RAW 상품을 검색할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void searchRawProducts_success() throws Exception {
         when(adminBannerService.searchRawProducts("책상", 10))
                 .thenReturn(new AdminBannerRawProductSearchResponse(
@@ -151,6 +157,7 @@ class AdminBannerControllerTest {
 
     @Test
     @DisplayName("DELETE /api/v1/admin/banners/{id} 요청으로 배너를 삭제할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void deleteBanner_success() throws Exception {
         doNothing().when(adminBannerService).delete(1L);
 

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
@@ -11,8 +11,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
@@ -56,8 +58,7 @@ class AdminBannerControllerTest {
                 "질문",
                 "prompt",
                 List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
-                List.of(1L),
-                true
+                List.of(1L)
         );
         when(adminBannerService.create(any(AdminBannerCreateRequest.class))).thenReturn(sampleResponse());
 
@@ -90,8 +91,7 @@ class AdminBannerControllerTest {
                 null,
                 null,
                 List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 2L)),
-                List.of(2L),
-                false
+                List.of(2L)
         );
         AdminBannerResponse response = new AdminBannerResponse(
                 1L,
@@ -99,7 +99,6 @@ class AdminBannerControllerTest {
                 "수정 제목",
                 "질문",
                 "prompt",
-                false,
                 List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", 2L, "책상 B", "https://image/2")),
                 List.of(new AdminBannerMappedRawProductResponse(2L, "soozip", null, 22L, "책상 B", "https://image/2", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
@@ -111,8 +110,23 @@ class AdminBannerControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.bannerTitle").value("수정 제목"))
-                .andExpect(jsonPath("$.data.isExposed").value(false));
+                .andExpect(jsonPath("$.data.bannerTitle").value("수정 제목"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/banners/image-upload-url 요청으로 presigned URL을 생성할 수 있다")
+    void createBannerImageUploadUrl_success() throws Exception {
+        AdminBannerImageUploadRequest request = new AdminBannerImageUploadRequest("png");
+        when(adminBannerService.createImageUploadUrl(any(AdminBannerImageUploadRequest.class), any(String.class)))
+                .thenReturn(new AdminBannerImageUploadResponse("https://upload-url", "https://public-url"));
+
+        mockMvc.perform(post("/api/v1/admin/banners/image-upload-url")
+                        .param("contentType", "image/png")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploadUrl").value("https://upload-url"))
+                .andExpect(jsonPath("$.data.publicUrl").value("https://public-url"));
     }
 
     @Test
@@ -147,7 +161,6 @@ class AdminBannerControllerTest {
                 "배너 제목",
                 "질문",
                 "prompt",
-                true,
                 List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", 1L, "책상 A", "https://image/1")),
                 List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
@@ -49,6 +50,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("POST /api/v1/admin/styles 요청으로 스타일을 생성할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void createStyle_success() throws Exception {
         AdminStyleCreateRequest request = new AdminStyleCreateRequest(
                 "https://image",
@@ -69,6 +71,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("GET /api/v1/admin/styles 요청으로 스타일 목록을 조회할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void getStyles_success() throws Exception {
         when(adminStyleService.getAll()).thenReturn(new AdminStyleListResponse(List.of(sampleResponse())));
 
@@ -80,6 +83,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("PATCH /api/v1/admin/styles/{id} 요청으로 스타일을 수정할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void updateStyle_success() throws Exception {
         AdminStyleUpdateRequest request = new AdminStyleUpdateRequest(
                 null,
@@ -109,6 +113,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("POST /api/v1/admin/styles/image-upload-url 요청으로 presigned URL을 생성할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void createStyleImageUploadUrl_success() throws Exception {
         AdminBannerImageUploadRequest request = new AdminBannerImageUploadRequest("png");
         when(adminStyleService.createImageUploadUrl(any(AdminBannerImageUploadRequest.class), any(String.class)))
@@ -125,6 +130,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("GET /api/v1/admin/styles/raw-products/search 요청으로 스타일용 RAW 상품을 검색할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void searchRawProducts_success() throws Exception {
         when(adminStyleService.searchRawProducts("책상", 10))
                 .thenReturn(new AdminBannerRawProductSearchResponse(
@@ -140,6 +146,7 @@ class AdminStyleControllerTest {
 
     @Test
     @DisplayName("DELETE /api/v1/admin/styles/{id} 요청으로 스타일을 삭제할 수 있다")
+    @WithMockUser(roles = "ADMIN")
     void deleteStyle_success() throws Exception {
         doNothing().when(adminStyleService).delete(1L);
 

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminStyleControllerTest.java
@@ -10,17 +10,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
-import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerStyleAnswerChipResponse;
-import or.sopt.houme.domain.user.service.admin.AdminBannerService;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleListResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleResponse;
+import or.sopt.houme.domain.user.service.admin.AdminStyleService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
-class AdminBannerControllerTest {
+class AdminStyleControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -47,85 +45,76 @@ class AdminBannerControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private AdminBannerService adminBannerService;
+    private AdminStyleService adminStyleService;
 
     @Test
-    @DisplayName("POST /api/v1/admin/banners 요청으로 배너를 생성할 수 있다")
-    void createBanner_success() throws Exception {
-        AdminBannerCreateRequest request = new AdminBannerCreateRequest(
+    @DisplayName("POST /api/v1/admin/styles 요청으로 스타일을 생성할 수 있다")
+    void createStyle_success() throws Exception {
+        AdminStyleCreateRequest request = new AdminStyleCreateRequest(
                 "https://image",
-                "배너 제목",
-                "배너 설명",
-                "질문",
+                "스타일 제목",
+                "스타일 설명",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
                 List.of(1L)
         );
-        when(adminBannerService.create(any(AdminBannerCreateRequest.class))).thenReturn(sampleResponse());
+        when(adminStyleService.create(any(AdminStyleCreateRequest.class))).thenReturn(sampleResponse());
 
-        mockMvc.perform(post("/api/v1/admin/banners")
+        mockMvc.perform(post("/api/v1/admin/styles")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.bannerTitle").value("배너 제목"))
-                .andExpect(jsonPath("$.data.styleDescription").value("배너 설명"))
-                .andExpect(jsonPath("$.data.styleAnswerChips[0].label").value("칩"));
+                .andExpect(jsonPath("$.data.bannerTitle").value("스타일 제목"))
+                .andExpect(jsonPath("$.data.styleDescription").value("스타일 설명"));
     }
 
     @Test
-    @DisplayName("GET /api/v1/admin/banners 요청으로 배너 목록을 조회할 수 있다")
-    void getBanners_success() throws Exception {
-        when(adminBannerService.getAll()).thenReturn(new AdminBannerListResponse(List.of(sampleResponse())));
+    @DisplayName("GET /api/v1/admin/styles 요청으로 스타일 목록을 조회할 수 있다")
+    void getStyles_success() throws Exception {
+        when(adminStyleService.getAll()).thenReturn(new AdminStyleListResponse(List.of(sampleResponse())));
 
-        mockMvc.perform(get("/api/v1/admin/banners"))
+        mockMvc.perform(get("/api/v1/admin/styles"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.banners[0].id").value(1L))
-                .andExpect(jsonPath("$.data.banners[0].mappedRawProducts[0].productName").value("책상 A"));
+                .andExpect(jsonPath("$.data.styles[0].id").value(1L))
+                .andExpect(jsonPath("$.data.styles[0].mappedRawProducts[0].productName").value("책상 A"));
     }
 
     @Test
-    @DisplayName("PATCH /api/v1/admin/banners/{id} 요청으로 배너를 수정할 수 있다")
-    void updateBanner_success() throws Exception {
-        AdminBannerUpdateRequest request = new AdminBannerUpdateRequest(
+    @DisplayName("PATCH /api/v1/admin/styles/{id} 요청으로 스타일을 수정할 수 있다")
+    void updateStyle_success() throws Exception {
+        AdminStyleUpdateRequest request = new AdminStyleUpdateRequest(
                 null,
-                "수정 제목",
+                "수정 스타일",
                 "수정 설명",
-                null,
-                null,
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 2L)),
+                "new prompt",
                 List.of(2L)
         );
-        AdminBannerResponse response = new AdminBannerResponse(
+        AdminStyleResponse response = new AdminStyleResponse(
                 1L,
                 "https://image",
-                "수정 제목",
+                "수정 스타일",
                 "수정 설명",
-                "질문",
-                "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", 2L, "책상 B", "https://image/2")),
+                "new prompt",
                 List.of(new AdminBannerMappedRawProductResponse(2L, "soozip", null, 22L, "책상 B", "https://image/2", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)
         );
-        when(adminBannerService.update(any(Long.class), any(AdminBannerUpdateRequest.class))).thenReturn(response);
+        when(adminStyleService.update(any(Long.class), any(AdminStyleUpdateRequest.class))).thenReturn(response);
 
-        mockMvc.perform(patch("/api/v1/admin/banners/1")
+        mockMvc.perform(patch("/api/v1/admin/styles/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.bannerTitle").value("수정 제목"))
-                .andExpect(jsonPath("$.data.styleDescription").value("수정 설명"));
+                .andExpect(jsonPath("$.data.bannerTitle").value("수정 스타일"));
     }
 
     @Test
-    @DisplayName("POST /api/v1/admin/banners/image-upload-url 요청으로 presigned URL을 생성할 수 있다")
-    void createBannerImageUploadUrl_success() throws Exception {
+    @DisplayName("POST /api/v1/admin/styles/image-upload-url 요청으로 presigned URL을 생성할 수 있다")
+    void createStyleImageUploadUrl_success() throws Exception {
         AdminBannerImageUploadRequest request = new AdminBannerImageUploadRequest("png");
-        when(adminBannerService.createImageUploadUrl(any(AdminBannerImageUploadRequest.class), any(String.class)))
+        when(adminStyleService.createImageUploadUrl(any(AdminBannerImageUploadRequest.class), any(String.class)))
                 .thenReturn(new AdminBannerImageUploadResponse("https://upload-url", "https://public-url"));
 
-        mockMvc.perform(post("/api/v1/admin/banners/image-upload-url")
+        mockMvc.perform(post("/api/v1/admin/styles/image-upload-url")
                         .param("contentType", "image/png")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -135,14 +124,14 @@ class AdminBannerControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v1/admin/banners/raw-products/search 요청으로 배너용 RAW 상품을 검색할 수 있다")
+    @DisplayName("GET /api/v1/admin/styles/raw-products/search 요청으로 스타일용 RAW 상품을 검색할 수 있다")
     void searchRawProducts_success() throws Exception {
-        when(adminBannerService.searchRawProducts("책상", 10))
+        when(adminStyleService.searchRawProducts("책상", 10))
                 .thenReturn(new AdminBannerRawProductSearchResponse(
                         List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드"))
                 ));
 
-        mockMvc.perform(get("/api/v1/admin/banners/raw-products/search")
+        mockMvc.perform(get("/api/v1/admin/styles/raw-products/search")
                         .param("keyword", "책상")
                         .param("size", "10"))
                 .andExpect(status().isOk())
@@ -150,24 +139,22 @@ class AdminBannerControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /api/v1/admin/banners/{id} 요청으로 배너를 삭제할 수 있다")
-    void deleteBanner_success() throws Exception {
-        doNothing().when(adminBannerService).delete(1L);
+    @DisplayName("DELETE /api/v1/admin/styles/{id} 요청으로 스타일을 삭제할 수 있다")
+    void deleteStyle_success() throws Exception {
+        doNothing().when(adminStyleService).delete(1L);
 
-        mockMvc.perform(delete("/api/v1/admin/banners/1"))
+        mockMvc.perform(delete("/api/v1/admin/styles/1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value("배너가 삭제되었습니다."));
+                .andExpect(jsonPath("$.data").value("스타일이 삭제되었습니다."));
     }
 
-    private AdminBannerResponse sampleResponse() {
-        return new AdminBannerResponse(
+    private AdminStyleResponse sampleResponse() {
+        return new AdminStyleResponse(
                 1L,
                 "https://image",
-                "배너 제목",
-                "배너 설명",
-                "질문",
+                "스타일 제목",
+                "스타일 설명",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", 1L, "책상 A", "https://image/1")),
                 List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -1,0 +1,186 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminBannerServiceImplTest {
+
+    @InjectMocks
+    private AdminBannerServiceImpl adminBannerService;
+
+    @Mock
+    private BannerRepository bannerRepository;
+
+    @Mock
+    private CurationRawProductRepository curationRawProductRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("create()는 스타일 배너를 생성하고 RAW 상품 매핑을 저장한다")
+    void create_success() {
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        CurationRawProduct chipRawProduct = rawProduct(1L, 101L, "책상 A");
+        CurationRawProduct mappedRawProduct = rawProduct(2L, 202L, "의자 B");
+        AtomicReference<Banner> savedBannerRef = new AtomicReference<>();
+
+        AdminBannerCreateRequest request = new AdminBannerCreateRequest(
+                "https://image",
+                "배너 제목",
+                "어떤 책상을 선호하시나요?",
+                "mid century modern",
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "모니터 받침대가 결합된 책상", 1L)),
+                List.of(1L, 2L),
+                true
+        );
+
+        when(curationRawProductRepository.findAllById(List.of(1L, 2L)))
+                .thenReturn(List.of(chipRawProduct, mappedRawProduct));
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenAnswer(invocation -> {
+            Banner banner = invocation.getArgument(0);
+            ReflectionTestUtils.setField(banner, "id", 10L);
+            ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
+            ReflectionTestUtils.setField(banner, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
+            savedBannerRef.set(banner);
+            return banner;
+        });
+        when(bannerRepository.findByIdWithRawProducts(10L)).thenAnswer(invocation -> Optional.ofNullable(savedBannerRef.get()));
+
+        AdminBannerResponse response = adminBannerService.create(request);
+
+        assertThat(response.id()).isEqualTo(10L);
+        assertThat(response.bannerTitle()).isEqualTo("배너 제목");
+        assertThat(response.styleAnswerChips()).hasSize(1);
+        assertThat(response.styleAnswerChips().getFirst().curationRawProductName()).isEqualTo("책상 A");
+        assertThat(response.mappedRawProducts()).hasSize(2);
+        verify(bannerRepository, times(1)).saveAndFlush(any(Banner.class));
+    }
+
+    @Test
+    @DisplayName("create()는 스타일 답변 칩이 4개를 초과하면 예외를 던진다")
+    void create_invalidChipSize() {
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        AdminBannerCreateRequest request = new AdminBannerCreateRequest(
+                "https://image",
+                "배너 제목",
+                "질문",
+                "prompt",
+                List.of(
+                        new AdminBannerStyleAnswerChipRequest(1, "a", 1L),
+                        new AdminBannerStyleAnswerChipRequest(2, "b", 2L),
+                        new AdminBannerStyleAnswerChipRequest(3, "c", 3L),
+                        new AdminBannerStyleAnswerChipRequest(4, "d", 4L),
+                        new AdminBannerStyleAnswerChipRequest(5, "e", 5L)
+                ),
+                List.of(),
+                true
+        );
+
+        GeneralException exception = assertThrows(GeneralException.class, () -> adminBannerService.create(request));
+        assertEquals(ErrorCode.NOT_VALID_EXCEPTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("update()는 배너 정보를 수정하고 매핑 가구를 교체한다")
+    void update_success() throws Exception {
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        Banner banner = Banner.create(
+                "https://old-image",
+                "기존 제목",
+                "기존 질문",
+                "기존 프롬프트",
+                objectMapper.writeValueAsString(List.of()),
+                true
+        );
+        ReflectionTestUtils.setField(banner, "id", 11L);
+        ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
+        ReflectionTestUtils.setField(banner, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
+
+        CurationRawProduct mappedRawProduct = rawProduct(3L, 303L, "조명 C");
+        when(bannerRepository.findByIdWithRawProducts(11L)).thenReturn(Optional.of(banner));
+        when(curationRawProductRepository.findAllById(List.of(3L))).thenReturn(List.of(mappedRawProduct));
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AdminBannerUpdateRequest request = new AdminBannerUpdateRequest(
+                "https://new-image",
+                "새 제목",
+                null,
+                null,
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "포인트 조명", 3L)),
+                List.of(3L),
+                false
+        );
+
+        AdminBannerResponse response = adminBannerService.update(11L, request);
+
+        assertThat(response.bannerImageUrl()).isEqualTo("https://new-image");
+        assertThat(response.bannerTitle()).isEqualTo("새 제목");
+        assertThat(response.isExposed()).isFalse();
+        assertThat(response.styleAnswerChips()).hasSize(1);
+        assertThat(response.mappedRawProducts()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("searchRawProducts()는 키워드로 RAW 상품을 검색한다")
+    void searchRawProducts_success() {
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        when(curationRawProductRepository.searchByKeyword(eq("책상"), eq(PageRequest.of(0, 10))))
+                .thenReturn(new PageImpl<>(List.of(rawProduct(1L, 10L, "책상 A"))));
+
+        AdminBannerRawProductSearchResponse response = adminBannerService.searchRawProducts("책상", 10);
+
+        assertThat(response.rawProducts()).hasSize(1);
+        assertThat(response.rawProducts().get(0).productName()).isEqualTo("책상 A");
+    }
+
+    private CurationRawProduct rawProduct(Long id, Long productId, String productName) {
+        CurationRawProduct rawProduct = CurationRawProduct.builder()
+                .id(id)
+                .source("soozip")
+                .category(SoozipCategory.FURNITURE)
+                .productId(productId)
+                .productImageUrl("https://image/" + id)
+                .productSiteUrl("https://site/" + id)
+                .productName(productName)
+                .productMallName("SOOZIP")
+                .brand("브랜드")
+                .fetchedAt(LocalDateTime.of(2026, 3, 13, 12, 0))
+                .build();
+        return rawProduct;
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -16,12 +16,16 @@ import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
+import or.sopt.houme.global.util.S3PresignedUtil;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,12 +53,15 @@ class AdminBannerServiceImplTest {
     @Mock
     private CurationRawProductRepository curationRawProductRepository;
 
+    @Mock
+    private S3PresignedUtil s3PresignedUtil;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     @DisplayName("create()는 스타일 배너를 생성하고 RAW 상품 매핑을 저장한다")
     void create_success() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
         CurationRawProduct chipRawProduct = rawProduct(1L, 101L, "책상 A");
         CurationRawProduct mappedRawProduct = rawProduct(2L, 202L, "의자 B");
         AtomicReference<Banner> savedBannerRef = new AtomicReference<>();
@@ -65,8 +72,7 @@ class AdminBannerServiceImplTest {
                 "어떤 책상을 선호하시나요?",
                 "mid century modern",
                 List.of(new AdminBannerStyleAnswerChipRequest(1, "모니터 받침대가 결합된 책상", 1L)),
-                List.of(1L, 2L),
-                true
+                List.of(1L, 2L)
         );
 
         when(curationRawProductRepository.findAllById(List.of(1L, 2L)))
@@ -94,7 +100,7 @@ class AdminBannerServiceImplTest {
     @Test
     @DisplayName("create()는 스타일 답변 칩이 4개를 초과하면 예외를 던진다")
     void create_invalidChipSize() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
         AdminBannerCreateRequest request = new AdminBannerCreateRequest(
                 "https://image",
                 "배너 제목",
@@ -107,8 +113,7 @@ class AdminBannerServiceImplTest {
                         new AdminBannerStyleAnswerChipRequest(4, "d", 4L),
                         new AdminBannerStyleAnswerChipRequest(5, "e", 5L)
                 ),
-                List.of(),
-                true
+                List.of()
         );
 
         GeneralException exception = assertThrows(GeneralException.class, () -> adminBannerService.create(request));
@@ -118,14 +123,13 @@ class AdminBannerServiceImplTest {
     @Test
     @DisplayName("update()는 배너 정보를 수정하고 매핑 가구를 교체한다")
     void update_success() throws Exception {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
         Banner banner = Banner.create(
                 "https://old-image",
                 "기존 제목",
                 "기존 질문",
                 "기존 프롬프트",
-                objectMapper.writeValueAsString(List.of()),
-                true
+                objectMapper.writeValueAsString(List.of())
         );
         ReflectionTestUtils.setField(banner, "id", 11L);
         ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
@@ -142,23 +146,37 @@ class AdminBannerServiceImplTest {
                 null,
                 null,
                 List.of(new AdminBannerStyleAnswerChipRequest(1, "포인트 조명", 3L)),
-                List.of(3L),
-                false
+                List.of(3L)
         );
 
         AdminBannerResponse response = adminBannerService.update(11L, request);
 
         assertThat(response.bannerImageUrl()).isEqualTo("https://new-image");
         assertThat(response.bannerTitle()).isEqualTo("새 제목");
-        assertThat(response.isExposed()).isFalse();
         assertThat(response.styleAnswerChips()).hasSize(1);
         assertThat(response.mappedRawProducts()).hasSize(1);
     }
 
     @Test
+    @DisplayName("createImageUploadUrl()은 배너 이미지 업로드용 presigned url을 반환한다")
+    void createImageUploadUrl_success() {
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
+        when(s3PresignedUtil.createPresignedUrl("png", "banner", "image/png"))
+                .thenReturn(new S3PresignedUrlResponseDTO("https://upload", "https://public", "banner/1.png", "banner"));
+
+        AdminBannerImageUploadResponse response = adminBannerService.createImageUploadUrl(
+                new AdminBannerImageUploadRequest("png"),
+                "image/png"
+        );
+
+        assertThat(response.uploadUrl()).isEqualTo("https://upload");
+        assertThat(response.publicUrl()).isEqualTo("https://public");
+    }
+
+    @Test
     @DisplayName("searchRawProducts()는 키워드로 RAW 상품을 검색한다")
     void searchRawProducts_success() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper);
+        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
         when(curationRawProductRepository.searchByKeyword(eq("책상"), eq(PageRequest.of(0, 10))))
                 .thenReturn(new PageImpl<>(List.of(rawProduct(1L, 10L, "책상 A"))));
 

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.user.service.admin;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,13 +22,17 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.respon
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,6 +50,44 @@ class AdminBannerServiceImplTest {
 
     @Mock
     private AdminBannerSupport adminBannerSupport;
+
+    @Test
+    @DisplayName("normalizeStyleAnswerChips()는 null 요청 요소를 거절한다")
+    void normalizeStyleAnswerChips_rejectsNullRequestItem() {
+        AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
+
+        assertThatThrownBy(() -> support.normalizeStyleAnswerChips(Arrays.asList(
+                new AdminBannerStyleAnswerChipRequest(1, "칩", 1L),
+                null
+        )))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_VALID_EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("normalizeStyleAnswerChips()는 null order를 거절한다")
+    void normalizeStyleAnswerChips_rejectsNullOrder() {
+        AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
+
+        assertThatThrownBy(() -> support.normalizeStyleAnswerChips(List.of(
+                new AdminBannerStyleAnswerChipRequest(null, "칩", 1L)
+        )))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_VALID_EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("deduplicateIds()는 null 요소를 거절한다")
+    void deduplicateIds_rejectsNullElement() {
+        AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
+
+        assertThatThrownBy(() -> support.deduplicateIds(Arrays.asList(1L, null, 2L)))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_VALID_EXCEPTION);
+    }
 
     @Test
     @DisplayName("create()는 배너를 생성한다")

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -1,43 +1,36 @@
 package or.sopt.houme.domain.user.service.admin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
+import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
-import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerCreateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerStyleAnswerChipRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerUpdateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerResponse;
-import or.sopt.houme.global.api.ErrorCode;
-import or.sopt.houme.global.api.GeneralException;
-import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
-import or.sopt.houme.global.util.S3PresignedUtil;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,118 +44,112 @@ class AdminBannerServiceImplTest {
     private BannerRepository bannerRepository;
 
     @Mock
-    private CurationRawProductRepository curationRawProductRepository;
-
-    @Mock
-    private S3PresignedUtil s3PresignedUtil;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private AdminBannerSupport adminBannerSupport;
 
     @Test
-    @DisplayName("create()는 스타일 배너를 생성하고 RAW 상품 매핑을 저장한다")
+    @DisplayName("create()는 배너를 생성한다")
     void create_success() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
         CurationRawProduct chipRawProduct = rawProduct(1L, 101L, "책상 A");
-        CurationRawProduct mappedRawProduct = rawProduct(2L, 202L, "의자 B");
-        AtomicReference<Banner> savedBannerRef = new AtomicReference<>();
+        Banner banner = Banner.create(
+                BannerType.BANNER,
+                "https://image",
+                "배너 제목",
+                "설명",
+                "질문",
+                "prompt",
+                "[]"
+        );
+        ReflectionTestUtils.setField(banner, "id", 10L);
+        ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
+        ReflectionTestUtils.setField(banner, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
 
         AdminBannerCreateRequest request = new AdminBannerCreateRequest(
                 "https://image",
                 "배너 제목",
-                "어떤 책상을 선호하시나요?",
-                "mid century modern",
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "모니터 받침대가 결합된 책상", 1L)),
-                List.of(1L, 2L)
+                "설명",
+                "질문",
+                "prompt",
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
+                List.of(1L)
         );
 
-        when(curationRawProductRepository.findAllById(List.of(1L, 2L)))
-                .thenReturn(List.of(chipRawProduct, mappedRawProduct));
-        when(bannerRepository.saveAndFlush(any(Banner.class))).thenAnswer(invocation -> {
-            Banner banner = invocation.getArgument(0);
-            ReflectionTestUtils.setField(banner, "id", 10L);
-            ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
-            ReflectionTestUtils.setField(banner, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
-            savedBannerRef.set(banner);
-            return banner;
-        });
-        when(bannerRepository.findByIdWithRawProducts(10L)).thenAnswer(invocation -> Optional.ofNullable(savedBannerRef.get()));
+        when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
+                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", 1L)));
+        when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(1L)))).thenReturn(List.of(1L));
+        when(adminBannerSupport.loadRequiredRawProducts(List.of(1L))).thenReturn(Map.of(1L, chipRawProduct));
+        when(adminBannerSupport.normalizeRequired("https://image")).thenReturn("https://image");
+        when(adminBannerSupport.normalizeRequired("배너 제목")).thenReturn("배너 제목");
+        when(adminBannerSupport.normalizeRequired("설명")).thenReturn("설명");
+        when(adminBannerSupport.normalizeRequired("질문")).thenReturn("질문");
+        when(adminBannerSupport.normalizeRequired("prompt")).thenReturn("prompt");
+        when(adminBannerSupport.toStyleAnswerChipsJson(any())).thenReturn("[{\"order\":1}]");
+        when(adminBannerSupport.buildMappings(any(Banner.class), eq(List.of(1L)), eq(Map.of(1L, chipRawProduct))))
+                .thenReturn(List.of());
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(banner);
+        when(bannerRepository.findByIdWithRawProducts(10L, BannerType.BANNER, true)).thenReturn(Optional.of(banner));
+        when(adminBannerSupport.parseStyleAnswerChipsJson(any())).thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", 1L)));
+        when(adminBannerSupport.toMappedRawProductResponses(eq(banner), eq(Map.of(1L, chipRawProduct)))).thenReturn(List.of());
 
         AdminBannerResponse response = adminBannerService.create(request);
 
         assertThat(response.id()).isEqualTo(10L);
         assertThat(response.bannerTitle()).isEqualTo("배너 제목");
-        assertThat(response.styleAnswerChips()).hasSize(1);
-        assertThat(response.styleAnswerChips().getFirst().curationRawProductName()).isEqualTo("책상 A");
-        assertThat(response.mappedRawProducts()).hasSize(2);
-        verify(bannerRepository, times(1)).saveAndFlush(any(Banner.class));
+        assertThat(response.styleDescription()).isEqualTo("설명");
+        verify(bannerRepository).saveAndFlush(any(Banner.class));
     }
 
     @Test
-    @DisplayName("create()는 스타일 답변 칩이 4개를 초과하면 예외를 던진다")
-    void create_invalidChipSize() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
-        AdminBannerCreateRequest request = new AdminBannerCreateRequest(
-                "https://image",
-                "배너 제목",
-                "질문",
-                "prompt",
-                List.of(
-                        new AdminBannerStyleAnswerChipRequest(1, "a", 1L),
-                        new AdminBannerStyleAnswerChipRequest(2, "b", 2L),
-                        new AdminBannerStyleAnswerChipRequest(3, "c", 3L),
-                        new AdminBannerStyleAnswerChipRequest(4, "d", 4L),
-                        new AdminBannerStyleAnswerChipRequest(5, "e", 5L)
-                ),
-                List.of()
-        );
-
-        GeneralException exception = assertThrows(GeneralException.class, () -> adminBannerService.create(request));
-        assertEquals(ErrorCode.NOT_VALID_EXCEPTION, exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("update()는 배너 정보를 수정하고 매핑 가구를 교체한다")
-    void update_success() throws Exception {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
+    @DisplayName("update()는 배너를 수정한다")
+    void update_success() {
+        CurationRawProduct rawProduct = rawProduct(3L, 303L, "조명 C");
         Banner banner = Banner.create(
+                BannerType.BANNER,
                 "https://old-image",
                 "기존 제목",
+                "기존 설명",
                 "기존 질문",
                 "기존 프롬프트",
-                objectMapper.writeValueAsString(List.of())
+                "[]"
         );
         ReflectionTestUtils.setField(banner, "id", 11L);
         ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
         ReflectionTestUtils.setField(banner, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
 
-        CurationRawProduct mappedRawProduct = rawProduct(3L, 303L, "조명 C");
-        when(bannerRepository.findByIdWithRawProducts(11L)).thenReturn(Optional.of(banner));
-        when(curationRawProductRepository.findAllById(List.of(3L))).thenReturn(List.of(mappedRawProduct));
-        when(bannerRepository.saveAndFlush(any(Banner.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
         AdminBannerUpdateRequest request = new AdminBannerUpdateRequest(
                 "https://new-image",
                 "새 제목",
-                null,
-                null,
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "포인트 조명", 3L)),
+                "새 설명",
+                "새 질문",
+                "새 프롬프트",
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 3L)),
                 List.of(3L)
         );
 
+        when(bannerRepository.findByIdWithRawProducts(11L, BannerType.BANNER, true)).thenReturn(Optional.of(banner));
+        when(adminBannerSupport.parseStyleAnswerChipsJson(any())).thenReturn(List.of());
+        when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
+                .thenReturn(List.of(new BannerStyleAnswerChip(1, "새 칩", 3L)));
+        when(adminBannerSupport.extractMappedRawProductIds(banner)).thenReturn(List.of());
+        when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(3L)))).thenReturn(List.of(3L));
+        when(adminBannerSupport.loadRequiredRawProducts(List.of(3L))).thenReturn(Map.of(3L, rawProduct));
+        when(adminBannerSupport.normalizeRequired(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adminBannerSupport.toStyleAnswerChipsJson(any())).thenReturn("[{\"order\":1}]");
+        when(adminBannerSupport.buildMappings(any(Banner.class), eq(List.of(3L)), any())).thenReturn(List.of());
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(banner);
+        when(adminBannerSupport.toMappedRawProductResponses(eq(banner), eq(Map.of(3L, rawProduct))))
+                .thenReturn(List.of(AdminBannerMappedRawProductResponse.of(rawProduct)));
+
         AdminBannerResponse response = adminBannerService.update(11L, request);
 
-        assertThat(response.bannerImageUrl()).isEqualTo("https://new-image");
         assertThat(response.bannerTitle()).isEqualTo("새 제목");
-        assertThat(response.styleAnswerChips()).hasSize(1);
-        assertThat(response.mappedRawProducts()).hasSize(1);
+        assertThat(response.styleDescription()).isEqualTo("새 설명");
     }
 
     @Test
-    @DisplayName("createImageUploadUrl()은 배너 이미지 업로드용 presigned url을 반환한다")
+    @DisplayName("createImageUploadUrl()은 업로드 URL을 반환한다")
     void createImageUploadUrl_success() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
-        when(s3PresignedUtil.createPresignedUrl("png", "banner", "image/png"))
-                .thenReturn(new S3PresignedUrlResponseDTO("https://upload", "https://public", "banner/1.png", "banner"));
+        when(adminBannerSupport.createImageUploadUrl(any(), eq("image/png"), eq("banner")))
+                .thenReturn(new AdminBannerImageUploadResponse("https://upload", "https://public"));
 
         AdminBannerImageUploadResponse response = adminBannerService.createImageUploadUrl(
                 new AdminBannerImageUploadRequest("png"),
@@ -174,20 +161,21 @@ class AdminBannerServiceImplTest {
     }
 
     @Test
-    @DisplayName("searchRawProducts()는 키워드로 RAW 상품을 검색한다")
+    @DisplayName("searchRawProducts()는 검색 결과를 반환한다")
     void searchRawProducts_success() {
-        adminBannerService = new AdminBannerServiceImpl(bannerRepository, curationRawProductRepository, objectMapper, s3PresignedUtil);
-        when(curationRawProductRepository.searchByKeyword(eq("책상"), eq(PageRequest.of(0, 10))))
-                .thenReturn(new PageImpl<>(List.of(rawProduct(1L, 10L, "책상 A"))));
+        AdminBannerRawProductSearchResponse searchResponse = new AdminBannerRawProductSearchResponse(
+                List.of(AdminBannerMappedRawProductResponse.of(rawProduct(1L, 10L, "책상 A")))
+        );
+        when(adminBannerSupport.searchRawProducts("책상", 10)).thenReturn(searchResponse);
 
         AdminBannerRawProductSearchResponse response = adminBannerService.searchRawProducts("책상", 10);
 
         assertThat(response.rawProducts()).hasSize(1);
-        assertThat(response.rawProducts().get(0).productName()).isEqualTo("책상 A");
+        assertThat(response.rawProducts().getFirst().productName()).isEqualTo("책상 A");
     }
 
     private CurationRawProduct rawProduct(Long id, Long productId, String productName) {
-        CurationRawProduct rawProduct = CurationRawProduct.builder()
+        return CurationRawProduct.builder()
                 .id(id)
                 .source("soozip")
                 .category(SoozipCategory.FURNITURE)
@@ -199,6 +187,5 @@ class AdminBannerServiceImplTest {
                 .brand("브랜드")
                 .fetchedAt(LocalDateTime.of(2026, 3, 13, 12, 0))
                 .build();
-        return rawProduct;
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImplTest.java
@@ -1,0 +1,168 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerMappedRawProductResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleCreateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.request.AdminStyleUpdateRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.style.response.AdminStyleResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminStyleServiceImplTest {
+
+    @InjectMocks
+    private AdminStyleServiceImpl adminStyleService;
+
+    @Mock
+    private BannerRepository bannerRepository;
+
+    @Mock
+    private AdminBannerSupport adminBannerSupport;
+
+    @Test
+    @DisplayName("create()는 스타일을 생성한다")
+    void create_success() {
+        CurationRawProduct rawProduct = rawProduct(1L, 101L, "의자 A");
+        Banner style = Banner.create(
+                BannerType.STYLE,
+                "https://image",
+                "스타일 제목",
+                "스타일 설명",
+                null,
+                "prompt",
+                null
+        );
+        ReflectionTestUtils.setField(style, "id", 20L);
+        ReflectionTestUtils.setField(style, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
+        ReflectionTestUtils.setField(style, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
+
+        AdminStyleCreateRequest request = new AdminStyleCreateRequest(
+                "https://image",
+                "스타일 제목",
+                "스타일 설명",
+                "prompt",
+                List.of(1L)
+        );
+
+        when(adminBannerSupport.loadRequiredRawProducts(List.of(1L))).thenReturn(Map.of(1L, rawProduct));
+        when(adminBannerSupport.normalizeRequired(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adminBannerSupport.buildMappings(any(Banner.class), eq(List.of(1L)), any())).thenReturn(List.of());
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(style);
+        when(bannerRepository.findByIdWithRawProducts(20L, BannerType.STYLE, false)).thenReturn(Optional.of(style));
+        when(adminBannerSupport.toMappedRawProductResponses(eq(style), eq(Map.of(1L, rawProduct))))
+                .thenReturn(List.of(AdminBannerMappedRawProductResponse.of(rawProduct)));
+
+        AdminStyleResponse response = adminStyleService.create(request);
+
+        assertThat(response.id()).isEqualTo(20L);
+        assertThat(response.bannerTitle()).isEqualTo("스타일 제목");
+        assertThat(response.styleDescription()).isEqualTo("스타일 설명");
+        verify(bannerRepository).saveAndFlush(any(Banner.class));
+    }
+
+    @Test
+    @DisplayName("update()는 스타일을 수정한다")
+    void update_success() {
+        CurationRawProduct rawProduct = rawProduct(2L, 202L, "테이블 B");
+        Banner style = Banner.create(
+                BannerType.STYLE,
+                "https://old-image",
+                "기존 스타일",
+                "기존 설명",
+                null,
+                "old prompt",
+                null
+        );
+        ReflectionTestUtils.setField(style, "id", 21L);
+        ReflectionTestUtils.setField(style, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
+        ReflectionTestUtils.setField(style, "updatedAt", LocalDateTime.of(2026, 3, 13, 12, 5));
+
+        AdminStyleUpdateRequest request = new AdminStyleUpdateRequest(
+                null,
+                "새 스타일",
+                "새 설명",
+                "new prompt",
+                List.of(2L)
+        );
+
+        when(bannerRepository.findByIdWithRawProducts(21L, BannerType.STYLE, false)).thenReturn(Optional.of(style));
+        when(adminBannerSupport.loadRequiredRawProducts(List.of(2L))).thenReturn(Map.of(2L, rawProduct));
+        when(adminBannerSupport.normalizeRequired(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adminBannerSupport.buildMappings(any(Banner.class), eq(List.of(2L)), any())).thenReturn(List.of());
+        when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(style);
+        when(adminBannerSupport.toMappedRawProductResponses(eq(style), eq(Map.of(2L, rawProduct))))
+                .thenReturn(List.of(AdminBannerMappedRawProductResponse.of(rawProduct)));
+
+        AdminStyleResponse response = adminStyleService.update(21L, request);
+
+        assertThat(response.bannerTitle()).isEqualTo("새 스타일");
+        assertThat(response.styleDescription()).isEqualTo("새 설명");
+    }
+
+    @Test
+    @DisplayName("createImageUploadUrl()은 스타일 이미지 업로드 URL을 반환한다")
+    void createImageUploadUrl_success() {
+        when(adminBannerSupport.createImageUploadUrl(any(), eq("image/png"), eq("style")))
+                .thenReturn(new AdminBannerImageUploadResponse("https://upload", "https://public"));
+
+        AdminBannerImageUploadResponse response = adminStyleService.createImageUploadUrl(
+                new AdminBannerImageUploadRequest("png"),
+                "image/png"
+        );
+
+        assertThat(response.uploadUrl()).isEqualTo("https://upload");
+        assertThat(response.publicUrl()).isEqualTo("https://public");
+    }
+
+    @Test
+    @DisplayName("searchRawProducts()는 검색 결과를 반환한다")
+    void searchRawProducts_success() {
+        AdminBannerRawProductSearchResponse searchResponse = new AdminBannerRawProductSearchResponse(
+                List.of(AdminBannerMappedRawProductResponse.of(rawProduct(1L, 10L, "책상 A")))
+        );
+        when(adminBannerSupport.searchRawProducts("책상", 10)).thenReturn(searchResponse);
+
+        AdminBannerRawProductSearchResponse response = adminStyleService.searchRawProducts("책상", 10);
+
+        assertThat(response.rawProducts()).hasSize(1);
+    }
+
+    private CurationRawProduct rawProduct(Long id, Long productId, String productName) {
+        return CurationRawProduct.builder()
+                .id(id)
+                .source("soozip")
+                .category(SoozipCategory.FURNITURE)
+                .productId(productId)
+                .productImageUrl("https://image/" + id)
+                .productSiteUrl("https://site/" + id)
+                .productName(productName)
+                .productMallName("SOOZIP")
+                .brand("브랜드")
+                .fetchedAt(LocalDateTime.of(2026, 3, 13, 12, 0))
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #440 

## 해당 PR은 #445 PR에서 연결되는 PR입니다.

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

#445 에서 구현한 Banner테이블을 재활용하여 만들어봤습니다.
거의 다루는 데이터가 유사하다고 판단하여 ENUM으로 둘을 구분하였습니다. 어드민을 통해 입력된 데이터 예시는 다음과 같습니다.

| id | created\_at | updated\_at | banner\_image\_url | banner\_title | banner\_type | style\_answer\_chips\_json | style\_description | style\_prompt | style\_question |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | 2026-03-13 14:47:53.081396 | 2026-03-13 14:47:53.081396 | https://houme-bucket.s3.ap-northeast-2.amazonaws.com/style/1773380837049\_6b3fbb80.png | style\_test\_1 | STYLE | null | style\_test\_description | style\_test\_prompt | null |
| 2 | 2026-03-13 14:49:28.224203 | 2026-03-13 14:49:28.224203 | https://houme-bucket.s3.ap-northeast-2.amazonaws.com/banner/1773380965254\_6da98a03.png | banner\_title | BANNER | \[{"label": "banner\_answer\_1", "order": 1, "curationRawProductId": 886}, {"label": "banner\_answer\_2", "order": 2, "curationRawProductId": 912}, {"label": "banner\_answer\_3", "order": 3, "curationRawProductId": 839}, {"label": "banner\_answer\_4", "order": 4, "curationRawProductId": 828}\] | banner\_description | banner\_prompt | banner\_question |


본탁님이 만들어주신 엑셀파일에서 반영된 필드 내역을 다음과 같습니다.

```
1. 스타일 이미지: bannerImageUrl
2. 스타일 이름: bannerTitle
3. 스타일 설명: styleDescription
4. 사용된 가구 이름: 매핑 테이블 BannerCurationRawProduct
5. 스타일 참고 프롬프트: stylePrompt
```

확인해보시고 추가되어야하는 데이터가 있다면 말씀해주세요~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **신규 기능**
  * 관리자 대시보드에 배너 관리 추가(생성·조회·수정·삭제, 이미지 업로드)
  * 관리자 대시보드에 스타일 관리 추가(생성·조회·수정·삭제, 이미지 업로드)
  * 배너/스타일에 RAW 상품 검색 및 매핑(칩 기반 매핑 포함) 기능 추가
* **테스트**
  * 관리자 API 및 서비스 계층에 대한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->