### PR TITLE
[FEATURE] 도면 view, name 필드 관리 기능 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -11,8 +12,9 @@ import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import java.util.List;
 
 public record AdminFloorPlanCreateRequest(
+        @JsonAlias("floorPlanName")
         @NotBlank
-        String floorPlanName,
+        String name,
         @NotNull
         Form form,
         @NotNull

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
@@ -1,6 +1,5 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.request;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -12,9 +11,8 @@ import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import java.util.List;
 
 public record AdminFloorPlanCreateRequest(
-        @JsonAlias("floorPlanName")
         @NotBlank
-        String name,
+        String floorPlanName,
         @NotNull
         Form form,
         @NotNull

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanImageRequest.java
@@ -17,7 +17,7 @@ public record AdminFloorPlanImageRequest(
         @NotNull
         @Min(1)
         Integer sortOrder,
-        @JsonAlias("veiw")
+        @JsonAlias({"viewName", "veiw"})
         String view
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanImageRequest.java
@@ -17,7 +17,7 @@ public record AdminFloorPlanImageRequest(
         @NotNull
         @Min(1)
         Integer sortOrder,
-        @JsonAlias({"viewName", "veiw"})
+        @JsonAlias("veiw")
         String view
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
@@ -1,6 +1,5 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.request;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
@@ -10,8 +9,7 @@ import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import java.util.List;
 
 public record AdminFloorPlanUpdateRequest(
-        @JsonAlias("floorPlanName")
-        String name,
+        String floorPlanName,
         Form form,
         Structure structure,
         Equilibrium equilibrium,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
@@ -9,7 +10,8 @@ import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import java.util.List;
 
 public record AdminFloorPlanUpdateRequest(
-        String floorPlanName,
+        @JsonAlias("floorPlanName")
+        String name,
         Form form,
         Structure structure,
         Equilibrium equilibrium,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record AdminFloorPlanResponse(
         Long id,
-        String name,
+        String floorPlanName,
         Form form,
         Structure structure,
         Equilibrium equilibrium,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record AdminFloorPlanResponse(
         Long id,
-        String floorPlanName,
+        String name,
         Form form,
         Structure structure,
         Equilibrium equilibrium,

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
@@ -45,7 +45,7 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
         FloorPlanImages images = toFloorPlanImages(request.images());
 
         FloorPlan floorPlan = FloorPlan.create(
-                normalizeRequired(request.name()),
+                normalizeRequired(request.floorPlanName()),
                 request.form(),
                 request.structure(),
                 request.equilibrium(),
@@ -83,7 +83,7 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
                 : resolveImages(floorPlan);
 
         floorPlan.update(
-                request.name() != null ? normalizeRequired(request.name()) : floorPlan.getFloorPlanName(),
+                request.floorPlanName() != null ? normalizeRequired(request.floorPlanName()) : floorPlan.getFloorPlanName(),
                 request.form() != null ? request.form() : floorPlan.getForm(),
                 request.structure() != null ? request.structure() : floorPlan.getStructure(),
                 request.equilibrium() != null ? request.equilibrium() : floorPlan.getEquilibrium(),

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
@@ -45,7 +45,7 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
         FloorPlanImages images = toFloorPlanImages(request.images());
 
         FloorPlan floorPlan = FloorPlan.create(
-                normalizeRequired(request.floorPlanName()),
+                normalizeRequired(request.name()),
                 request.form(),
                 request.structure(),
                 request.equilibrium(),
@@ -83,7 +83,7 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
                 : resolveImages(floorPlan);
 
         floorPlan.update(
-                request.floorPlanName() != null ? normalizeRequired(request.floorPlanName()) : floorPlan.getFloorPlanName(),
+                request.name() != null ? normalizeRequired(request.name()) : floorPlan.getFloorPlanName(),
                 request.form() != null ? request.form() : floorPlan.getForm(),
                 request.structure() != null ? request.structure() : floorPlan.getStructure(),
                 request.equilibrium() != null ? request.equilibrium() : floorPlan.getEquilibrium(),

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1526,10 +1526,6 @@
                             <label for="floorPlanEditId" class="form-label">수정 대상 도면 ID</label>
                             <input type="text" class="form-control" id="floorPlanEditId" placeholder="목록에서 수정 선택 시 자동 입력" readonly>
                         </div>
-                        <div>
-                            <label for="floorPlanName" class="form-label">도면 이름</label>
-                            <input type="text" class="form-control" id="floorPlanName" placeholder="예: 복층 오피스텔 A타입" required>
-                        </div>
                         <div class="full-span">
                             <label for="floorPlanImageFile" class="form-label">도면 이미지 업로드</label>
                             <div class="banner-image-upload-panel">
@@ -2520,15 +2516,6 @@
                     <div class="floor-plan-image-card-meta">원본 파일명: ${escapeHtml(image.originalFilename || '-')}</div>
                     <div class="floor-plan-image-card-meta">저장 파일명: ${escapeHtml(image.filename || '-')}</div>
                     <div class="floor-plan-image-card-meta">확장자: ${escapeHtml(image.fileExtension || '-')} · 순서: ${image.sortOrder}</div>
-                    <div class="mt-2">
-                        <label class="form-label form-label-sm mb-1">이미지 view</label>
-                        <input
-                            type="text"
-                            class="form-control form-control-sm"
-                            value="${escapeHtml(image.view || '')}"
-                            placeholder="예: 거실 / 주방 / 침실"
-                            data-floor-plan-view="${index}">
-                    </div>
                 </div>
                 <div class="floor-plan-image-card-actions">
                     <button type="button" class="btn btn-sm btn-outline-secondary" ${index === 0 ? 'disabled' : ''} data-floor-plan-move-up="${index}">위로</button>
@@ -2564,13 +2551,6 @@
                     floorPlanAdminState.images[index] = next;
                     normalizeFloorPlanImageOrders();
                     renderFloorPlanImages();
-                });
-            }
-
-            const viewInput = card.querySelector('[data-floor-plan-view]');
-            if (viewInput) {
-                viewInput.addEventListener('input', function() {
-                    floorPlanAdminState.images[index].view = this.value;
                 });
             }
 
@@ -2646,8 +2626,7 @@
                 filename: extractFilenameFromUrl(publicUrl),
                 originalFilename: imageFile.name,
                 fileExtension: extension,
-                sortOrder: floorPlanAdminState.images.length + 1,
-                view: ''
+                sortOrder: floorPlanAdminState.images.length + 1
             });
             normalizeFloorPlanImageOrders();
             renderFloorPlanImages();
@@ -3456,19 +3435,14 @@
             const card = document.createElement('div');
             card.className = 'banner-card';
             const imageCount = Array.isArray(floorPlan.images) ? floorPlan.images.length : 0;
-            const representativeView = imageCount > 0 ? floorPlan.images[0]?.view : null;
             card.innerHTML = `
                 <img class="banner-card-image" src="${escapeHtml(floorPlan.representativeImageUrl || '')}" alt="도면 #${floorPlan.id}">
                 <div class="banner-card-body">
                     <div class="banner-card-title-row">
-                        <span class="banner-card-title">${escapeHtml(floorPlan.name || `도면 #${floorPlan.id}`)}</span>
+                        <span class="banner-card-title">도면 #${floorPlan.id}</span>
                         <span class="text-muted small">이미지 ${imageCount}장</span>
                     </div>
                     <div class="floor-plan-summary-grid">
-                        <div class="floor-plan-summary-item">
-                            <span class="floor-plan-summary-item-label">도면 이름</span>
-                            <span>${escapeHtml(floorPlan.name || '-')}</span>
-                        </div>
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">주거형태</span>
                             <span>${escapeHtml(FLOOR_PLAN_FORM_LABELS[floorPlan.form] || floorPlan.form || '-')}</span>
@@ -3480,10 +3454,6 @@
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">평형</span>
                             <span>${escapeHtml(FLOOR_PLAN_EQUILIBRIUM_LABELS[floorPlan.equilibrium] || floorPlan.equilibrium || '-')}</span>
-                        </div>
-                        <div class="floor-plan-summary-item">
-                            <span class="floor-plan-summary-item-label">대표 이미지 view</span>
-                            <span>${escapeHtml(representativeView || '-')}</span>
                         </div>
                         <div class="floor-plan-summary-item" style="grid-column: 1 / -1;">
                             <span class="floor-plan-summary-item-label">도면 프롬프트</span>
@@ -3518,14 +3488,12 @@
                 filename: image.filename,
                 originalFilename: image.originalFilename,
                 fileExtension: image.fileExtension,
-                sortOrder: image.sortOrder,
-                view: image.view || ''
+                sortOrder: image.sortOrder
             })).sort((a, b) => a.sortOrder - b.sortOrder)
             : [];
         normalizeFloorPlanImageOrders();
 
         document.getElementById('floorPlanEditId').value = floorPlan.id;
-        document.getElementById('floorPlanName').value = floorPlan.name || floorPlan.floorPlanName || '';
         document.getElementById('floorPlanForm').value = floorPlan.form || '';
         document.getElementById('floorPlanStructure').value = floorPlan.structure || '';
         document.getElementById('floorPlanEquilibrium').value = floorPlan.equilibrium || '';
@@ -3553,15 +3521,13 @@
         const form = parseStringValue(document.getElementById('floorPlanForm').value);
         const structure = parseStringValue(document.getElementById('floorPlanStructure').value);
         const equilibrium = parseStringValue(document.getElementById('floorPlanEquilibrium').value);
-        const name = parseStringValue(document.getElementById('floorPlanName').value);
         const floorPlanPrompt = parseStringValue(document.getElementById('floorPlanPrompt').value);
 
-        if (!name || !form || !structure || !equilibrium || !floorPlanPrompt) {
-            throw new Error('도면 이름, 주거형태, 구조, 평형, 도면 프롬프트를 모두 입력해주세요.');
+        if (!form || !structure || !equilibrium || !floorPlanPrompt) {
+            throw new Error('주거형태, 구조, 평형, 도면 프롬프트를 모두 입력해주세요.');
         }
 
         return {
-            name,
             form,
             structure,
             equilibrium,
@@ -3571,8 +3537,7 @@
                 filename: image.filename,
                 originalFilename: image.originalFilename,
                 fileExtension: image.fileExtension,
-                sortOrder: index + 1,
-                view: parseStringValue(image.view)
+                sortOrder: index + 1
             }))
         };
     }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1534,9 +1534,10 @@
                             <label for="floorPlanImageFile" class="form-label">도면 이미지 업로드</label>
                             <div class="banner-image-upload-panel">
                                 <input type="file" class="form-control" id="floorPlanImageFile" accept="image/*">
+                                <input type="text" class="form-control" id="floorPlanImageView" placeholder="이미지 view 예: 거실 / 주방 / 침실">
                                 <div class="banner-image-upload-actions">
                                     <button type="button" id="upload-floor-plan-image-button" class="btn btn-outline-primary">S3 업로드 후 목록 추가</button>
-                                    <span id="floorPlanImageUploadStatus" class="text-muted small">이미지를 하나씩 업로드해 도면 이미지 목록을 구성하세요.</span>
+                                    <span id="floorPlanImageUploadStatus" class="text-muted small">이미지를 하나씩 업로드하고, 필요하면 view도 함께 입력하세요.</span>
                                 </div>
                             </div>
                         </div>
@@ -2581,9 +2582,11 @@
     async function uploadFloorPlanImage() {
         const accessToken = localStorage.getItem('accessToken');
         const fileInput = document.getElementById('floorPlanImageFile');
+        const viewInput = document.getElementById('floorPlanImageView');
         const statusElement = document.getElementById('floorPlanImageUploadStatus');
         const uploadButton = document.getElementById('upload-floor-plan-image-button');
         const imageFile = fileInput.files && fileInput.files[0];
+        const imageView = parseStringValue(viewInput?.value);
 
         if (!accessToken) {
             statusElement.textContent = '액세스 토큰이 없습니다.';
@@ -2647,11 +2650,14 @@
                 originalFilename: imageFile.name,
                 fileExtension: extension,
                 sortOrder: floorPlanAdminState.images.length + 1,
-                view: ''
+                view: imageView || ''
             });
             normalizeFloorPlanImageOrders();
             renderFloorPlanImages();
             fileInput.value = '';
+            if (viewInput) {
+                viewInput.value = '';
+            }
             statusElement.textContent = `${imageFile.name} 업로드가 완료되어 도면 이미지 목록에 추가되었습니다.`;
         } catch (error) {
             statusElement.textContent = error.message || '도면 이미지 업로드 중 오류가 발생했습니다.';
@@ -3531,6 +3537,7 @@
         document.getElementById('floorPlanEquilibrium').value = floorPlan.equilibrium || '';
         document.getElementById('floorPlanPrompt').value = floorPlan.floorPlanPrompt || '';
         document.getElementById('floorPlanImageFile').value = '';
+        document.getElementById('floorPlanImageView').value = '';
         document.getElementById('floorPlanImageUploadStatus').textContent = '기존 도면 이미지가 로드되었습니다. 새 이미지를 업로드하면 목록에 추가됩니다.';
         document.getElementById('floor-plan-form-result').innerHTML = '<div class="alert alert-info">도면 수정 모드로 전환했습니다.</div>';
         renderFloorPlanImages();
@@ -3540,7 +3547,8 @@
         floorPlanAdminState = createInitialFloorPlanAdminState();
         document.getElementById('floor-plan-form').reset();
         document.getElementById('floorPlanEditId').value = '';
-        document.getElementById('floorPlanImageUploadStatus').textContent = '이미지를 하나씩 업로드해 도면 이미지 목록을 구성하세요.';
+        document.getElementById('floorPlanImageView').value = '';
+        document.getElementById('floorPlanImageUploadStatus').textContent = '이미지를 하나씩 업로드하고, 필요하면 view도 함께 입력하세요.';
         document.getElementById('floor-plan-form-result').innerHTML = '';
         renderFloorPlanImages();
     }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -136,6 +136,9 @@
             font-weight: 700;
             color: #1f2937;
         }
