### PR TITLE
[FEATURE] 닉네임 Tag 기능 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
@@ -15,7 +15,13 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Builder
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_nickname_nickname_tag",
+                columnNames = {"nickname", "nickname_tag"}
+        )
+)
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
@@ -28,6 +28,9 @@ public class User extends BaseEntity {
     @Column(name = "nickname", nullable = true)
     private String nickname;
 
+    @Column(name = "nickname_tag", nullable = true, length = 5)
+    private String nicknameTag;
+
     @Column(name = "birthday", nullable = true)
     private LocalDate birthday;
 
@@ -64,8 +67,9 @@ public class User extends BaseEntity {
     }
 
     // v2 자체 회원가입시 사용되는 유저 업데이트 메서드
-    public void updateUserFromSignUpV2(String nickname, LocalDate birthday, Gender gender) {
+    public void updateUserFromSignUpV2(String nickname, String nicknameTag, LocalDate birthday, Gender gender) {
         this.nickname = nickname;
+        this.nicknameTag = nicknameTag;
         this.name = nickname;
         this.birthday = birthday;
         this.gender = gender;

--- a/src/main/java/or/sopt/houme/domain/user/repository/UserRepository.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Boolean existsByEmail(String email);
 
+    Boolean existsByNicknameAndNicknameTag(String nickname, String nicknameTag);
+
     Optional<User> findByEmail(String email);
 
     Optional<User> findById(Long id);

--- a/src/main/java/or/sopt/houme/domain/user/service/NicknameService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/NicknameService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.user.model.entity.NicknameWord;
 import or.sopt.houme.domain.user.model.entity.NicknameWordType;
 import or.sopt.houme.domain.user.repository.NicknameWordRepository;
+import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.UserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -15,15 +17,33 @@ import java.util.concurrent.ThreadLocalRandom;
 @Service
 @RequiredArgsConstructor
 public class NicknameService {
+    private static final int NICKNAME_TAG_RETRY_COUNT = 20;
 
     private final NicknameWordRepository nicknameWordRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public String rotateNickname() {
         List<NicknameWord> adjectives = nicknameWordRepository.findAllByTypeAndIsActiveTrue(NicknameWordType.ADJECTIVE);
         List<NicknameWord> nouns = nicknameWordRepository.findAllByTypeAndIsActiveTrue(NicknameWordType.NOUN);
 
-        return randomWord(adjectives) + randomWord(nouns) + randomNumberSuffix();
+        return randomWord(adjectives) + randomWord(nouns);
+    }
+
+    @Transactional(readOnly = true)
+    public String generateNicknameTag(String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        for (int attempt = 0; attempt < NICKNAME_TAG_RETRY_COUNT; attempt++) {
+            String nicknameTag = randomNumberTag();
+            if (!Boolean.TRUE.equals(userRepository.existsByNicknameAndNicknameTag(nickname, nicknameTag))) {
+                return nicknameTag;
+            }
+        }
+
+        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
     }
 
     private String randomWord(List<NicknameWord> words) {
@@ -35,8 +55,8 @@ public class NicknameService {
         return words.get(index).getWord();
     }
 
-    private String randomNumberSuffix() {
+    private String randomNumberTag() {
         int number = ThreadLocalRandom.current().nextInt(10_000);
-        return String.format("%04d", number);
+        return "#" + String.format("%04d", number);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/NicknameService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/NicknameService.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Service
 @RequiredArgsConstructor
 public class NicknameService {
-    private static final int NICKNAME_TAG_RETRY_COUNT = 20;
+    static final int NICKNAME_TAG_RETRY_COUNT = 20;
 
     private final NicknameWordRepository nicknameWordRepository;
     private final UserRepository userRepository;

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -58,6 +58,7 @@ public class OAuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistTokenRepository blacklistTokenRepository;
     private final SignupSessionRepository signupSessionRepository;
+    private final NicknameService nicknameService;
 
     private final KaKaoConfig kaKaoConfig;
     private final CookieConfig cookieConfig;
@@ -187,18 +188,20 @@ public class OAuthService {
 
     @Transactional
     public String signUpWithToken(String signupToken, String name, Gender gender, LocalDate birthday, HttpServletResponse response) {
-        return signUpWithTokenInternal(signupToken, name, null, gender, birthday, response);
+        return signUpWithTokenInternal(signupToken, name, null, null, gender, birthday, response);
     }
 
     @Transactional
     public String signUpWithTokenV2(String signupToken, String nickname, Gender gender, LocalDate birthday, HttpServletResponse response) {
-        return signUpWithTokenInternal(signupToken, nickname, nickname, gender, birthday, response);
+        String nicknameTag = nicknameService.generateNicknameTag(nickname);
+        return signUpWithTokenInternal(signupToken, nickname, nickname, nicknameTag, gender, birthday, response);
     }
 
     private String signUpWithTokenInternal(
             String signupToken,
             String name,
             String nickname,
+            String nicknameTag,
             Gender gender,
             LocalDate birthday,
             HttpServletResponse response
@@ -219,6 +222,7 @@ public class OAuthService {
                         .email(signupSession.email())
                         .name(name)
                         .nickname(nickname)
+                        .nicknameTag(nicknameTag)
                         .birthday(birthday)
                         .gender(gender)
                         .role(Role.ROLE_USER)

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -27,7 +27,10 @@ import or.sopt.houme.global.config.JWTConfig;
 import or.sopt.houme.global.config.KaKaoConfig;
 import or.sopt.houme.global.jwt.JWTUtil;
 import or.sopt.houme.global.util.CookieUtil;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +50,7 @@ import java.util.stream.IntStream;
 public class OAuthService {
 
     private static final int SIGN_UP_CREDIT_COUNT = 1;
+    private static final String USER_NICKNAME_TAG_UNIQUE_CONSTRAINT = "uk_user_nickname_nickname_tag";
 
     private final KaKaoOAuthClient kaKaoOAuthClient;
     private final KaKaoUserInfoClient kaKaoUserInfoClient;
@@ -59,6 +63,7 @@ public class OAuthService {
     private final BlacklistTokenRepository blacklistTokenRepository;
     private final SignupSessionRepository signupSessionRepository;
     private final NicknameService nicknameService;
+    private final UserNicknameTagTransactionService userNicknameTagTransactionService;
 
     private final KaKaoConfig kaKaoConfig;
     private final CookieConfig cookieConfig;
@@ -191,10 +196,21 @@ public class OAuthService {
         return signUpWithTokenInternal(signupToken, name, null, null, gender, birthday, response);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public String signUpWithTokenV2(String signupToken, String nickname, Gender gender, LocalDate birthday, HttpServletResponse response) {
-        String nicknameTag = nicknameService.generateNicknameTag(nickname);
-        return signUpWithTokenInternal(signupToken, nickname, nickname, nicknameTag, gender, birthday, response);
+        SignupSession signupSession = signupSessionRepository.consume(signupToken)
+                .orElseThrow(() -> new UserException(ErrorCode.SIGNUP_TOKEN_INVALID));
+
+        if (!StringUtils.hasText(signupSession.email())) {
+            throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        if (userRepository.existsByEmail(signupSession.email())) {
+            throw new UserException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        User savedUser = createUserWithNicknameTagRetry(signupSession, nickname, gender, birthday);
+        issueTokens(savedUser, response);
+        return savedUser.getDisplayName();
     }
 
     private String signUpWithTokenInternal(
@@ -244,6 +260,41 @@ public class OAuthService {
             throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
         }
 
+        issueTokens(savedUser, response);
+
+        if (StringUtils.hasText(nickname)) {
+            return savedUser.getDisplayName();
+        }
+        return savedUser.getName();
+    }
+
+    private User createUserWithNicknameTagRetry(
+            SignupSession signupSession,
+            String nickname,
+            Gender gender,
+            LocalDate birthday
+    ) {
+        for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
+            String nicknameTag = nicknameService.generateNicknameTag(nickname);
+            try {
+                return userNicknameTagTransactionService.createSocialUserWithNicknameTag(
+                        signupSession,
+                        nickname,
+                        nickname,
+                        nicknameTag,
+                        gender,
+                        birthday
+                );
+            } catch (DataIntegrityViolationException exception) {
+                if (!isNicknameTagConstraintViolation(exception)) {
+                    throw exception;
+                }
+            }
+        }
+        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
+    }
+
+    private void issueTokens(User savedUser, HttpServletResponse response) {
         String access = jwtUtil.createJwt("access", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
         String refresh = jwtUtil.createJwt("refresh", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
 
@@ -260,11 +311,17 @@ public class OAuthService {
                 cookieConfig.isSecure(),
                 cookieConfig.getSameSite()
         );
+    }
 
-        if (StringUtils.hasText(nickname)) {
-            return savedUser.getDisplayName();
+    private boolean isNicknameTagConstraintViolation(DataIntegrityViolationException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolationException) {
+                return USER_NICKNAME_TAG_UNIQUE_CONSTRAINT.equals(constraintViolationException.getConstraintName());
+            }
+            current = current.getCause();
         }
-        return savedUser.getName();
+        return exception.getMessage() != null && exception.getMessage().contains(USER_NICKNAME_TAG_UNIQUE_CONSTRAINT);
     }
 
 

--- a/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
@@ -1,0 +1,92 @@
+package or.sopt.houme.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.credit.model.entity.Credit;
+import or.sopt.houme.domain.credit.model.entity.CreditStatus;
+import or.sopt.houme.domain.credit.repository.CreditRepository;
+import or.sopt.houme.domain.user.model.entity.Gender;
+import or.sopt.houme.domain.user.model.entity.Role;
+import or.sopt.houme.domain.user.model.entity.SocialType;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.domain.user.model.entity.UserStatus;
+import or.sopt.houme.domain.user.model.entity.record.SignupSession;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.CreditException;
+import or.sopt.houme.global.api.handler.UserException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class UserNicknameTagTransactionService {
+
+    private static final int SIGN_UP_CREDIT_COUNT = 1;
+
+    private final UserRepository userRepository;
+    private final CreditRepository creditRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public User createSocialUserWithNicknameTag(
+            SignupSession signupSession,
+            String name,
+            String nickname,
+            String nicknameTag,
+            Gender gender,
+            LocalDate birthday
+    ) {
+        User savedUser = userRepository.saveAndFlush(
+                User.builder()
+                        .password(null)
+                        .email(signupSession.email())
+                        .name(name)
+                        .nickname(nickname)
+                        .nicknameTag(nicknameTag)
+                        .birthday(birthday)
+                        .gender(gender)
+                        .role(Role.ROLE_USER)
+                        .socialType(SocialType.KAKAO)
+                        .status(UserStatus.ACTIVE)
+                        .hasGeneratedImage(Boolean.FALSE)
+                        .build()
+        );
+        createSignUpCredits(savedUser);
+        return savedUser;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public String completeUserSignUpV2(
+            Long userId,
+            String nickname,
+            String nicknameTag,
+            Gender gender,
+            LocalDate birthday
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateUserFromSignUpV2(nickname, nicknameTag, birthday, gender);
+        userRepository.saveAndFlush(user);
+        createSignUpCredits(user);
+        return user.getDisplayName();
+    }
+
+    private void createSignUpCredits(User user) {
+        try {
+            List<Credit> newCredits = IntStream.range(0, SIGN_UP_CREDIT_COUNT)
+                    .mapToObj(i -> Credit.builder()
+                            .status(CreditStatus.ACTIVE)
+                            .user(user)
+                            .build())
+                    .toList();
+            creditRepository.saveAll(newCredits);
+        } catch (Exception e) {
+            throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -82,6 +82,7 @@ public class UserServiceImpl implements UserService {
     private final RecommendFurnitureRepository recommendFurnitureRepository;
     private final JjymRepository jjymRepository;
     private final CurationRawProductColorRepository curationRawProductColorRepository;
+    private final NicknameService nicknameService;
 
     @Override
     @Transactional(readOnly = true)
@@ -284,7 +285,8 @@ public class UserServiceImpl implements UserService {
     @Override
     public String updateUserV2(User user, String nickname, Gender gender, LocalDate birthday) {
         User findUser = findUser(user);
-        findUser.updateUserFromSignUpV2(nickname, birthday, gender);
+        String nicknameTag = nicknameService.generateNicknameTag(nickname);
+        findUser.updateUserFromSignUpV2(nickname, nicknameTag, birthday, gender);
 
         return createSignUpCreditAndGetDisplayName(findUser);
     }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -46,8 +46,11 @@ import or.sopt.houme.global.api.handler.GenerateImageException;
 import or.sopt.houme.global.api.handler.HouseException;
 import or.sopt.houme.global.api.handler.TagException;
 import or.sopt.houme.global.api.handler.UserException;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -67,6 +70,7 @@ import java.util.stream.IntStream;
 public class UserServiceImpl implements UserService {
 
     private static final int SIGN_UP_CREDIT_COUNT = 1;
+    private static final String USER_NICKNAME_TAG_UNIQUE_CONSTRAINT = "uk_user_nickname_nickname_tag";
 
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
@@ -83,6 +87,7 @@ public class UserServiceImpl implements UserService {
     private final JjymRepository jjymRepository;
     private final CurationRawProductColorRepository curationRawProductColorRepository;
     private final NicknameService nicknameService;
+    private final UserNicknameTagTransactionService userNicknameTagTransactionService;
 
     @Override
     @Transactional(readOnly = true)
@@ -283,12 +288,29 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public String updateUserV2(User user, String nickname, Gender gender, LocalDate birthday) {
-        User findUser = findUser(user);
-        String nicknameTag = nicknameService.generateNicknameTag(nickname);
-        findUser.updateUserFromSignUpV2(nickname, nicknameTag, birthday, gender);
+        Long userId = user.getId();
+        findUser(user);
 
-        return createSignUpCreditAndGetDisplayName(findUser);
+        for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
+            String nicknameTag = nicknameService.generateNicknameTag(nickname);
+            try {
+                return userNicknameTagTransactionService.completeUserSignUpV2(
+                        userId,
+                        nickname,
+                        nicknameTag,
+                        gender,
+                        birthday
+                );
+            } catch (DataIntegrityViolationException exception) {
+                if (!isNicknameTagConstraintViolation(exception)) {
+                    throw exception;
+                }
+            }
+        }
+
+        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
     }
 
     private String createSignUpCreditAndGetDisplayName(User findUser) {
@@ -315,6 +337,17 @@ public class UserServiceImpl implements UserService {
         user.updateHasGeneratedImage();
 
         userRepository.save(user);
+    }
+
+    private boolean isNicknameTagConstraintViolation(DataIntegrityViolationException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolationException) {
+                return USER_NICKNAME_TAG_UNIQUE_CONSTRAINT.equals(constraintViolationException.getConstraintName());
+            }
+            current = current.getCause();
+        }
+        return exception.getMessage() != null && exception.getMessage().contains(USER_NICKNAME_TAG_UNIQUE_CONSTRAINT);
     }
 
     /**

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -188,6 +188,7 @@ public enum ErrorCode {
     // 로그 저장시 objectMapper 에러
     OBJECTMAPPER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50019, "생성 로그 JSON 변환에 실패, 서버 개발자에게 문의해주세요"),
     NICKNAME_RESOURCE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, 50020, "닉네임 리소스가 비어 있습니다. 서버 관리자에게 문의해주세요"),
+    NICKNAME_TAG_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50021, "닉네임 태그 생성에 실패했습니다. 서버 관리자에게 문의해주세요"),
 
     /**
      * 502 BAD_GATEWAY

--- a/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
@@ -92,14 +92,14 @@ class UserV2ControllerTest {
                 any(String.class),
                 any(Gender.class),
                 any(LocalDate.class)
-        )).willReturn("느긋한펭귄0042");
+        )).willReturn("느긋한펭귄");
 
         mockMvc.perform(patch("/api/v2/sign-up")
                         .with(authentication(requestAuthentication))
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "nickname": "느긋한펭귄0042",
+                                  "nickname": "느긋한펭귄",
                                   "gender": "MALE",
                                   "birthday": "2000-01-01"
                                 }
@@ -107,7 +107,7 @@ class UserV2ControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").value("응답 성공"))
-                .andExpect(jsonPath("$.data").value("느긋한펭귄0042"));
+                .andExpect(jsonPath("$.data").value("느긋한펭귄"));
     }
 
     @Test
@@ -140,12 +140,12 @@ class UserV2ControllerTest {
     @Test
     @DisplayName("GET /api/v2/nickname/rotate 요청 시 랜덤 닉네임을 반환한다")
     void rotateNickname_success() throws Exception {
-        given(nicknameService.rotateNickname()).willReturn("느긋한펭귄0042");
+        given(nicknameService.rotateNickname()).willReturn("느긋한펭귄");
 
         mockMvc.perform(get("/api/v2/nickname/rotate"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").value("응답 성공"))
-                .andExpect(jsonPath("$.data").value("느긋한펭귄0042"));
+                .andExpect(jsonPath("$.data").value("느긋한펭귄"));
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/NicknameServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/NicknameServiceTest.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.user.service;
 import or.sopt.houme.domain.user.model.entity.NicknameWord;
 import or.sopt.houme.domain.user.model.entity.NicknameWordType;
 import or.sopt.houme.domain.user.repository.NicknameWordRepository;
+import or.sopt.houme.domain.user.repository.UserRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.UserException;
 import org.junit.jupiter.api.DisplayName;
@@ -29,8 +30,11 @@ class NicknameServiceTest {
     @Mock
     private NicknameWordRepository nicknameWordRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     @Test
-    @DisplayName("닉네임 rotate 결과는 등록된 단어 조합과 숫자 4자리 형식을 유지한다")
+    @DisplayName("닉네임 rotate 결과는 등록된 단어 조합 형식을 유지한다")
     void rotateNickname_format() {
         List<NicknameWord> adjectives = List.of(
                 NicknameWord.of(NicknameWordType.ADJECTIVE, "느긋한"),
@@ -56,9 +60,31 @@ class NicknameServiceTest {
         for (int i = 0; i < 50; i++) {
             String nickname = nicknameService.rotateNickname();
 
-            assertThat(nickname).matches("^[가-힣]+[가-힣]+\\d{4}$");
-            assertThat(allowedWords).contains(nickname.substring(0, nickname.length() - 4));
+            assertThat(nickname).matches("^[가-힣]+[가-힣]+$");
+            assertThat(allowedWords).contains(nickname);
         }
+    }
+
+    @Test
+    @DisplayName("닉네임 태그 생성 결과는 #과 숫자 4자리 형식을 유지한다")
+    void generateNicknameTag_format() {
+        given(userRepository.existsByNicknameAndNicknameTag(org.mockito.ArgumentMatchers.eq("느긋한펭귄"), org.mockito.ArgumentMatchers.anyString()))
+                .willReturn(false);
+
+        String nicknameTag = nicknameService.generateNicknameTag("느긋한펭귄");
+
+        assertThat(nicknameTag).matches("^#\\d{4}$");
+    }
+
+    @Test
+    @DisplayName("닉네임 태그 생성이 반복 충돌하면 예외가 발생한다")
+    void generateNicknameTag_whenCollisionsRepeat_throwException() {
+        given(userRepository.existsByNicknameAndNicknameTag(org.mockito.ArgumentMatchers.eq("느긋한펭귄"), org.mockito.ArgumentMatchers.anyString()))
+                .willReturn(true);
+
+        UserException exception = assertThrows(UserException.class, () -> nicknameService.generateNicknameTag("느긋한펭귄"));
+
+        assertEquals(ErrorCode.NICKNAME_TAG_GENERATION_FAILED, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/service/NicknameServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/NicknameServiceTest.java
@@ -88,6 +88,15 @@ class NicknameServiceTest {
     }
 
     @Test
+    @DisplayName("닉네임이 비어 있으면 유효성 예외가 발생한다")
+    void generateNicknameTag_whenNicknameBlank_throwException() {
+        UserException exception = assertThrows(UserException.class,
+                () -> nicknameService.generateNicknameTag("   "));
+
+        assertEquals(ErrorCode.NOT_VALID_EXCEPTION, exception.getErrorCode());
+    }
+
+    @Test
     @DisplayName("활성화된 닉네임 리소스가 없으면 정해진 예외가 발생한다")
     void rotateNickname_whenWordsMissing_throwException() {
         given(nicknameWordRepository.findAllByTypeAndIsActiveTrue(NicknameWordType.ADJECTIVE))

--- a/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
@@ -68,6 +69,8 @@ class OAuthServiceTest {
     private CookieConfig cookieConfig;
     @Mock
     private NicknameService nicknameService;
+    @Mock
+    private UserNicknameTagTransactionService userNicknameTagTransactionService;
 
     @Mock
     private HttpServletResponse response;
@@ -76,15 +79,25 @@ class OAuthServiceTest {
     @DisplayName("signUpWithTokenV2는 닉네임 태그를 분리 저장하고 닉네임만 반환한다")
     void signUpWithTokenV2_success() {
         SignupSession signupSession = SignupSession.of(1L, "test@houme.kr", "카카오닉네임");
+        User savedUser = User.builder()
+                .id(1L)
+                .name("느긋한펭귄")
+                .nickname("느긋한펭귄")
+                .nicknameTag("#4821")
+                .role(Role.ROLE_USER)
+                .build();
 
         when(signupSessionRepository.consume("signup-token")).thenReturn(Optional.of(signupSession));
         when(userRepository.existsByEmail("test@houme.kr")).thenReturn(false);
         when(nicknameService.generateNicknameTag("느긋한펭귄")).thenReturn("#4821");
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
-            User user = invocation.getArgument(0);
-            ReflectionTestUtils.setField(user, "id", 1L);
-            return user;
-        });
+        when(userNicknameTagTransactionService.createSocialUserWithNicknameTag(
+                signupSession,
+                "느긋한펭귄",
+                "느긋한펭귄",
+                "#4821",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1)
+        )).thenReturn(savedUser);
         when(jwtConfig.getAccessTokenValidityInSeconds()).thenReturn(3600L);
         when(jwtConfig.getRefreshTokenValidityInSeconds()).thenReturn(86400L);
         when(jwtUtil.createJwt(eq("access"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("accessToken");
@@ -101,11 +114,64 @@ class OAuthServiceTest {
         );
 
         assertEquals("느긋한펭귄", result);
-        verify(userRepository).save(argThat(savedUser ->
-                "느긋한펭귄".equals(savedUser.getNickname()) &&
-                "느긋한펭귄".equals(savedUser.getName()) &&
-                "#4821".equals(savedUser.getNicknameTag())
-        ));
+        verify(userNicknameTagTransactionService).createSocialUserWithNicknameTag(
+                signupSession,
+                "느긋한펭귄",
+                "느긋한펭귄",
+                "#4821",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1)
+        );
+    }
+
+    @Test
+    @DisplayName("signUpWithTokenV2는 닉네임 태그 유니크 충돌이 나면 재시도한다")
+    void signUpWithTokenV2_retryOnNicknameTagConstraintViolation() {
+        SignupSession signupSession = SignupSession.of(1L, "test@houme.kr", "카카오닉네임");
+        User savedUser = User.builder()
+                .id(1L)
+                .name("느긋한펭귄")
+                .nickname("느긋한펭귄")
+                .nicknameTag("#5678")
+                .role(Role.ROLE_USER)
+                .build();
+
+        when(signupSessionRepository.consume("signup-token")).thenReturn(Optional.of(signupSession));
+        when(userRepository.existsByEmail("test@houme.kr")).thenReturn(false);
+        when(nicknameService.generateNicknameTag("느긋한펭귄")).thenReturn("#1234", "#5678");
+        when(userNicknameTagTransactionService.createSocialUserWithNicknameTag(
+                signupSession,
+                "느긋한펭귄",
+                "느긋한펭귄",
+                "#1234",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1)
+        )).thenThrow(new DataIntegrityViolationException("uk_user_nickname_nickname_tag"));
+        when(userNicknameTagTransactionService.createSocialUserWithNicknameTag(
+                signupSession,
+                "느긋한펭귄",
+                "느긋한펭귄",
+                "#5678",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1)
+        )).thenReturn(savedUser);
+        when(jwtConfig.getAccessTokenValidityInSeconds()).thenReturn(3600L);
+        when(jwtConfig.getRefreshTokenValidityInSeconds()).thenReturn(86400L);
+        when(jwtUtil.createJwt(eq("access"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("accessToken");
+        when(jwtUtil.createJwt(eq("refresh"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("refreshToken");
+        when(cookieConfig.getDomain()).thenReturn("domain");
+        when(cookieConfig.getSameSite()).thenReturn("true");
+
+        String result = oAuthService.signUpWithTokenV2(
+                "signup-token",
+                "느긋한펭귄",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1),
+                response
+        );
+
+        assertEquals("느긋한펭귄", result);
+        verify(nicknameService, times(2)).generateNicknameTag("느긋한펭귄");
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
@@ -11,12 +11,14 @@ import or.sopt.houme.domain.user.presentation.controller.dto.KakaoLoginResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.KaKaoOAuthTokenDTO;
 import or.sopt.houme.domain.user.presentation.controller.dto.KaKaoUserInfoResponse;
 import or.sopt.houme.domain.credit.repository.CreditRepository;
+import or.sopt.houme.domain.user.model.entity.Gender;
 import or.sopt.houme.domain.user.model.entity.Role;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
 import or.sopt.houme.domain.user.repository.SignupSessionRepository;
 import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.domain.user.model.entity.record.SignupSession;
 import or.sopt.houme.global.api.handler.UserException;
 import or.sopt.houme.global.config.CookieConfig;
 import or.sopt.houme.global.config.JWTConfig;
@@ -64,9 +66,47 @@ class OAuthServiceTest {
     private KaKaoConfig kaKaoConfig;
     @Mock
     private CookieConfig cookieConfig;
+    @Mock
+    private NicknameService nicknameService;
 
     @Mock
     private HttpServletResponse response;
+
+    @Test
+    @DisplayName("signUpWithTokenV2는 닉네임 태그를 분리 저장하고 닉네임만 반환한다")
+    void signUpWithTokenV2_success() {
+        SignupSession signupSession = SignupSession.of(1L, "test@houme.kr", "카카오닉네임");
+
+        when(signupSessionRepository.consume("signup-token")).thenReturn(Optional.of(signupSession));
+        when(userRepository.existsByEmail("test@houme.kr")).thenReturn(false);
+        when(nicknameService.generateNicknameTag("느긋한펭귄")).thenReturn("#4821");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", 1L);
+            return user;
+        });
+        when(jwtConfig.getAccessTokenValidityInSeconds()).thenReturn(3600L);
+        when(jwtConfig.getRefreshTokenValidityInSeconds()).thenReturn(86400L);
+        when(jwtUtil.createJwt(eq("access"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("accessToken");
+        when(jwtUtil.createJwt(eq("refresh"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("refreshToken");
+        when(cookieConfig.getDomain()).thenReturn("domain");
+        when(cookieConfig.getSameSite()).thenReturn("true");
+
+        String result = oAuthService.signUpWithTokenV2(
+                "signup-token",
+                "느긋한펭귄",
+                Gender.MALE,
+                java.time.LocalDate.of(2000, 1, 1),
+                response
+        );
+
+        assertEquals("느긋한펭귄", result);
+        verify(userRepository).save(argThat(savedUser ->
+                "느긋한펭귄".equals(savedUser.getNickname()) &&
+                "느긋한펭귄".equals(savedUser.getName()) &&
+                "#4821".equals(savedUser.getNicknameTag())
+        ));
+    }
 
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -41,6 +41,7 @@ import or.sopt.houme.global.api.handler.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -73,6 +74,7 @@ class UserServiceImplTest {
     private final JjymRepository jjymRepository = mock(JjymRepository.class);
     private final CurationRawProductColorRepository curationRawProductColorRepository = mock(CurationRawProductColorRepository.class);
     private final NicknameService nicknameService = mock(NicknameService.class);
+    private final UserNicknameTagTransactionService userNicknameTagTransactionService = mock(UserNicknameTagTransactionService.class);
 
     private final UserServiceImpl userService = new UserServiceImpl(
             userRepository,
@@ -89,7 +91,8 @@ class UserServiceImplTest {
             recommendFurnitureRepository,
             jjymRepository,
             curationRawProductColorRepository,
-            nicknameService
+            nicknameService,
+            userNicknameTagTransactionService
             );
 
     private User user;
@@ -590,6 +593,16 @@ class UserServiceImplTest {
 
         given(userRepository.findById(1L)).willReturn(Optional.of(dbUser));
         given(nicknameService.generateNicknameTag("새닉네임")).willReturn("#1234");
+        given(userNicknameTagTransactionService.completeUserSignUpV2(
+                1L,
+                "새닉네임",
+                "#1234",
+                Gender.MALE,
+                LocalDate.of(2000, 5, 15)
+        )).willAnswer(invocation -> {
+            dbUser.updateUserFromSignUpV2("새닉네임", "#1234", LocalDate.of(2000, 5, 15), Gender.MALE);
+            return dbUser.getDisplayName();
+        });
 
         // when
         userService.updateUserV2(inputUser, "새닉네임", Gender.MALE, LocalDate.of(2000, 5, 15));
@@ -600,6 +613,36 @@ class UserServiceImplTest {
         assertEquals("#1234", dbUser.getNicknameTag());
         assertEquals(Gender.MALE, dbUser.getGender());
         assertEquals(LocalDate.of(2000, 5, 15), dbUser.getBirthday());
+    }
+
+    @Test
+    @DisplayName("updateUserV2는 닉네임 태그 유니크 충돌이 나면 재시도한다")
+    void updateUserV2_retryOnNicknameTagConstraintViolation() {
+        User inputUser = User.builder().id(1L).build();
+        User dbUser = User.builder().id(1L).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(dbUser));
+        given(nicknameService.generateNicknameTag("새닉네임"))
+                .willReturn("#1234", "#5678");
+        given(userNicknameTagTransactionService.completeUserSignUpV2(
+                1L,
+                "새닉네임",
+                "#1234",
+                Gender.MALE,
+                LocalDate.of(2000, 5, 15)
+        )).willThrow(new DataIntegrityViolationException("uk_user_nickname_nickname_tag"));
+        given(userNicknameTagTransactionService.completeUserSignUpV2(
+                1L,
+                "새닉네임",
+                "#5678",
+                Gender.MALE,
+                LocalDate.of(2000, 5, 15)
+        )).willReturn("새닉네임");
+
+        String result = userService.updateUserV2(inputUser, "새닉네임", Gender.MALE, LocalDate.of(2000, 5, 15));
+
+        assertEquals("새닉네임", result);
+        then(nicknameService).should(times(2)).generateNicknameTag("새닉네임");
     }
 
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -72,6 +72,7 @@ class UserServiceImplTest {
     private final RecommendFurnitureRepository recommendFurnitureRepository = mock(RecommendFurnitureRepository.class);
     private final JjymRepository jjymRepository = mock(JjymRepository.class);
     private final CurationRawProductColorRepository curationRawProductColorRepository = mock(CurationRawProductColorRepository.class);
+    private final NicknameService nicknameService = mock(NicknameService.class);
 
     private final UserServiceImpl userService = new UserServiceImpl(
             userRepository,
@@ -87,7 +88,8 @@ class UserServiceImplTest {
             generateImageUsedProductRepository,
             recommendFurnitureRepository,
             jjymRepository,
-            curationRawProductColorRepository
+            curationRawProductColorRepository,
+            nicknameService
             );
 
     private User user;
@@ -587,13 +589,15 @@ class UserServiceImplTest {
                 .build();
 
         given(userRepository.findById(1L)).willReturn(Optional.of(dbUser));
+        given(nicknameService.generateNicknameTag("새닉네임")).willReturn("#1234");
 
         // when
-        userService.updateUserV2(inputUser, "새닉네임1234", Gender.MALE, LocalDate.of(2000, 5, 15));
+        userService.updateUserV2(inputUser, "새닉네임", Gender.MALE, LocalDate.of(2000, 5, 15));
 
         // then
-        assertEquals("새닉네임1234", dbUser.getName());
-        assertEquals("새닉네임1234", dbUser.getNickname());
+        assertEquals("새닉네임", dbUser.getName());
+        assertEquals("새닉네임", dbUser.getNickname());
+        assertEquals("#1234", dbUser.getNicknameTag());
         assertEquals(Gender.MALE, dbUser.getGender());
         assertEquals(LocalDate.of(2000, 5, 15), dbUser.getBirthday());
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #464 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 회원가입 시, 닉네임이 중복된다면 서버 자체적으로 난수 태그를 붙이도록하여 중복 닉네임을 방지하도록 로직을 구현하였습니다.

## 🙏 Question & PR point

```
    @Transactional(readOnly = true)
    public String generateNicknameTag(String nickname) {
        if (!StringUtils.hasText(nickname)) {
            throw new UserException(ErrorCode.NOT_VALID_EXCEPTION);
        }

        for (int attempt = 0; attempt < NICKNAME_TAG_RETRY_COUNT; attempt++) {
            String nicknameTag = randomNumberTag();
            if (!Boolean.TRUE.equals(userRepository.existsByNicknameAndNicknameTag(nickname, nicknameTag))) {
                return nicknameTag;
            }
        }

        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
    }
```

닉네임을 생성할때 db를 거치지 않도록 하고 싶었지만 현실적으로 불가능함을 깨달았습니다. 난수를 8자리로 늘리면 확률에 기반하여 중복확률이 매우 줄어들지만 이는 확실한 해결책은 아니죠.

그래서 db를 계속 조회하는 방식으로 구현해보았습니다. 이는 최대 20번까지 조회되며 횟수를 넘어가면 `NICKNAME_TAG_GENERATION_FAILED`를 반환하도록 구현하였습니다.

태그는 아직 조회 시에는 반환하지 않고 탐색탭이 생길때 조회가 가능하도록 로직을 리팩터링 하겠습니다.


++

```
@Table(
        name = "users",
        uniqueConstraints = @UniqueConstraint(
                name = "uk_user_nickname_nickname_tag",
                columnNames = {"nickname", "nickname_tag"}
        )
)
```

같은 태그+닉네임이 들어가는 것을 application단에서 확인하는 것에 더불어 db단에서 중복하여 확인 할 수 있도록 테이블에 유니크 제약조건을 추가하였습니다.

```
 @Transactional(propagation = Propagation.REQUIRES_NEW)
    public User createSocialUserWithNicknameTag(
            SignupSession signupSession,
            String name,
            String nickname,
            String nicknameTag,
            Gender gender,
            LocalDate birthday
    ) {
        User savedUser = userRepository.saveAndFlush(
                User.builder()
                        .password(null)
                        .email(signupSession.email())
                        .name(name)
                        .nickname(nickname)
                        .nicknameTag(nicknameTag)
                        .birthday(birthday)
                        .gender(gender)
                        .role(Role.ROLE_USER)
                        .socialType(SocialType.KAKAO)
                        .status(UserStatus.ACTIVE)
                        .hasGeneratedImage(Boolean.FALSE)
                        .build()
        );
        createSignUpCredits(savedUser);
        return savedUser;
    }
```

이때 데이터 정합성 오류가 발생하면 트랜잭션이 오염되어 실제 데이터베이스에 반영이 제대로 되지 않은채 rollback 처리 될 수 있습니다. 이를 방지하고자  `@Transactional(propagation = Propagation.REQUIRES_NEW)` 로 트랜잭션을 분리하여 해당 데이터만 제대로 retry가 가능하도록 로직을 구현하였습니다.

막상 구현하고나니 간단한 구현 결과에 비해 로직이 너무 복잡해져서 고민입니다.


<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 닉네임 중복을 방지하기 위한 고유 태그 시스템이 추가되었습니다. 사용자가 회원가입하거나 프로필을 업데이트할 때 각 닉네임에 자동으로 고유한 태그가 생성되어 할당됩니다.

* **테스트**
  * 새로운 닉네임 태그 생성 및 할당 기능에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->