### PR TITLE
[FEATURE] 선택한 배너 기반 이미지 생성 API

### DIFF
--- a/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.banner.model.vo;
 
 public record BannerStyleAnswerChip(
+        Long id,
         Integer order,
         String label,
         String selectedPrompt,

--- a/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/vo/BannerStyleAnswerChip.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.banner.model.vo;
 public record BannerStyleAnswerChip(
         Integer order,
         String label,
+        String selectedPrompt,
         Long curationRawProductId
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/BannerDetailAnswerResponse.java
+++ b/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/BannerDetailAnswerResponse.java
@@ -1,10 +1,11 @@
 package or.sopt.houme.domain.banner.presentation.dto.response;
 
 public record BannerDetailAnswerResponse(
+        Long id,
         String text
 ) {
 
-    public static BannerDetailAnswerResponse of(String text) {
-        return new BannerDetailAnswerResponse(text);
+    public static BannerDetailAnswerResponse of(Long id, String text) {
+        return new BannerDetailAnswerResponse(id, text);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
@@ -74,7 +74,12 @@ public class BannerServiceImpl implements BannerService {
                 banner.getBannerImageUrl(),
                 banner.getStyleQuestion(),
                 parseStyleAnswerChips(banner.getStyleAnswerChipsJson()).stream()
-                        .map(chip -> BannerDetailAnswerResponse.of(chip.id(), chip.label()))
+                        .map(chip -> {
+                            if (chip.id() == null) {
+                                throw new ValidException(ErrorCode.NOT_VALID_EXCEPTION);
+                            }
+                            return BannerDetailAnswerResponse.of(chip.id(), chip.label());
+                        })
                         .toList()
         );
     }

--- a/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
@@ -74,7 +74,7 @@ public class BannerServiceImpl implements BannerService {
                 banner.getBannerImageUrl(),
                 banner.getStyleQuestion(),
                 parseStyleAnswerChips(banner.getStyleAnswerChipsJson()).stream()
-                        .map(chip -> BannerDetailAnswerResponse.of(chip.label()))
+                        .map(chip -> BannerDetailAnswerResponse.of(chip.id(), chip.label()))
                         .toList()
         );
     }

--- a/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/dto/GeminiImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/dto/GeminiImageRequest.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.generateImage.infrastructure.gemini.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -16,12 +17,28 @@ public record GeminiImageRequest(
         );
     }
 
+    public static GeminiImageRequest of(String prompt, List<Part> referenceImageParts) {
+        List<Part> parts = new ArrayList<>();
+        parts.add(Part.text(prompt));
+        if (referenceImageParts != null) {
+            parts.addAll(referenceImageParts);
+        }
+        return new GeminiImageRequest(
+                List.of(new Content("user", parts)),
+                new GenerationConfig(List.of("IMAGE"))
+        );
+    }
+
     public record Content(String role, List<Part> parts) {
     }
 
     public record Part(String text, InlineData inlineData) {
         public static Part text(String text) {
             return new Part(text, null);
+        }
+
+        public static Part inlineData(String mimeType, String data) {
+            return new Part(null, new InlineData(mimeType, data));
         }
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageService.java
@@ -2,6 +2,9 @@ package or.sopt.houme.domain.generateImage.infrastructure.gemini.service;
 
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 
+import java.util.List;
+
 public interface GeminiImageService {
     ImageUploadResponseDTO createImage(String prompt);
+    ImageUploadResponseDTO createImageWithReferences(String prompt, List<String> referenceImageUrls);
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageServiceImpl.java
@@ -17,17 +17,30 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 @Service
 @Profile("!load_test")
 @RequiredArgsConstructor
 @Slf4j
 public class GeminiImageServiceImpl implements GeminiImageService {
+    private static final String NANO_BANANA_MODEL = "gemini-2.5-flash-image-preview";
 
     private final GeminiImageClient geminiImageClient;
     private final GeminiImageConfig geminiImageConfig;
     private final S3Util s3Util;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
 
     @Value("${gemini.api-key:}")
     private String apiKey;
@@ -37,18 +50,27 @@ public class GeminiImageServiceImpl implements GeminiImageService {
         // Gemini는 해상도 파라미터를 받지 않으므로 프롬프트 힌트로만 전달합니다.
         String promptWithSize = applySizeHint(prompt, geminiImageConfig.getSize());
         GeminiImageRequest request = GeminiImageRequest.of(promptWithSize);
+        return executeGeminiRequest(promptWithSize, request, defaultModel(geminiImageConfig.getModel()));
+    }
 
+    @Override
+    public ImageUploadResponseDTO createImageWithReferences(String prompt, List<String> referenceImageUrls) {
+        String promptWithSize = applySizeHint(prompt, geminiImageConfig.getSize());
+        List<GeminiImageRequest.Part> referenceParts = toReferenceImageParts(referenceImageUrls);
+        GeminiImageRequest request = GeminiImageRequest.of(promptWithSize, referenceParts);
+        return executeGeminiRequest(promptWithSize, request, NANO_BANANA_MODEL);
+    }
+
+    private ImageUploadResponseDTO executeGeminiRequest(
+            String prompt,
+            GeminiImageRequest request,
+            String model
+    ) {
         try {
-            GeminiImageResponse response = geminiImageClient.generateImage(
-                    defaultModel(geminiImageConfig.getModel()),
-                    apiKey,
-                    request
-            );
-
-            // Gemini는 inlineData에 base64 문자열로 이미지를 반환합니다.
+            GeminiImageResponse response = geminiImageClient.generateImage(model, apiKey, request);
             byte[] image = decodeBase64(extractBase64(response));
             ImageUploadResponseDTO responseDTO = s3Util.uploadByByte(S3Constant.CHAT_GPT_DIRNAME, image);
-            responseDTO.setPullPrompt(promptWithSize);
+            responseDTO.setPullPrompt(prompt);
             return responseDTO;
         } catch (FeignException e) {
             log.info(e.getMessage());
@@ -56,6 +78,57 @@ public class GeminiImageServiceImpl implements GeminiImageService {
         } catch (IllegalArgumentException e) {
             throw new S3Exception(ErrorCode.INCODING_EXCEPTION);
         }
+    }
+
+    private List<GeminiImageRequest.Part> toReferenceImageParts(List<String> referenceImageUrls) {
+        if (referenceImageUrls == null || referenceImageUrls.isEmpty()) {
+            return List.of();
+        }
+        return referenceImageUrls.stream()
+                .filter(url -> url != null && !url.isBlank())
+                .map(this::downloadImage)
+                .map(imageData -> GeminiImageRequest.Part.inlineData(imageData.mimeType(), imageData.base64Data()))
+                .collect(Collectors.toList());
+    }
+
+    private DownloadedImageData downloadImage(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("User-Agent", "Houme-Gemini/1.0")
+                    .GET()
+                    .build();
+
+            HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+            }
+
+            String mimeType = response.headers()
+                    .firstValue("content-type")
+                    .map(this::normalizeMimeType)
+                    .orElse("image/jpeg");
+            String base64 = Base64.getEncoder().encodeToString(response.body());
+            return new DownloadedImageData(mimeType, base64);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+        } catch (IllegalArgumentException e) {
+            throw new ChatGptException(ErrorCode.CHAT_GPT_CALL_EXCEPTION);
+        }
+    }
+
+    private String normalizeMimeType(String contentType) {
+        String lowered = contentType.toLowerCase(Locale.ROOT);
+        int separator = lowered.indexOf(';');
+        String mimeType = separator >= 0 ? lowered.substring(0, separator).trim() : lowered.trim();
+        if (!mimeType.startsWith("image/")) {
+            return "image/jpeg";
+        }
+        return mimeType;
     }
 
     private String extractBase64(GeminiImageResponse response) {
@@ -113,5 +186,8 @@ public class GeminiImageServiceImpl implements GeminiImageService {
             return trimmed;
         }
         return null;
+    }
+
+    private record DownloadedImageData(String mimeType, String base64Data) {
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageServiceImpl.java
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class GeminiImageServiceImpl implements GeminiImageService {
-    private static final String NANO_BANANA_MODEL = "gemini-2.5-flash-image-preview";
-
     private final GeminiImageClient geminiImageClient;
     private final GeminiImageConfig geminiImageConfig;
     private final S3Util s3Util;
@@ -58,7 +56,7 @@ public class GeminiImageServiceImpl implements GeminiImageService {
         String promptWithSize = applySizeHint(prompt, geminiImageConfig.getSize());
         List<GeminiImageRequest.Part> referenceParts = toReferenceImageParts(referenceImageUrls);
         GeminiImageRequest request = GeminiImageRequest.of(promptWithSize, referenceParts);
-        return executeGeminiRequest(promptWithSize, request, NANO_BANANA_MODEL);
+        return executeGeminiRequest(promptWithSize, request, defaultModel(geminiImageConfig.getModel()));
     }
 
     private ImageUploadResponseDTO executeGeminiRequest(
@@ -84,11 +82,19 @@ public class GeminiImageServiceImpl implements GeminiImageService {
         if (referenceImageUrls == null || referenceImageUrls.isEmpty()) {
             return List.of();
         }
-        return referenceImageUrls.stream()
-                .filter(url -> url != null && !url.isBlank())
-                .map(this::downloadImage)
-                .map(imageData -> GeminiImageRequest.Part.inlineData(imageData.mimeType(), imageData.base64Data()))
-                .collect(Collectors.toList());
+        List<GeminiImageRequest.Part> referenceParts = new java.util.ArrayList<>();
+        for (String url : referenceImageUrls) {
+            if (url == null || url.isBlank()) {
+                continue;
+            }
+            try {
+                DownloadedImageData imageData = downloadImage(url);
+                referenceParts.add(GeminiImageRequest.Part.inlineData(imageData.mimeType(), imageData.base64Data()));
+            } catch (ChatGptException e) {
+                log.warn("참조 이미지 다운로드 실패. 해당 URL은 건너뜁니다. url={}", url);
+            }
+        }
+        return referenceParts.stream().collect(Collectors.toList());
     }
 
     private DownloadedImageData downloadImage(String url) {

--- a/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageStubService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/infrastructure/gemini/service/GeminiImageStubService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -48,6 +49,11 @@ public class GeminiImageStubService implements GeminiImageService {
                 .build();
         responseDTO.setPullPrompt(prompt);
         return responseDTO;
+    }
+
+    @Override
+    public ImageUploadResponseDTO createImageWithReferences(String prompt, List<String> referenceImageUrls) {
+        return createImage(prompt);
     }
 
     private long resolveDelay() {

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -105,8 +105,8 @@ public class GenerateImageController {
         return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
     }
 
-    @Operation(summary = "배너 기반 Gemini 이미지 생성 API",
-            description = "선택한 배너/답변칩/도면 정보를 기반으로 Gemini 나노바나나 모델로 이미지를 생성합니다.")
+    @Operation(summary = "배너 템플릿 기반 인테리어 이미지 생성 API",
+            description = "선택한 배너 템플릿/답변칩/도면 정보를 기반으로 Gemini 나노바나나 모델로 인테리어 이미지를 생성합니다.")
     @PostMapping("/v1/generated-images/generate/banner")
     public ResponseEntity<ApiResponse<BannerGenerateImageResponse>> generateBannerImageByGemini(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.service.facade.GenerateImageFacade;
@@ -101,6 +103,18 @@ public class GenerateImageController {
         ImageInfoListResponse imageInfoListResponse = generateImageFacade.generateImageBy2eaGemini(userDetails.getUser(), request);
 
         return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
+    }
+
+    @Operation(summary = "배너 기반 Gemini 이미지 생성 API",
+            description = "선택한 배너/답변칩/도면 정보를 기반으로 Gemini 나노바나나 모델로 이미지를 생성합니다.")
+    @PostMapping("/v1/generated-images/generate/banner")
+    public ResponseEntity<ApiResponse<BannerGenerateImageResponse>> generateBannerImageByGemini(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid BannerGenerateImageRequest request
+    ) {
+        BannerGenerateImageResponse response =
+                generateImageFacade.generateBannerImageByGemini(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @Operation(summary = "이미지 생성 폴백 로직",

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/BannerGenerateImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/BannerGenerateImageRequest.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.domain.generateImage.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record BannerGenerateImageRequest(
+        @NotNull(message = "bannerId는 필수입니다.")
+        Long bannerId,
+        @NotNull(message = "answerId는 필수입니다.")
+        Long answerId,
+        @NotNull(message = "floorPlanId는 필수입니다.")
+        Long floorPlanId,
+        @NotBlank(message = "floorPlanView는 필수입니다.")
+        String floorPlanView,
+        @NotNull(message = "isMirror는 필수입니다.")
+        Boolean isMirror
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/BannerGenerateImageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/BannerGenerateImageResponse.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.generateImage.presentation.dto.response;
+
+public record BannerGenerateImageResponse(
+        Long imageId
+) {
+    public static BannerGenerateImageResponse of(Long imageId) {
+        return new BannerGenerateImageResponse(imageId);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -1,9 +1,11 @@
 package or.sopt.houme.domain.generateImage.service;
 
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
@@ -115,5 +117,24 @@ public class GenerateImageTransactionService {
                 priorityTag.getTagNameKr(),
                 user.getName()
         );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BannerGenerateImageResponse saveBannerImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Banner banner,
+            ImageUploadResponseDTO imageResponse
+    ) {
+        GenerateImage generateImage = generateImageService.createGenerateImage(
+                imageResponse,
+                null,
+                GenerateImageType.LIST,
+                banner
+        );
+
+        creditService.commitCreditDeletion(lockedCredit);
+        userService.updateHasGeneratedImage(user);
+        return BannerGenerateImageResponse.of(generateImage.getId());
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -362,7 +362,7 @@ public class GenerateImageFacade {
 
             String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildReferenceImageUrls(banner, selectedChip, floorPlanImageUrl);
-            String prompt = buildBannerPrompt(banner, selectedChip, floorPlan, request.floorPlanView(), request.isMirror());
+            String prompt = buildBannerPrompt(banner, selectedChip, floorPlan);
             log.info(
                     "배너 템플릿 이미지 생성 프롬프트/참고이미지 bannerId={}, answerId={}, prompt={}, referenceImageUrls={}",
                     banner.getId(),
@@ -679,9 +679,7 @@ public class GenerateImageFacade {
     private String buildBannerPrompt(
             Banner banner,
             BannerStyleAnswerChip selectedChip,
-            FloorPlan floorPlan,
-            String floorPlanView,
-            boolean isMirror
+            FloorPlan floorPlan
     ) {
         List<String> parts = new ArrayList<>();
         if (banner.getStylePrompt() != null && !banner.getStylePrompt().isBlank()) {
@@ -693,10 +691,6 @@ public class GenerateImageFacade {
         if (floorPlan.getFloorPlanPrompt() != null && !floorPlan.getFloorPlanPrompt().isBlank()) {
             parts.add(floorPlan.getFloorPlanPrompt());
         }
-        if (floorPlanView != null && !floorPlanView.isBlank()) {
-            parts.add("선택한 도면 뷰: " + floorPlanView.trim());
-        }
-        parts.add("도면 좌우 반전 여부: " + (isMirror ? "반전" : "원본"));
         return String.join("\n\n", parts);
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -1,14 +1,25 @@
 package or.sopt.houme.domain.generateImage.service.facade;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
+import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.generateImage.presentation.dto.SelectedTagInfo;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
@@ -22,6 +33,9 @@ import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.model.floorPlan.vo.FloorPlanImageItem;
+import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.generateImage.service.openai.facade.OpenAiFacade;
 import or.sopt.houme.domain.generateImage.service.prompt.dto.PromptFurnitureListDTO;
@@ -35,6 +49,7 @@ import or.sopt.houme.domain.house.service.taste.TasteService;
 import or.sopt.houme.domain.house.service.taste.TasteTagService;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 import or.sopt.houme.global.api.handler.*;
@@ -51,17 +66,23 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class GenerateImageFacade {
+    private static final TypeReference<List<BannerStyleAnswerChip>> STYLE_ANSWER_CHIP_TYPE = new TypeReference<>() {};
 
     private final GenerateImageService generateImageService;
     private final OpenAiFacade openAiFacade;
     private final PromptService promptService;
     private final GeminiImageService geminiImageService;
+    private final BannerRepository bannerRepository;
+    private final FloorPlanRepository floorPlanRepository;
     private final HouseService houseService;
     private final CreditService creditService;
     private final TasteTagService tasteTagService;
     private final UserService userService;
     private final TagService tagService;
     private final FurnitureService furnitureService;
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final FloorPlanImageJsonCodec floorPlanImageJsonCodec;
+    private final ObjectMapper objectMapper;
 
     // 비동기 서비스
     private final AsyncGenerateImageService asyncGenerateImageService;
@@ -321,6 +342,64 @@ public class GenerateImageFacade {
         return generateImageBy2eaInternal(user, generateImageRequest, true);
     }
 
+    public BannerGenerateImageResponse generateBannerImageByGemini(User user, BannerGenerateImageRequest request) {
+        Credit lockedCredit = null;
+
+        try {
+            lockedCredit = creditService.tryLockAndGetCredit(user);
+
+            Banner banner = bannerRepository.findByIdWithRawProducts(request.bannerId(), BannerType.BANNER, false)
+                    .orElseThrow(() -> new BannerException(ErrorCode.NOT_FOUND_BANNER));
+            FloorPlan floorPlan = floorPlanRepository.findById(request.floorPlanId())
+                    .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
+
+            BannerStyleAnswerChip selectedChip = parseStyleAnswerChips(banner.getStyleAnswerChipsJson()).stream()
+                    .filter(chip -> chip.id() != null && chip.id().equals(request.answerId()))
+                    .findFirst()
+                    .orElseThrow(() -> new ValidException(ErrorCode.NOT_VALID_EXCEPTION));
+
+            String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
+            List<String> referenceImageUrls = buildReferenceImageUrls(banner, selectedChip, floorPlanImageUrl);
+            String prompt = buildBannerPrompt(banner, selectedChip, floorPlan, request.floorPlanView(), request.isMirror());
+
+            ImageUploadResponseDTO imageUploadResponseDTO =
+                    geminiImageService.createImageWithReferences(prompt, referenceImageUrls);
+
+            if (imageUploadResponseDTO.getImageLink().equals(S3Constant.FALL_BACK_IMAGE)) {
+                log.error("배너 이미지 생성 중 폴백 이미지가 생성되었습니다. bannerId={}", banner.getId());
+                throw new ImageFallbackException(ErrorCode.GENERATED_IMAGE_EXCEPTION, null);
+            }
+
+            BannerGenerateImageResponse response = generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                    user,
+                    lockedCredit,
+                    banner,
+                    imageUploadResponseDTO
+            );
+            return response;
+        } catch (ValidException validException) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw validException;
+        } catch (GenerateImageException | ImageFallbackException | CreditException | BannerException | HouseException e) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error("배너 기반 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw new GenerateImageException(ErrorCode.GENERATED_IMAGE_EXCEPTION);
+        } finally {
+            if (lockedCredit != null) {
+                creditService.releaseLock(user);
+            }
+        }
+    }
+
     private ImageInfoListResponse generateImageBy2eaInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         // finally 블록에서 사용하기 위해 선언
@@ -502,6 +581,111 @@ public class GenerateImageFacade {
         return futures.stream()
                 .map(CompletableFuture::join)
                 .collect(Collectors.toList());
+    }
+
+    private List<BannerStyleAnswerChip> parseStyleAnswerChips(String styleAnswerChipsJson) {
+        if (styleAnswerChipsJson == null || styleAnswerChipsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<BannerStyleAnswerChip> chips = objectMapper.readValue(styleAnswerChipsJson, STYLE_ANSWER_CHIP_TYPE);
+            if (chips == null) {
+                return List.of();
+            }
+            return chips.stream().filter(Objects::nonNull).toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    private String resolveFloorPlanImageUrl(FloorPlan floorPlan, String floorPlanView) {
+        List<FloorPlanImageItem> images = floorPlanImageJsonCodec.read(floorPlan.getImagesJson());
+        if (images.isEmpty()) {
+            return floorPlan.getUrl();
+        }
+
+        String normalizedView = floorPlanView == null ? "" : floorPlanView.trim();
+        if (!normalizedView.isEmpty()) {
+            Optional<String> matchedUrl = images.stream()
+                    .filter(Objects::nonNull)
+                    .filter(item -> item.url() != null && !item.url().isBlank())
+                    .filter(item -> item.view() != null && item.view().trim().equalsIgnoreCase(normalizedView))
+                    .map(FloorPlanImageItem::url)
+                    .findFirst();
+            if (matchedUrl.isPresent()) {
+                return matchedUrl.get();
+            }
+        }
+
+        return images.stream()
+                .filter(Objects::nonNull)
+                .map(FloorPlanImageItem::url)
+                .filter(url -> url != null && !url.isBlank())
+                .findFirst()
+                .orElse(floorPlan.getUrl());
+    }
+
+    private List<String> buildReferenceImageUrls(
+            Banner banner,
+            BannerStyleAnswerChip selectedChip,
+            String floorPlanImageUrl
+    ) {
+        LinkedHashSet<String> urls = new LinkedHashSet<>();
+        if (floorPlanImageUrl != null && !floorPlanImageUrl.isBlank()) {
+            urls.add(floorPlanImageUrl);
+        }
+        if (banner.getBannerImageUrl() != null && !banner.getBannerImageUrl().isBlank()) {
+            urls.add(banner.getBannerImageUrl());
+        }
+
+        Map<Long, CurationRawProduct> bannerRawProductsById = new LinkedHashMap<>();
+        banner.getBannerRawProducts().stream()
+                .map(mapping -> mapping != null ? mapping.getCurationRawProduct() : null)
+                .filter(Objects::nonNull)
+                .forEach(rawProduct -> {
+                    bannerRawProductsById.put(rawProduct.getId(), rawProduct);
+                    if (rawProduct.getProductImageUrl() != null && !rawProduct.getProductImageUrl().isBlank()) {
+                        urls.add(rawProduct.getProductImageUrl());
+                    }
+                });
+
+        if (selectedChip.curationRawProductId() != null) {
+            CurationRawProduct selectedChipRawProduct = bannerRawProductsById.get(selectedChip.curationRawProductId());
+            if (selectedChipRawProduct == null) {
+                selectedChipRawProduct = curationRawProductRepository.findById(selectedChip.curationRawProductId())
+                        .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT));
+            }
+            if (selectedChipRawProduct != null
+                    && selectedChipRawProduct.getProductImageUrl() != null
+                    && !selectedChipRawProduct.getProductImageUrl().isBlank()) {
+                urls.add(selectedChipRawProduct.getProductImageUrl());
+            }
+        }
+        return List.copyOf(urls);
+    }
+
+    private String buildBannerPrompt(
+            Banner banner,
+            BannerStyleAnswerChip selectedChip,
+            FloorPlan floorPlan,
+            String floorPlanView,
+            boolean isMirror
+    ) {
+        List<String> parts = new ArrayList<>();
+        if (banner.getStylePrompt() != null && !banner.getStylePrompt().isBlank()) {
+            parts.add(banner.getStylePrompt());
+        }
+        if (selectedChip.selectedPrompt() != null && !selectedChip.selectedPrompt().isBlank()) {
+            parts.add(selectedChip.selectedPrompt());
+        }
+        if (floorPlan.getFloorPlanPrompt() != null && !floorPlan.getFloorPlanPrompt().isBlank()) {
+            parts.add(floorPlan.getFloorPlanPrompt());
+        }
+        if (floorPlanView != null && !floorPlanView.isBlank()) {
+            parts.add("선택한 도면 뷰: " + floorPlanView.trim());
+        }
+        parts.add("도면 좌우 반전 여부: " + (isMirror ? "반전" : "원본"));
+        return String.join("\n\n", parts);
     }
 
     // houseId로 결과 이미지 찾아오기

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -346,6 +346,8 @@ public class GenerateImageFacade {
         Credit lockedCredit = null;
 
         try {
+            log.info("배너 템플릿 기반 인테리어 이미지 생성 시작 userId={}, bannerId={}, answerId={}, floorPlanId={}, view={}, isMirror={}",
+                    user.getId(), request.bannerId(), request.answerId(), request.floorPlanId(), request.floorPlanView(), request.isMirror());
             lockedCredit = creditService.tryLockAndGetCredit(user);
 
             Banner banner = bannerRepository.findByIdWithRawProducts(request.bannerId(), BannerType.BANNER, false)
@@ -361,12 +363,21 @@ public class GenerateImageFacade {
             String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildReferenceImageUrls(banner, selectedChip, floorPlanImageUrl);
             String prompt = buildBannerPrompt(banner, selectedChip, floorPlan, request.floorPlanView(), request.isMirror());
+            log.info(
+                    "배너 템플릿 이미지 생성 프롬프트/참고이미지 bannerId={}, answerId={}, prompt={}, referenceImageUrls={}",
+                    banner.getId(),
+                    selectedChip.id(),
+                    prompt,
+                    referenceImageUrls
+            );
+            log.info("AI 호출 준비 완료 bannerId={}, answerId={}, referenceImageCount={}", banner.getId(), selectedChip.id(), referenceImageUrls.size());
 
             ImageUploadResponseDTO imageUploadResponseDTO =
                     geminiImageService.createImageWithReferences(prompt, referenceImageUrls);
+            log.info("AI 호출 완료 bannerId={}, generatedUrl={}", banner.getId(), imageUploadResponseDTO.getImageLink());
 
             if (imageUploadResponseDTO.getImageLink().equals(S3Constant.FALL_BACK_IMAGE)) {
-                log.error("배너 이미지 생성 중 폴백 이미지가 생성되었습니다. bannerId={}", banner.getId());
+                log.error("배너 템플릿 기반 인테리어 이미지 생성 중 폴백 이미지가 생성되었습니다. bannerId={}", banner.getId());
                 throw new ImageFallbackException(ErrorCode.GENERATED_IMAGE_EXCEPTION, null);
             }
 
@@ -376,19 +387,20 @@ public class GenerateImageFacade {
                     banner,
                     imageUploadResponseDTO
             );
+            log.info("배너 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());
             return response;
         } catch (ValidException validException) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
                 creditService.rollbackCreditPending(lockedCredit);
             }
             throw validException;
-        } catch (GenerateImageException | ImageFallbackException | CreditException | BannerException | HouseException e) {
+        } catch (GeneralException e) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
                 creditService.rollbackCreditPending(lockedCredit);
             }
             throw e;
         } catch (Exception e) {
-            log.error("배너 기반 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
+            log.error("배너 템플릿 기반 인테리어 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
                 creditService.rollbackCreditPending(lockedCredit);
             }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/request/AdminBannerStyleAnswerChipRequest.java
@@ -11,6 +11,7 @@ public record AdminBannerStyleAnswerChipRequest(
         @Max(4)
         @NotNull Integer order,
         @NotBlank String label,
+        @NotBlank String selectedPrompt,
         @NotNull @Positive Long curationRawProductId
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response;
 
 public record AdminBannerStyleAnswerChipResponse(
+        Long id,
         Integer order,
         String label,
         String selectedPrompt,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/banner/response/AdminBannerStyleAnswerChipResponse.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.respo
 public record AdminBannerStyleAnswerChipResponse(
         Integer order,
         String label,
+        String selectedPrompt,
         Long curationRawProductId,
         String curationRawProductName,
         String curationRawProductImageUrl

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -136,6 +136,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                     return new AdminBannerStyleAnswerChipResponse(
                             chip.order(),
                             chip.label(),
+                            chip.selectedPrompt(),
                             chip.curationRawProductId(),
                             rawProduct != null ? rawProduct.getProductName() : null,
                             rawProduct != null ? rawProduct.getProductImageUrl() : null

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -80,7 +80,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
 
         List<BannerStyleAnswerChip> currentChips = adminBannerSupport.parseStyleAnswerChipsJson(banner.getStyleAnswerChipsJson());
         List<BannerStyleAnswerChip> targetChips = request.styleAnswerChips() != null
-                ? adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips())
+                ? adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips(), currentChips)
                 : currentChips;
 
         List<Long> currentMappedRawProductIds = adminBannerSupport.extractMappedRawProductIds(banner);
@@ -134,6 +134,7 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 .map(chip -> {
                     CurationRawProduct rawProduct = rawProductMap.get(chip.curationRawProductId());
                     return new AdminBannerStyleAnswerChipResponse(
+                            chip.id(),
                             chip.order(),
                             chip.label(),
                             chip.selectedPrompt(),

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
@@ -113,6 +113,13 @@ public class AdminBannerSupport {
     }
 
     public List<BannerStyleAnswerChip> normalizeStyleAnswerChips(List<AdminBannerStyleAnswerChipRequest> requests) {
+        return normalizeStyleAnswerChips(requests, List.of());
+    }
+
+    public List<BannerStyleAnswerChip> normalizeStyleAnswerChips(
+            List<AdminBannerStyleAnswerChipRequest> requests,
+            List<BannerStyleAnswerChip> existingChips
+    ) {
         if (requests == null) {
             return List.of();
         }
@@ -120,12 +127,13 @@ public class AdminBannerSupport {
             throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
         }
 
-        List<BannerStyleAnswerChip> chips = requests.stream()
+        List<BannerStyleAnswerChip> normalizedWithoutId = requests.stream()
                 .map(request -> {
                     if (request == null || request.order() == null || request.curationRawProductId() == null) {
                         throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
                     }
                     return new BannerStyleAnswerChip(
+                            null,
                             request.order(),
                             normalizeRequired(request.label()),
                             normalizeRequired(request.selectedPrompt()),
@@ -135,8 +143,17 @@ public class AdminBannerSupport {
                 .sorted(Comparator.comparing(BannerStyleAnswerChip::order))
                 .toList();
 
+        List<BannerStyleAnswerChip> chips = assignStyleAnswerChipIds(normalizedWithoutId, existingChips);
+
         Set<Integer> orders = new LinkedHashSet<>();
+        Set<Long> ids = new LinkedHashSet<>();
         for (BannerStyleAnswerChip chip : chips) {
+            if (chip.id() == null || chip.id() < 1) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+            if (!ids.add(chip.id())) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
             if (chip.order() == null || chip.order() < 1) {
                 throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
             }
@@ -148,6 +165,42 @@ public class AdminBannerSupport {
             }
         }
         return chips;
+    }
+
+    private List<BannerStyleAnswerChip> assignStyleAnswerChipIds(
+            List<BannerStyleAnswerChip> chips,
+            List<BannerStyleAnswerChip> existingChips
+    ) {
+        Map<Integer, Long> existingIdByOrder = (existingChips == null ? List.<BannerStyleAnswerChip>of() : existingChips).stream()
+                .filter(Objects::nonNull)
+                .filter(chip -> chip.order() != null && chip.id() != null && chip.id() > 0)
+                .collect(Collectors.toMap(
+                        BannerStyleAnswerChip::order,
+                        BannerStyleAnswerChip::id,
+                        (left, right) -> left,
+                        LinkedHashMap::new
+                ));
+
+        long nextId = existingIdByOrder.values().stream()
+                .mapToLong(Long::longValue)
+                .max()
+                .orElse(0L) + 1L;
+
+        List<BannerStyleAnswerChip> result = new ArrayList<>(chips.size());
+        for (BannerStyleAnswerChip chip : chips) {
+            Long resolvedId = existingIdByOrder.get(chip.order());
+            if (resolvedId == null) {
+                resolvedId = nextId++;
+            }
+            result.add(new BannerStyleAnswerChip(
+                    resolvedId,
+                    chip.order(),
+                    chip.label(),
+                    chip.selectedPrompt(),
+                    chip.curationRawProductId()
+            ));
+        }
+        return result;
     }
 
     public String toStyleAnswerChipsJson(List<BannerStyleAnswerChip> chips) {

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerSupport.java
@@ -128,6 +128,7 @@ public class AdminBannerSupport {
                     return new BannerStyleAnswerChip(
                             request.order(),
                             normalizeRequired(request.label()),
+                            normalizeRequired(request.selectedPrompt()),
                             request.curationRawProductId()
                     );
                 })

--- a/src/main/java/or/sopt/houme/global/config/FeignConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/FeignConfig.java
@@ -12,10 +12,9 @@ public class FeignConfig {
     @Bean
     public Request.Options feignRequestOptions() {
 
-        // 1분(60초) 문제를 해결하기 위해 130초(130,000ms)로 설정합니다.
-        // (Resilience4j의 TimeLimiter(120초)보다 길게 설정)
+        // Gemini 이미지 생성은 2분 이상 걸릴 수 있어 여유 있게 설정합니다.
         long connectTimeout = 5_000; // 5초
-        long readTimeout = 130_000;  // 130초
+        long readTimeout = 300_000;  // 300초
 
         return new Request.Options(
                 connectTimeout, TimeUnit.MILLISECONDS,

--- a/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
+++ b/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.global.util;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -60,8 +61,34 @@ public class S3UtilImpl implements S3Util {
             amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata));
 
         } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 upload failed (service). bucket={}, key={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getStatusCode(),
+                    e.getErrorCode(),
+                    e.getRequestId(),
+                    e.getErrorMessage(),
+                    e
+            );
+            throw new S3Exception(ErrorCode.IMAGE_UPLOAD_AMAZON_EXCEPTION);
+        } catch (SdkClientException e) {
+            log.error(
+                    "S3 upload failed (client). bucket={}, key={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getMessage(),
+                    e
+            );
             throw new S3Exception(ErrorCode.IMAGE_UPLOAD_AMAZON_EXCEPTION);
         } catch (IOException e) {
+            log.error(
+                    "S3 upload failed (io). bucket={}, key={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getMessage(),
+                    e
+            );
             throw new S3Exception(ErrorCode.IMAGE_UPLOAD_IO_EXCEPTION);
         }
 
@@ -92,8 +119,34 @@ public class S3UtilImpl implements S3Util {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(imageBytes);
             amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
         } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 uploadByByte failed (service). bucket={}, key={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getStatusCode(),
+                    e.getErrorCode(),
+                    e.getRequestId(),
+                    e.getErrorMessage(),
+                    e
+            );
+            throw new S3Exception(ErrorCode.IMAGE_UPLOAD_AMAZON_EXCEPTION);
+        } catch (SdkClientException e) {
+            log.error(
+                    "S3 uploadByByte failed (client). bucket={}, key={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getMessage(),
+                    e
+            );
             throw new S3Exception(ErrorCode.IMAGE_UPLOAD_AMAZON_EXCEPTION);
         } catch (Exception e) {
+            log.error(
+                    "S3 uploadByByte failed (other). bucket={}, key={}, message={}",
+                    bucket,
+                    fileName,
+                    e.getMessage(),
+                    e
+            );
             throw new S3Exception(ErrorCode.IMAGE_UPLOAD_IO_EXCEPTION);
         }
 
@@ -123,6 +176,16 @@ public class S3UtilImpl implements S3Util {
             }
 
         } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 delete failed. bucket={}, key={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket,
+                    filename,
+                    e.getStatusCode(),
+                    e.getErrorCode(),
+                    e.getRequestId(),
+                    e.getErrorMessage(),
+                    e
+            );
             throw new S3Exception(ErrorCode.IMAGE_DELETE_EXCEPTION);
         }
     }

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
@@ -58,7 +58,7 @@ class AdminBannerControllerTest {
                 "배너 설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", "선택 프롬프트", 1L)),
                 List.of(1L)
         );
         when(adminBannerService.create(any(AdminBannerCreateRequest.class))).thenReturn(sampleResponse());
@@ -93,7 +93,7 @@ class AdminBannerControllerTest {
                 "수정 설명",
                 null,
                 null,
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 2L)),
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", "새 선택 프롬프트", 2L)),
                 List.of(2L)
         );
         AdminBannerResponse response = new AdminBannerResponse(
@@ -103,7 +103,7 @@ class AdminBannerControllerTest {
                 "수정 설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", 2L, "책상 B", "https://image/2")),
+                List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", "새 선택 프롬프트", 2L, "책상 B", "https://image/2")),
                 List.of(new AdminBannerMappedRawProductResponse(2L, "soozip", null, 22L, "책상 B", "https://image/2", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)
@@ -179,7 +179,7 @@ class AdminBannerControllerTest {
                 "배너 설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", 1L, "책상 A", "https://image/1")),
+                List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", "선택 프롬프트", 1L, "책상 A", "https://image/1")),
                 List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminBannerControllerTest.java
@@ -103,7 +103,7 @@ class AdminBannerControllerTest {
                 "수정 설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "새 칩", "새 선택 프롬프트", 2L, "책상 B", "https://image/2")),
+                List.of(new AdminBannerStyleAnswerChipResponse(2L, 1, "새 칩", "새 선택 프롬프트", 2L, "책상 B", "https://image/2")),
                 List.of(new AdminBannerMappedRawProductResponse(2L, "soozip", null, 22L, "책상 B", "https://image/2", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)
@@ -179,7 +179,7 @@ class AdminBannerControllerTest {
                 "배너 설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipResponse(1, "칩", "선택 프롬프트", 1L, "책상 A", "https://image/1")),
+                List.of(new AdminBannerStyleAnswerChipResponse(1L, 1, "칩", "선택 프롬프트", 1L, "책상 A", "https://image/1")),
                 List.of(new AdminBannerMappedRawProductResponse(1L, "soozip", null, 10L, "책상 A", "https://image/1", "브랜드")),
                 LocalDateTime.of(2026, 3, 13, 12, 0),
                 LocalDateTime.of(2026, 3, 13, 12, 5)

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -57,7 +57,7 @@ class AdminBannerServiceImplTest {
         AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
 
         assertThatThrownBy(() -> support.normalizeStyleAnswerChips(Arrays.asList(
-                new AdminBannerStyleAnswerChipRequest(1, "칩", 1L),
+                new AdminBannerStyleAnswerChipRequest(1, "칩", "선택 프롬프트", 1L),
                 null
         )))
                 .isInstanceOf(GeneralException.class)
@@ -71,7 +71,7 @@ class AdminBannerServiceImplTest {
         AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
 
         assertThatThrownBy(() -> support.normalizeStyleAnswerChips(List.of(
-                new AdminBannerStyleAnswerChipRequest(null, "칩", 1L)
+                new AdminBannerStyleAnswerChipRequest(null, "칩", "선택 프롬프트", 1L)
         )))
                 .isInstanceOf(GeneralException.class)
                 .extracting(e -> ((GeneralException) e).getErrorCode())
@@ -112,12 +112,12 @@ class AdminBannerServiceImplTest {
                 "설명",
                 "질문",
                 "prompt",
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", 1L)),
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "칩", "선택 프롬프트", 1L)),
                 List.of(1L)
         );
 
         when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
-                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", 1L)));
+                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", "선택 프롬프트", 1L)));
         when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(1L)))).thenReturn(List.of(1L));
         when(adminBannerSupport.loadRequiredRawProducts(List.of(1L))).thenReturn(Map.of(1L, chipRawProduct));
         when(adminBannerSupport.normalizeRequired("https://image")).thenReturn("https://image");
@@ -129,7 +129,8 @@ class AdminBannerServiceImplTest {
         when(adminBannerSupport.buildMappings(any(Banner.class), eq(List.of(1L)), eq(Map.of(1L, chipRawProduct))))
                 .thenReturn(List.of());
         when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(banner);
-        when(adminBannerSupport.parseStyleAnswerChipsJson(any())).thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", 1L)));
+        when(adminBannerSupport.parseStyleAnswerChipsJson(any()))
+                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", "선택 프롬프트", 1L)));
         when(adminBannerSupport.toMappedRawProductResponses(eq(banner), eq(Map.of(1L, chipRawProduct)))).thenReturn(List.of());
 
         AdminBannerResponse response = adminBannerService.create(request);
@@ -163,14 +164,14 @@ class AdminBannerServiceImplTest {
                 "새 설명",
                 "새 질문",
                 "새 프롬프트",
-                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", 3L)),
+                List.of(new AdminBannerStyleAnswerChipRequest(1, "새 칩", "새 선택 프롬프트", 3L)),
                 List.of(3L)
         );
 
         when(bannerRepository.findByIdWithRawProducts(11L, BannerType.BANNER, true)).thenReturn(Optional.of(banner));
         when(adminBannerSupport.parseStyleAnswerChipsJson(any())).thenReturn(List.of());
         when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
-                .thenReturn(List.of(new BannerStyleAnswerChip(1, "새 칩", 3L)));
+                .thenReturn(List.of(new BannerStyleAnswerChip(1, "새 칩", "새 선택 프롬프트", 3L)));
         when(adminBannerSupport.extractMappedRawProductIds(banner)).thenReturn(List.of());
         when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(3L)))).thenReturn(List.of(3L));
         when(adminBannerSupport.loadRequiredRawProducts(List.of(3L))).thenReturn(Map.of(3L, rawProduct));

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -90,6 +90,38 @@ class AdminBannerServiceImplTest {
     }
 
     @Test
+    @DisplayName("normalizeStyleAnswerChips()는 생성 시 칩 id를 자동으로 부여한다")
+    void normalizeStyleAnswerChips_autoAssignsIdsOnCreate() {
+        AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
+
+        List<BannerStyleAnswerChip> chips = support.normalizeStyleAnswerChips(List.of(
+                new AdminBannerStyleAnswerChipRequest(2, "두 번째", "프롬프트2", 2L),
+                new AdminBannerStyleAnswerChipRequest(1, "첫 번째", "프롬프트1", 1L)
+        ));
+
+        assertThat(chips).extracting(BannerStyleAnswerChip::id).containsExactly(1L, 2L);
+        assertThat(chips).extracting(BannerStyleAnswerChip::order).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("normalizeStyleAnswerChips()는 수정 시 동일 order의 기존 id를 유지한다")
+    void normalizeStyleAnswerChips_keepsIdsOnUpdate() {
+        AdminBannerSupport support = new AdminBannerSupport(null, new ObjectMapper(), null);
+
+        List<BannerStyleAnswerChip> existing = List.of(
+                new BannerStyleAnswerChip(11L, 1, "기존1", "기존프롬프트1", 1L),
+                new BannerStyleAnswerChip(22L, 2, "기존2", "기존프롬프트2", 2L)
+        );
+
+        List<BannerStyleAnswerChip> updated = support.normalizeStyleAnswerChips(List.of(
+                new AdminBannerStyleAnswerChipRequest(1, "변경1", "변경프롬프트1", 1L),
+                new AdminBannerStyleAnswerChipRequest(2, "변경2", "변경프롬프트2", 2L)
+        ), existing);
+
+        assertThat(updated).extracting(BannerStyleAnswerChip::id).containsExactly(11L, 22L);
+    }
+
+    @Test
     @DisplayName("create()는 배너를 생성한다")
     void create_success() {
         CurationRawProduct chipRawProduct = rawProduct(1L, 101L, "책상 A");
@@ -117,7 +149,7 @@ class AdminBannerServiceImplTest {
         );
 
         when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
-                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", "선택 프롬프트", 1L)));
+                .thenReturn(List.of(new BannerStyleAnswerChip(1L, 1, "칩", "선택 프롬프트", 1L)));
         when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(1L)))).thenReturn(List.of(1L));
         when(adminBannerSupport.loadRequiredRawProducts(List.of(1L))).thenReturn(Map.of(1L, chipRawProduct));
         when(adminBannerSupport.normalizeRequired("https://image")).thenReturn("https://image");
@@ -130,7 +162,7 @@ class AdminBannerServiceImplTest {
                 .thenReturn(List.of());
         when(bannerRepository.saveAndFlush(any(Banner.class))).thenReturn(banner);
         when(adminBannerSupport.parseStyleAnswerChipsJson(any()))
-                .thenReturn(List.of(new BannerStyleAnswerChip(1, "칩", "선택 프롬프트", 1L)));
+                .thenReturn(List.of(new BannerStyleAnswerChip(1L, 1, "칩", "선택 프롬프트", 1L)));
         when(adminBannerSupport.toMappedRawProductResponses(eq(banner), eq(Map.of(1L, chipRawProduct)))).thenReturn(List.of());
 
         AdminBannerResponse response = adminBannerService.create(request);
@@ -170,8 +202,8 @@ class AdminBannerServiceImplTest {
 
         when(bannerRepository.findByIdWithRawProducts(11L, BannerType.BANNER, true)).thenReturn(Optional.of(banner));
         when(adminBannerSupport.parseStyleAnswerChipsJson(any())).thenReturn(List.of());
-        when(adminBannerSupport.normalizeStyleAnswerChips(request.styleAnswerChips()))
-                .thenReturn(List.of(new BannerStyleAnswerChip(1, "새 칩", "새 선택 프롬프트", 3L)));
+        when(adminBannerSupport.normalizeStyleAnswerChips(eq(request.styleAnswerChips()), any()))
+                .thenReturn(List.of(new BannerStyleAnswerChip(1L, 1, "새 칩", "새 선택 프롬프트", 3L)));
         when(adminBannerSupport.extractMappedRawProductIds(banner)).thenReturn(List.of());
         when(adminBannerSupport.extractAllRawProductIds(any(), eq(List.of(3L)))).thenReturn(List.of(3L));
         when(adminBannerSupport.loadRequiredRawProducts(List.of(3L))).thenReturn(Map.of(3L, rawProduct));


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #458 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- POST /api/v1/generated-images/generate/banner
- 배너 기반 이미지 생성 플로우
  - 배너, 도면, 답변칩 조회 -> 프롬프트 & 참조 이미지 조회
  - 프롬프트 조합
  - gemini 호출
  - S3 업로드
  - generate_images 엔티티 저장 및 크레딧 확정

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 정말 맨~~ 처음 테스트할때 130초 타임아웃이 터져서 임시로 300초로 증가시켜뒀습니다. 이미지 생성 API 모두 구현 끝나고 호출 시간을 본 뒤에 다시 타임아웃 시간을 재정립하겠습니다.
- 머지하기 전에는 필요 없는 로그를 지워서 머지하겠습니다. (S3 업로드, 사용 프롬프트 같은 테스트용 로그들)
- banners. style_answer_chips_json에 id를 추가했습니다. 이유는 답변 칩이 긴 문자열인데 이걸 그대로 클라에서 요청 값으로 받는게 신경 쓰여서, id를 디테일 페이지에서 응답하고 요청으로 받는 걸로 수정했습니다.
- banners. style_answer_chips_json에 seletledPrompt를 추가했습니다. 이유는 스타일 질문에서 답변 칩에 따라 추가 프롬프트가 필요하기 때문입니다.

### 어드민 관련 수정사항
@gdbs1107 
- 배너 답변칩 생성/수정 요청에 seletledPrompt를 추가했습니다. 이유는 위와 같습니다.
- seletledPrompt와 달리 id는 요청으로 받지 않고 자동으로 serial하게 생성하도록 해서 어드민에서는 id를 신경쓰지 않아도 됩니다.
- json 변경 내용은 아래처럼 이해하시면 됩니다.
기존: { order, label, curationRawProductId }
변경: { id, order, label, selectedPrompt, curationRawProductId }

## 📬 Postman
## [이미지 생성 테스트]
- API 테스트용으로 아래 사진들과 프롬프트를 사용해서 API를 호출해봤습니다.
### [사용 프롬프트]
> 도면 사진에 인테리어 스타일링을 적용해줘
선택한 상품이 있다면 그걸 적용해줘
도면은 유지하고 그곳에 스타일과 상품을 배치해줘

### [사용 이미지]
<img width="294" height="174" alt="image" src="https://github.com/user-attachments/assets/73d5f28b-1195-4a20-bdfd-0d4d0d15ae66" />
<img width="716" height="715" alt="image" src="https://github.com/user-attachments/assets/d657ab56-853f-44ea-8012-98cfc05b20f4" />
<img width="499" height="500" alt="image" src="https://github.com/user-attachments/assets/b6818dfd-72a5-48c5-b754-a23425a61964" />
<img width="413" height="413" alt="image" src="https://github.com/user-attachments/assets/768254e8-fdda-4638-911d-120a185aa4cc" />


## [2개의 결과는 아래와 같습니다.]
[1분 19초]
https://s3.ap-northeast-2.amazonaws.com/houme-bucket/chat_gpt_image/d699c044-aa34-4cf1-9b64-5e62bac56706-3a058020-6195-4223-bd49-10a77f0420de.webp
<img width="725" height="720" alt="image" src="https://github.com/user-attachments/assets/0cbec3f1-a230-4efe-871f-fa89ac40d0a5" />


[1분 3초]
https://s3.ap-northeast-2.amazonaws.com/houme-bucket/chat_gpt_image/782836d2-e45e-43aa-aaf4-dd7ff8c3e66b-fb5ef8eb-4e98-444d-a538-5b6911090ccd.webp
<img width="772" height="717" alt="image" src="https://github.com/user-attachments/assets/983ec621-ec41-4832-82f4-69bd4ace548e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 배너용 이미지 생성 엔드포인트가 추가되어 프롬프트와 참고 이미지(레퍼런스)를 함께 업로드해 AI로 배너 이미지를 생성할 수 있습니다.
  * 배너 스타일 답변에 식별자(id)와 선택 프롬프트(selectedPrompt) 필드가 추가되어 응답 및 관리에 표시됩니다.

* **개선사항**
  * 이미지 업로드/삭제 예외 처리 강화로 실패 원인 로깅 및 안정성 향상.
  * 외부 API 호출 타임아웃이 300초로 연장되어 대용량 작업 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->