+        .banner-chip-editor textarea.form-control {
+            min-height: 108px;
+        }
         .banner-search-results {
             display: flex;
             flex-direction: column;
@@ -171,6 +174,24 @@
             color: #0f4c81;
             font-size: 0.87rem;
             font-weight: 600;
+        }
+        .banner-card-chip-list {
+            display: grid;
+            gap: 10px;
+        }
+        .banner-card-chip-summary {
+            display: grid;
+            gap: 8px;
+            padding: 12px;
+            border: 1px solid #dbe5f0;
+            border-radius: 14px;
+            background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+        }
+        .banner-card-chip-prompt {
+            font-size: 0.88rem;
+            line-height: 1.5;
+            color: #475569;
+            white-space: pre-wrap;
         }
         .banner-card-chip button,
         .banner-selected-product-chip button,
@@ -2688,7 +2709,11 @@
                         <label class="form-label" for="bannerChipLabel-${index}">칩 문구</label>
                         <input type="text" class="form-control" id="bannerChipLabel-${index}" placeholder="예: 모니터 받침대가 결합된 책상">
                     </div>
-                    <div class="col-md-4">
+                    <div class="col-md-6">
+                        <label class="form-label" for="bannerChipSelectedPrompt-${index}">selected prompt</label>
+                        <textarea class="form-control" id="bannerChipSelectedPrompt-${index}" placeholder="선택된 답변 칩이 이미지 생성 프롬프트에 추가할 문구를 입력하세요."></textarea>
+                    </div>
+                    <div class="col-md-10">
                         <label class="form-label" for="bannerChipRawKeyword-${index}">연결 RAW 상품 검색</label>
                         <input type="text" class="form-control" id="bannerChipRawKeyword-${index}" placeholder="상품명, 브랜드, source, productId">
                     </div>
@@ -2949,7 +2974,12 @@
             const mappedRawProducts = Array.isArray(banner.mappedRawProducts) ? banner.mappedRawProducts : [];
             const styleAnswerChips = Array.isArray(banner.styleAnswerChips) ? banner.styleAnswerChips : [];
             const chipHtml = styleAnswerChips.length > 0
-                ? styleAnswerChips.map(chip => `<span class="banner-card-chip">${escapeHtml(chip.label)} · #${chip.curationRawProductId}</span>`).join('')
+                ? styleAnswerChips.map(chip => `
+                    <div class="banner-card-chip-summary">
+                        <span class="banner-card-chip">${escapeHtml(chip.label)} · #${chip.curationRawProductId}</span>
+                        <span class="banner-card-chip-prompt">${escapeHtml(chip.selectedPrompt || '-')}</span>
+                    </div>
+                `).join('')
                 : '<span class="text-muted small">등록된 스타일 답변이 없습니다.</span>';
             const mappedHtml = mappedRawProducts.length > 0
                 ? mappedRawProducts.map(product => `<span class="banner-card-chip">${escapeHtml(product.productName)} · #${product.id}</span>`).join('')
@@ -2977,7 +3007,7 @@
                         </div>
                         <div class="banner-card-block">
                             <span class="banner-card-label">스타일 답변 칩</span>
-                            <div class="d-flex flex-wrap gap-2">${chipHtml}</div>
+                            <div class="banner-card-chip-list">${chipHtml}</div>
                         </div>
                         <div class="banner-card-block">
                             <span class="banner-card-label">배너에 매핑된 가구</span>
@@ -3038,6 +3068,7 @@
         styleAnswerChips.slice(0, BANNER_CHIP_MAX_COUNT).forEach((chip, index) => {
             document.getElementById(`bannerChipOrder-${index}`).value = chip.order ?? index + 1;
             document.getElementById(`bannerChipLabel-${index}`).value = chip.label ?? '';
+            document.getElementById(`bannerChipSelectedPrompt-${index}`).value = chip.selectedPrompt ?? '';
         });
 
         bannerAdminState.selectedMappedRawProducts = (Array.isArray(banner.mappedRawProducts) ? banner.mappedRawProducts : []).map(product => ({
@@ -3071,14 +3102,15 @@
         for (let index = 0; index < BANNER_CHIP_MAX_COUNT; index += 1) {
             const order = parseNumberValue(document.getElementById(`bannerChipOrder-${index}`).value);
             const label = parseStringValue(document.getElementById(`bannerChipLabel-${index}`).value);
+            const selectedPrompt = parseStringValue(document.getElementById(`bannerChipSelectedPrompt-${index}`).value);
             const rawProduct = bannerAdminState.chipSelections[index].rawProduct;
 
-            if (!label && !rawProduct) {
+            if (!label && !selectedPrompt && !rawProduct) {
                 continue;
             }
 
-            if (!label || !rawProduct || order == null || !Number.isInteger(order)) {
-                throw new Error(`스타일 답변 칩 ${index + 1}의 문구, 순서, RAW 상품을 모두 입력해주세요.`);
+            if (!label || !selectedPrompt || !rawProduct || order == null || !Number.isInteger(order)) {
+                throw new Error(`스타일 답변 칩 ${index + 1}의 문구, selected prompt, 순서, RAW 상품을 모두 입력해주세요.`);
             }
             if (order < 1 || order > BANNER_CHIP_MAX_COUNT) {
                 throw new Error(`스타일 답변 칩 ${index + 1}의 순서는 1부터 ${BANNER_CHIP_MAX_COUNT} 사이여야 합니다.`);
@@ -3087,6 +3119,7 @@
             styleAnswerChips.push({
                 order,
                 label,
+                selectedPrompt,
                 curationRawProductId: rawProduct.id
             });
         }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1526,6 +1526,10 @@
                             <label for="floorPlanEditId" class="form-label">수정 대상 도면 ID</label>
                             <input type="text" class="form-control" id="floorPlanEditId" placeholder="목록에서 수정 선택 시 자동 입력" readonly>
                         </div>
+                        <div>
+                            <label for="floorPlanName" class="form-label">도면 이름</label>
+                            <input type="text" class="form-control" id="floorPlanName" placeholder="예: 복층 오피스텔 A타입" required>
+                        </div>
                         <div class="full-span">
                             <label for="floorPlanImageFile" class="form-label">도면 이미지 업로드</label>
                             <div class="banner-image-upload-panel">
@@ -2516,6 +2520,15 @@
                     <div class="floor-plan-image-card-meta">원본 파일명: ${escapeHtml(image.originalFilename || '-')}</div>
                     <div class="floor-plan-image-card-meta">저장 파일명: ${escapeHtml(image.filename || '-')}</div>
                     <div class="floor-plan-image-card-meta">확장자: ${escapeHtml(image.fileExtension || '-')} · 순서: ${image.sortOrder}</div>
+                    <div class="mt-2">
+                        <label class="form-label form-label-sm mb-1">이미지 view</label>
+                        <input
+                            type="text"
+                            class="form-control form-control-sm"
+                            value="${escapeHtml(image.view || '')}"
+                            placeholder="예: 거실 / 주방 / 침실"
+                            data-floor-plan-view="${index}">
+                    </div>
                 </div>
                 <div class="floor-plan-image-card-actions">
                     <button type="button" class="btn btn-sm btn-outline-secondary" ${index === 0 ? 'disabled' : ''} data-floor-plan-move-up="${index}">위로</button>
@@ -2551,6 +2564,13 @@
                     floorPlanAdminState.images[index] = next;
                     normalizeFloorPlanImageOrders();
                     renderFloorPlanImages();
+                });
+            }
+
+            const viewInput = card.querySelector('[data-floor-plan-view]');
+            if (viewInput) {
+                viewInput.addEventListener('input', function() {
+                    floorPlanAdminState.images[index].view = this.value;
                 });
             }
 
@@ -2626,7 +2646,8 @@
                 filename: extractFilenameFromUrl(publicUrl),
                 originalFilename: imageFile.name,
                 fileExtension: extension,
-                sortOrder: floorPlanAdminState.images.length + 1
+                sortOrder: floorPlanAdminState.images.length + 1,
+                view: ''
             });
             normalizeFloorPlanImageOrders();
             renderFloorPlanImages();
@@ -3435,14 +3456,19 @@
             const card = document.createElement('div');
             card.className = 'banner-card';
             const imageCount = Array.isArray(floorPlan.images) ? floorPlan.images.length : 0;
+            const representativeView = imageCount > 0 ? floorPlan.images[0]?.view : null;
             card.innerHTML = `
                 <img class="banner-card-image" src="${escapeHtml(floorPlan.representativeImageUrl || '')}" alt="도면 #${floorPlan.id}">
                 <div class="banner-card-body">
                     <div class="banner-card-title-row">
-                        <span class="banner-card-title">도면 #${floorPlan.id}</span>
+                        <span class="banner-card-title">${escapeHtml(floorPlan.name || `도면 #${floorPlan.id}`)}</span>
                         <span class="text-muted small">이미지 ${imageCount}장</span>
                     </div>
                     <div class="floor-plan-summary-grid">
+                        <div class="floor-plan-summary-item">
+                            <span class="floor-plan-summary-item-label">도면 이름</span>
+                            <span>${escapeHtml(floorPlan.name || '-')}</span>
+                        </div>
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">주거형태</span>
                             <span>${escapeHtml(FLOOR_PLAN_FORM_LABELS[floorPlan.form] || floorPlan.form || '-')}</span>
@@ -3454,6 +3480,10 @@
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">평형</span>
                             <span>${escapeHtml(FLOOR_PLAN_EQUILIBRIUM_LABELS[floorPlan.equilibrium] || floorPlan.equilibrium || '-')}</span>
+                        </div>
+                        <div class="floor-plan-summary-item">
+                            <span class="floor-plan-summary-item-label">대표 이미지 view</span>
+                            <span>${escapeHtml(representativeView || '-')}</span>
                         </div>
                         <div class="floor-plan-summary-item" style="grid-column: 1 / -1;">
                             <span class="floor-plan-summary-item-label">도면 프롬프트</span>
@@ -3488,12 +3518,14 @@
                 filename: image.filename,
                 originalFilename: image.originalFilename,
                 fileExtension: image.fileExtension,
-                sortOrder: image.sortOrder
+                sortOrder: image.sortOrder,
+                view: image.view || ''
             })).sort((a, b) => a.sortOrder - b.sortOrder)
             : [];
         normalizeFloorPlanImageOrders();
 
         document.getElementById('floorPlanEditId').value = floorPlan.id;
+        document.getElementById('floorPlanName').value = floorPlan.name || floorPlan.floorPlanName || '';
         document.getElementById('floorPlanForm').value = floorPlan.form || '';
         document.getElementById('floorPlanStructure').value = floorPlan.structure || '';
         document.getElementById('floorPlanEquilibrium').value = floorPlan.equilibrium || '';
@@ -3521,13 +3553,15 @@
         const form = parseStringValue(document.getElementById('floorPlanForm').value);
         const structure = parseStringValue(document.getElementById('floorPlanStructure').value);
         const equilibrium = parseStringValue(document.getElementById('floorPlanEquilibrium').value);
+        const name = parseStringValue(document.getElementById('floorPlanName').value);
         const floorPlanPrompt = parseStringValue(document.getElementById('floorPlanPrompt').value);
 
-        if (!form || !structure || !equilibrium || !floorPlanPrompt) {
-            throw new Error('주거형태, 구조, 평형, 도면 프롬프트를 모두 입력해주세요.');
+        if (!name || !form || !structure || !equilibrium || !floorPlanPrompt) {
+            throw new Error('도면 이름, 주거형태, 구조, 평형, 도면 프롬프트를 모두 입력해주세요.');
         }
 
         return {
+            name,
             form,
             structure,
             equilibrium,
@@ -3537,7 +3571,8 @@
                 filename: image.filename,
                 originalFilename: image.originalFilename,
                 fileExtension: image.fileExtension,
-                sortOrder: index + 1
+                sortOrder: index + 1,
+                view: parseStringValue(image.view)
             }))
         };
     }

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
@@ -68,8 +68,10 @@ class AdminFloorPlanControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.name").value("테스트 도면"))
                 .andExpect(jsonPath("$.data.form").value("OFFICETEL"))
-                .andExpect(jsonPath("$.data.images[0].url").value("https://image/1"));
+                .andExpect(jsonPath("$.data.images[0].url").value("https://image/1"))
+                .andExpect(jsonPath("$.data.images[0].view").value("창가 뷰"));
     }
 
     @Test
@@ -80,7 +82,9 @@ class AdminFloorPlanControllerTest {
         mockMvc.perform(get("/api/v1/admin/floor-plans"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.floorPlans[0].id").value(1L))
-                .andExpect(jsonPath("$.data.floorPlans[0].equilibrium").value("UNDER_5"));
+                .andExpect(jsonPath("$.data.floorPlans[0].equilibrium").value("UNDER_5"))
+                .andExpect(jsonPath("$.data.floorPlans[0].name").value("테스트 도면"))
+                .andExpect(jsonPath("$.data.floorPlans[0].images[0].view").value("창가 뷰"));
     }
 
     @Test
@@ -111,8 +115,10 @@ class AdminFloorPlanControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("수정 도면"))
                 .andExpect(jsonPath("$.data.structure").value("TWO_ROOM"))
-                .andExpect(jsonPath("$.data.representativeImageUrl").value("https://image/2"));
+                .andExpect(jsonPath("$.data.representativeImageUrl").value("https://image/2"))
+                .andExpect(jsonPath("$.data.images[0].view").value("강변 뷰"));
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
@@ -68,10 +68,8 @@ class AdminFloorPlanControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.name").value("테스트 도면"))
                 .andExpect(jsonPath("$.data.form").value("OFFICETEL"))
-                .andExpect(jsonPath("$.data.images[0].url").value("https://image/1"))
-                .andExpect(jsonPath("$.data.images[0].view").value("창가 뷰"));
+                .andExpect(jsonPath("$.data.images[0].url").value("https://image/1"));
     }
 
     @Test
@@ -82,9 +80,7 @@ class AdminFloorPlanControllerTest {
         mockMvc.perform(get("/api/v1/admin/floor-plans"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.floorPlans[0].id").value(1L))
-                .andExpect(jsonPath("$.data.floorPlans[0].equilibrium").value("UNDER_5"))
-                .andExpect(jsonPath("$.data.floorPlans[0].name").value("테스트 도면"))
-                .andExpect(jsonPath("$.data.floorPlans[0].images[0].view").value("창가 뷰"));
+                .andExpect(jsonPath("$.data.floorPlans[0].equilibrium").value("UNDER_5"));
     }
 
     @Test
@@ -115,10 +111,8 @@ class AdminFloorPlanControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.name").value("수정 도면"))
                 .andExpect(jsonPath("$.data.structure").value("TWO_ROOM"))
-                .andExpect(jsonPath("$.data.representativeImageUrl").value("https://image/2"))
-                .andExpect(jsonPath("$.data.images[0].view").value("강변 뷰"));
+                .andExpect(jsonPath("$.data.representativeImageUrl").value("https://image/2"));
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
@@ -84,7 +84,7 @@ class AdminFloorPlanServiceImplTest {
         AdminFloorPlanResponse response = adminFloorPlanService.create(request);
 
         assertThat(response.id()).isEqualTo(1L);
-        assertThat(response.name()).isEqualTo("테스트 도면");
+        assertThat(response.floorPlanName()).isEqualTo("테스트 도면");
         assertThat(response.form()).isEqualTo(Form.OFFICETEL);
         assertThat(response.structure()).isEqualTo(Structure.OPEN_ONE_ROOM);
         assertThat(response.equilibrium()).isEqualTo(Equilibrium.UNDER_5);
@@ -133,7 +133,7 @@ class AdminFloorPlanServiceImplTest {
 
         AdminFloorPlanResponse response = adminFloorPlanService.update(2L, request);
 
-        assertThat(response.name()).isEqualTo("수정 도면");
+        assertThat(response.floorPlanName()).isEqualTo("수정 도면");
         assertThat(response.form()).isEqualTo(Form.APARTMENT);
         assertThat(response.structure()).isEqualTo(Structure.TWO_ROOM);
         assertThat(response.equilibrium()).isEqualTo(Equilibrium.BETWEEN_11_15);

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
@@ -84,7 +84,7 @@ class AdminFloorPlanServiceImplTest {
         AdminFloorPlanResponse response = adminFloorPlanService.create(request);
 
         assertThat(response.id()).isEqualTo(1L);
-        assertThat(response.floorPlanName()).isEqualTo("테스트 도면");
+        assertThat(response.name()).isEqualTo("테스트 도면");
         assertThat(response.form()).isEqualTo(Form.OFFICETEL);
         assertThat(response.structure()).isEqualTo(Structure.OPEN_ONE_ROOM);
         assertThat(response.equilibrium()).isEqualTo(Equilibrium.UNDER_5);
@@ -133,7 +133,7 @@ class AdminFloorPlanServiceImplTest {
 
         AdminFloorPlanResponse response = adminFloorPlanService.update(2L, request);
 
-        assertThat(response.floorPlanName()).isEqualTo("수정 도면");
+        assertThat(response.name()).isEqualTo("수정 도면");
         assertThat(response.form()).isEqualTo(Form.APARTMENT);
         assertThat(response.structure()).isEqualTo(Structure.TWO_ROOM);
         assertThat(response.equilibrium()).isEqualTo(Equilibrium.BETWEEN_11_15);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #457 
- close #465  

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

이것도 거의 view 추가가 대부분이라 로직 변경사항은 매우 작습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

@kbt82883 
본탁님 현재 floor_plan_name이 nullable=false로 설정되어 있어서  기존의 데이터와 충돌하여 스키마 오류로 필드가 추가되지 않았습니다.

머 어려운거 아니라서 제가 추가했습니당. 다음부터 새로운 필드가 추가될땐 기존 데이터와 충돌이 발생하진 않는지 확인 한 번 해주시면 감사하겠습니다!
저도 코드리뷰 할때 더 꼼꼼히 보도록 할게요!!

## 📬 Postman

1. 도면 조회 - 기존 도면이름은 LEGACY로 표기됩니다.
<img width="1312" height="749" alt="image" src="https://github.com/user-attachments/assets/5d782ac9-0919-493a-b5c0-fd137dafb71f" />

2. 도면 등록
<img width="1319" height="674" alt="image" src="https://github.com/user-attachments/assets/2bd4ecdb-2976-4fe2-bc7a-143af2687e7f" />


<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API 변경사항**
  * 도면 DTO의 필드명 `floorPlanName`을 `name`으로 변경(이전 이름 호환 처리 포함)
  * 이미지 메타에 `view` 입력/저장 필드 허용

* **사용자 인터페이스 개선**
  * 도면 생성/수정 폼에 도면명 입력 필드 추가 및 검증 강화
  * 이미지별 뷰(view) 입력·편집·표시 기능 추가, 목록에 대표 이미지 뷰 노출

* **테스트**
  * 생성/조회/수정 관련 테스트에 새 필드 검증 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->