### PR TITLE
[CHORE] 도면 필드 다중선택 가능 기능 구현 및 UI 개선

### DIFF
--- a/src/main/java/or/sopt/houme/domain/house/model/floorPlan/entity/FloorPlan.java
+++ b/src/main/java/or/sopt/houme/domain/house/model/floorPlan/entity/FloorPlan.java
@@ -50,6 +50,18 @@ public class FloorPlan {
     @Column(name = "equilibrium")
     private Equilibrium equilibrium;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "forms_json", columnDefinition = "jsonb")
+    private String formsJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "structures_json", columnDefinition = "jsonb")
+    private String structuresJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "equilibriums_json", columnDefinition = "jsonb")
+    private String equilibriumsJson;
+
     @Column(name = "floor_plan_prompt", columnDefinition = "TEXT", nullable = false)
     private String floorPlanPrompt;
 
@@ -59,20 +71,29 @@ public class FloorPlan {
 
     public static FloorPlan create(
             String floorPlanName,
-            Form form,
-            Structure structure,
-            Equilibrium equilibrium,
+            java.util.List<Form> forms,
+            java.util.List<Structure> structures,
+            java.util.List<Equilibrium> equilibriums,
             String floorPlanPrompt,
             FloorPlanImages images,
-            String imagesJson
+            String imagesJson,
+            String formsJson,
+            String structuresJson,
+            String equilibriumsJson
     ) {
         validateFloorPlanName(floorPlanName);
+        validateSelections(forms);
+        validateSelections(structures);
+        validateSelections(equilibriums);
 
         FloorPlan floorPlan = FloorPlan.builder()
                 .floorPlanName(floorPlanName)
-                .form(form)
-                .structure(structure)
-                .equilibrium(equilibrium)
+                .form(forms.getFirst())
+                .structure(structures.getFirst())
+                .equilibrium(equilibriums.getFirst())
+                .formsJson(formsJson)
+                .structuresJson(structuresJson)
+                .equilibriumsJson(equilibriumsJson)
                 .floorPlanPrompt(floorPlanPrompt)
                 .build();
         floorPlan.applyImages(images, imagesJson);
@@ -81,19 +102,28 @@ public class FloorPlan {
 
     public void update(
             String floorPlanName,
-            Form form,
-            Structure structure,
-            Equilibrium equilibrium,
+            java.util.List<Form> forms,
+            java.util.List<Structure> structures,
+            java.util.List<Equilibrium> equilibriums,
             String floorPlanPrompt,
             FloorPlanImages images,
-            String imagesJson
+            String imagesJson,
+            String formsJson,
+            String structuresJson,
+            String equilibriumsJson
     ) {
         validateFloorPlanName(floorPlanName);
+        validateSelections(forms);
+        validateSelections(structures);
+        validateSelections(equilibriums);
 
         this.floorPlanName = floorPlanName;
-        this.form = form;
-        this.structure = structure;
-        this.equilibrium = equilibrium;
+        this.form = forms.getFirst();
+        this.structure = structures.getFirst();
+        this.equilibrium = equilibriums.getFirst();
+        this.formsJson = formsJson;
+        this.structuresJson = structuresJson;
+        this.equilibriumsJson = equilibriumsJson;
         this.floorPlanPrompt = floorPlanPrompt;
         applyImages(images, imagesJson);
     }
@@ -110,6 +140,12 @@ public class FloorPlan {
     private static void validateFloorPlanName(String floorPlanName) {
         if (floorPlanName == null || floorPlanName.isBlank()) {
             throw new HouseException(ErrorCode.INVALID_FLOOR_PLAN_NAME);
+        }
+    }
+
+    private static <T> void validateSelections(java.util.List<T> values) {
+        if (values == null || values.isEmpty() || values.stream().anyMatch(java.util.Objects::isNull)) {
+            throw new HouseException(ErrorCode.NOT_VALID_EXCEPTION);
         }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImpl.java
@@ -20,7 +20,10 @@ import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanEquilibriumJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanFormJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanStructureJsonCodec;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.HouseException;
 import or.sopt.houme.global.api.handler.ValidException;
@@ -43,6 +46,9 @@ public class FloorPlanServiceImpl implements FloorPlanService {
     private final FloorPlanRepository floorPlanRepository;
     private final GenerateImageRepository generateImageRepository;
     private final FloorPlanImageJsonCodec floorPlanImageJsonCodec;
+    private final FloorPlanFormJsonCodec floorPlanFormJsonCodec;
+    private final FloorPlanStructureJsonCodec floorPlanStructureJsonCodec;
+    private final FloorPlanEquilibriumJsonCodec floorPlanEquilibriumJsonCodec;
 
     // 집 구조 도면 제공 서비스 (조건에 받아서)
     @Cacheable(
@@ -52,8 +58,9 @@ public class FloorPlanServiceImpl implements FloorPlanService {
     @Override
     public FloorPlanListResponse getHousingPlan(Form form, Structure structure) {
 
-        List<FloorPlan> allByStructureAndType =
-                floorPlanRepository.findAllByStructure(structure);
+        List<FloorPlan> allByStructureAndType = floorPlanRepository.findAll().stream()
+                .filter(floorPlan -> containsForm(floorPlan, form) && containsStructure(floorPlan, structure))
+                .toList();
 
         List<FloorPlanResponse> list = allByStructureAndType.stream()
                 .map(FloorPlanResponse::of)
@@ -206,13 +213,13 @@ public class FloorPlanServiceImpl implements FloorPlanService {
             Structure layoutType,
             Equilibrium equilibrium
     ) {
-        if (residenceType != null && floorPlan.getForm() != residenceType) {
+        if (residenceType != null && !containsForm(floorPlan, residenceType)) {
             return false;
         }
-        if (layoutType != null && floorPlan.getStructure() != layoutType) {
+        if (layoutType != null && !containsStructure(floorPlan, layoutType)) {
             return false;
         }
-        if (equilibrium != null && floorPlan.getEquilibrium() != equilibrium) {
+        if (equilibrium != null && !containsEquilibrium(floorPlan, equilibrium)) {
             return false;
         }
         return true;
@@ -229,8 +236,8 @@ public class FloorPlanServiceImpl implements FloorPlanService {
 
         List<FloorPlan> similar = allFloorPlans.stream()
                 .filter(floorPlan ->
-                        (residenceType != null && floorPlan.getForm() == residenceType)
-                                || (layoutType != null && floorPlan.getStructure() == layoutType))
+                        (residenceType != null && containsForm(floorPlan, residenceType))
+                                || (layoutType != null && containsStructure(floorPlan, layoutType)))
                 .toList();
 
         if (!similar.isEmpty()) {
@@ -257,9 +264,46 @@ public class FloorPlanServiceImpl implements FloorPlanService {
                         .sorted((left, right) -> Long.compare(safeHouseFloorPlanId(left), safeHouseFloorPlanId(right)))
                         .map(HouseFloorPlan::getFloorPlan)
                         .filter(java.util.Objects::nonNull)
-                        .map(FloorPlan::getId)
-                        .findFirst())
+                .map(FloorPlan::getId)
+                .findFirst())
                 .orElse(null);
+    }
+
+    private boolean containsForm(FloorPlan floorPlan, Form form) {
+        return form == null || resolveForms(floorPlan).contains(form);
+    }
+
+    private boolean containsStructure(FloorPlan floorPlan, Structure structure) {
+        return structure == null || resolveStructures(floorPlan).contains(structure);
+    }
+
+    private boolean containsEquilibrium(FloorPlan floorPlan, Equilibrium equilibrium) {
+        return equilibrium == null || resolveEquilibriums(floorPlan).contains(equilibrium);
+    }
+
+    // 기존 단일 컬럼 데이터도 계속 조회되도록 JSON 값이 없으면 대표 enum 컬럼으로 fallback 한다.
+    private List<Form> resolveForms(FloorPlan floorPlan) {
+        List<Form> forms = floorPlanFormJsonCodec.read(floorPlan.getFormsJson());
+        if (!forms.isEmpty()) {
+            return forms;
+        }
+        return floorPlan.getForm() == null ? List.of() : List.of(floorPlan.getForm());
+    }
+
+    private List<Structure> resolveStructures(FloorPlan floorPlan) {
+        List<Structure> structures = floorPlanStructureJsonCodec.read(floorPlan.getStructuresJson());
+        if (!structures.isEmpty()) {
+            return structures;
+        }
+        return floorPlan.getStructure() == null ? List.of() : List.of(floorPlan.getStructure());
+    }
+
+    private List<Equilibrium> resolveEquilibriums(FloorPlan floorPlan) {
+        List<Equilibrium> equilibriums = floorPlanEquilibriumJsonCodec.read(floorPlan.getEquilibriumsJson());
+        if (!equilibriums.isEmpty()) {
+            return equilibriums;
+        }
+        return floorPlan.getEquilibrium() == null ? List.of() : List.of(floorPlan.getEquilibrium());
     }
 
     private List<FloorPlan> deduplicateById(List<FloorPlan> floorPlans) {

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanCreateRequest.java
@@ -15,12 +15,12 @@ public record AdminFloorPlanCreateRequest(
         @JsonAlias("floorPlanName")
         @NotBlank
         String name,
-        @NotNull
-        Form form,
-        @NotNull
-        Structure structure,
-        @NotNull
-        Equilibrium equilibrium,
+        @NotEmpty
+        List<@NotNull Form> forms,
+        @NotEmpty
+        List<@NotNull Structure> structures,
+        @NotEmpty
+        List<@NotNull Equilibrium> equilibriums,
         @NotBlank
         String floorPlanPrompt,
         @Valid

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/request/AdminFloorPlanUpdateRequest.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.re
 import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
@@ -12,9 +13,9 @@ import java.util.List;
 public record AdminFloorPlanUpdateRequest(
         @JsonAlias("floorPlanName")
         String name,
-        Form form,
-        Structure structure,
-        Equilibrium equilibrium,
+        List<@NotNull Form> forms,
+        List<@NotNull Structure> structures,
+        List<@NotNull Equilibrium> equilibriums,
         @NotBlank
         String floorPlanPrompt,
         @Valid

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/floorplan/response/AdminFloorPlanResponse.java
@@ -9,9 +9,9 @@ import java.util.List;
 public record AdminFloorPlanResponse(
         Long id,
         String name,
-        Form form,
-        Structure structure,
-        Equilibrium equilibrium,
+        List<Form> forms,
+        List<Structure> structures,
+        List<Equilibrium> equilibriums,
         String floorPlanPrompt,
         String representativeImageUrl,
         List<AdminFloorPlanImageResponse> images

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImpl.java
@@ -13,10 +13,16 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.res
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.response.AdminFloorPlanImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.response.AdminFloorPlanListResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.response.AdminFloorPlanResponse;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanEquilibriumJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanFormJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImagePresignedUrlGenerator;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanStructureJsonCodec;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
+import or.sopt.houme.domain.house.model.entity.enums.Form;
+import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -32,6 +38,9 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
     private final FloorPlanRepository floorPlanRepository;
     private final FloorPlanImagePresignedUrlGenerator floorPlanImagePresignedUrlGenerator;
     private final FloorPlanImageJsonCodec floorPlanImageJsonCodec;
+    private final FloorPlanFormJsonCodec floorPlanFormJsonCodec;
+    private final FloorPlanStructureJsonCodec floorPlanStructureJsonCodec;
+    private final FloorPlanEquilibriumJsonCodec floorPlanEquilibriumJsonCodec;
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -43,15 +52,21 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
     @Transactional
     public AdminFloorPlanResponse create(AdminFloorPlanCreateRequest request) {
         FloorPlanImages images = toFloorPlanImages(request.images());
+        List<Form> forms = deduplicateRequired(request.forms());
+        List<Structure> structures = deduplicateRequired(request.structures());
+        List<Equilibrium> equilibriums = deduplicateRequired(request.equilibriums());
 
         FloorPlan floorPlan = FloorPlan.create(
                 normalizeRequired(request.name()),
-                request.form(),
-                request.structure(),
-                request.equilibrium(),
+                forms,
+                structures,
+                equilibriums,
                 normalizeRequired(request.floorPlanPrompt()),
                 images,
-                floorPlanImageJsonCodec.write(images.items())
+                floorPlanImageJsonCodec.write(images.items()),
+                floorPlanFormJsonCodec.write(forms),
+                floorPlanStructureJsonCodec.write(structures),
+                floorPlanEquilibriumJsonCodec.write(equilibriums)
         );
 
         return toResponse(floorPlanRepository.saveAndFlush(floorPlan));
@@ -81,15 +96,27 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
         FloorPlanImages images = request.images() != null
                 ? toFloorPlanImages(request.images())
                 : resolveImages(floorPlan);
+        List<Form> forms = request.forms() != null
+                ? deduplicateRequired(request.forms())
+                : resolveForms(floorPlan);
+        List<Structure> structures = request.structures() != null
+                ? deduplicateRequired(request.structures())
+                : resolveStructures(floorPlan);
+        List<Equilibrium> equilibriums = request.equilibriums() != null
+                ? deduplicateRequired(request.equilibriums())
+                : resolveEquilibriums(floorPlan);
 
         floorPlan.update(
                 request.name() != null ? normalizeRequired(request.name()) : floorPlan.getFloorPlanName(),
-                request.form() != null ? request.form() : floorPlan.getForm(),
-                request.structure() != null ? request.structure() : floorPlan.getStructure(),
-                request.equilibrium() != null ? request.equilibrium() : floorPlan.getEquilibrium(),
+                forms,
+                structures,
+                equilibriums,
                 request.floorPlanPrompt() != null ? normalizeRequired(request.floorPlanPrompt()) : floorPlan.getFloorPlanPrompt(),
                 images,
-                floorPlanImageJsonCodec.write(images.items())
+                floorPlanImageJsonCodec.write(images.items()),
+                floorPlanFormJsonCodec.write(forms),
+                floorPlanStructureJsonCodec.write(structures),
+                floorPlanEquilibriumJsonCodec.write(equilibriums)
         );
 
         return toResponse(floorPlanRepository.saveAndFlush(floorPlan));
@@ -106,12 +133,13 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
 
     private AdminFloorPlanResponse toResponse(FloorPlan floorPlan) {
         FloorPlanImages images = resolveImages(floorPlan);
+        // 기존 단일 컬럼은 대표값으로 유지하고, admin 응답은 JSON 기반 다중 매핑을 기준으로 복원한다.
         return new AdminFloorPlanResponse(
                 floorPlan.getId(),
                 floorPlan.getFloorPlanName(),
-                floorPlan.getForm(),
-                floorPlan.getStructure(),
-                floorPlan.getEquilibrium(),
+                resolveForms(floorPlan),
+                resolveStructures(floorPlan),
+                resolveEquilibriums(floorPlan),
                 floorPlan.getFloorPlanPrompt(),
                 floorPlan.getUrl(),
                 images.items().stream().map(AdminFloorPlanImageResponse::of).toList()
@@ -143,6 +171,30 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
             );
         }
         return FloorPlanImages.restore(parsedImages, legacyImage);
+    }
+
+    private List<Form> resolveForms(FloorPlan floorPlan) {
+        List<Form> forms = floorPlanFormJsonCodec.read(floorPlan.getFormsJson());
+        if (!forms.isEmpty()) {
+            return forms;
+        }
+        return floorPlan.getForm() != null ? List.of(floorPlan.getForm()) : List.of();
+    }
+
+    private List<Structure> resolveStructures(FloorPlan floorPlan) {
+        List<Structure> structures = floorPlanStructureJsonCodec.read(floorPlan.getStructuresJson());
+        if (!structures.isEmpty()) {
+            return structures;
+        }
+        return floorPlan.getStructure() != null ? List.of(floorPlan.getStructure()) : List.of();
+    }
+
+    private List<Equilibrium> resolveEquilibriums(FloorPlan floorPlan) {
+        List<Equilibrium> equilibriums = floorPlanEquilibriumJsonCodec.read(floorPlan.getEquilibriumsJson());
+        if (!equilibriums.isEmpty()) {
+            return equilibriums;
+        }
+        return floorPlan.getEquilibrium() != null ? List.of(floorPlan.getEquilibrium()) : List.of();
     }
 
     private FloorPlanImageItem toFloorPlanImageItem(AdminFloorPlanImageRequest request) {
@@ -179,5 +231,19 @@ public class AdminFloorPlanServiceImpl implements AdminFloorPlanService {
             return null;
         }
         return trimmed;
+    }
+
+    private <T> List<T> deduplicateRequired(List<T> values) {
+        if (values == null) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        List<T> normalized = values.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (normalized.isEmpty()) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+        return normalized;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanEquilibriumJsonCodec.java
+++ b/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanEquilibriumJsonCodec.java
@@ -1,0 +1,45 @@
+package or.sopt.houme.domain.user.util.floorplan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class FloorPlanEquilibriumJsonCodec {
+
+    private static final TypeReference<List<Equilibrium>> FLOOR_PLAN_EQUILIBRIUM_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public String write(List<Equilibrium> equilibriums) {
+        try {
+            return objectMapper.writeValueAsString(equilibriums);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    public List<Equilibrium> read(String equilibriumsJson) {
+        if (equilibriumsJson == null || equilibriumsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<Equilibrium> equilibriums = objectMapper.readValue(equilibriumsJson, FLOOR_PLAN_EQUILIBRIUM_TYPE);
+            if (equilibriums == null) {
+                return List.of();
+            }
+            return equilibriums.stream().filter(Objects::nonNull).distinct().toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanFormJsonCodec.java
+++ b/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanFormJsonCodec.java
@@ -1,0 +1,45 @@
+package or.sopt.houme.domain.user.util.floorplan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.house.model.entity.enums.Form;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class FloorPlanFormJsonCodec {
+
+    private static final TypeReference<List<Form>> FLOOR_PLAN_FORM_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public String write(List<Form> forms) {
+        try {
+            return objectMapper.writeValueAsString(forms);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    public List<Form> read(String formsJson) {
+        if (formsJson == null || formsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<Form> forms = objectMapper.readValue(formsJson, FLOOR_PLAN_FORM_TYPE);
+            if (forms == null) {
+                return List.of();
+            }
+            return forms.stream().filter(Objects::nonNull).distinct().toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanStructureJsonCodec.java
+++ b/src/main/java/or/sopt/houme/domain/user/util/floorplan/FloorPlanStructureJsonCodec.java
@@ -1,0 +1,45 @@
+package or.sopt.houme.domain.user.util.floorplan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class FloorPlanStructureJsonCodec {
+
+    private static final TypeReference<List<Structure>> FLOOR_PLAN_STRUCTURE_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public String write(List<Structure> structures) {
+        try {
+            return objectMapper.writeValueAsString(structures);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+
+    public List<Structure> read(String structuresJson) {
+        if (structuresJson == null || structuresJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<Structure> structures = objectMapper.readValue(structuresJson, FLOOR_PLAN_STRUCTURE_TYPE);
+            if (structures == null) {
+                return List.of();
+            }
+            return structures.stream().filter(Objects::nonNull).distinct().toList();
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
+        }
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -781,6 +781,62 @@
             font-weight: 700;
             color: #64748b;
         }
+        .floor-plan-checkbox-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 10px;
+        }
+        .floor-plan-checkbox-card {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 12px;
+            border: 1px solid #d7deea;
+            border-radius: 12px;
+            background: #fff;
+        }
+        .floor-plan-checkbox-card label {
+            margin: 0;
+            font-size: 0.92rem;
+            font-weight: 600;
+            color: #334155;
+        }
+        .floor-plan-gallery {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(156px, 1fr));
+            gap: 12px;
+        }
+        .floor-plan-gallery-item {
+            display: grid;
+            gap: 8px;
+            padding: 10px;
+            border: 1px solid #e2e8f0;
+            border-radius: 14px;
+            background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+        }
+        .floor-plan-gallery-item img {
+            width: 100%;
+            height: 110px;
+            object-fit: cover;
+            border-radius: 10px;
+            background: #e2e8f0;
+        }
+        .floor-plan-gallery-view {
+            display: inline-flex;
+            width: fit-content;
+            align-items: center;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.8rem;
+            font-weight: 700;
+        }
+        .floor-plan-list-toolbar {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
     </style>
 </head>
 <body>
@@ -1693,9 +1749,12 @@
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <span>도면 목록</span>
-                <button id="get-floor-plans-button" class="btn btn-secondary btn-sm">도면 목록 새로고침</button>
+                <div class="floor-plan-list-toolbar">
+                    <button id="toggle-floor-plans-button" class="btn btn-outline-secondary btn-sm">도면 목록 숨기기</button>
+                    <button id="get-floor-plans-button" class="btn btn-secondary btn-sm">도면 목록 새로고침</button>
+                </div>
             </div>
-            <div class="card-body">
+            <div class="card-body" id="floor-plan-list-panel">
                 <div id="floor-plan-list-result" class="api-result"></div>
             </div>
         </div>
@@ -1703,7 +1762,8 @@
         <div class="card">
             <div class="card-header">도면 등록 / 수정</div>
             <div class="card-body">
-                <form id="floor-plan-form">
+                <form id="floor-plan-form" class="banner-form-shell">
+                    <p class="banner-form-lead">도면의 다중 매핑 조건과 모든 view를 함께 관리합니다.</p>
                     <div class="banner-editor-grid">
                         <div>
                             <label for="floorPlanEditId" class="form-label">수정 대상 도면 ID</label>
@@ -1724,36 +1784,72 @@
                                 </div>
                             </div>
                         </div>
-                        <div>
-                            <label for="floorPlanForm" class="form-label">주거형태</label>
-                            <select class="form-select" id="floorPlanForm" required>
-                                <option value="">주거형태를 선택하세요.</option>
-                                <option value="OFFICETEL">오피스텔</option>
-                                <option value="VILLA">빌라/다세대</option>
-                                <option value="APARTMENT">아파트</option>
-                                <option value="ETC">그 외</option>
-                            </select>
+                        <div class="full-span">
+                            <label class="form-label">주거형태</label>
+                            <div class="floor-plan-checkbox-grid">
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanFormOfficetel" data-floor-plan-group="forms" value="OFFICETEL">
+                                    <label for="floorPlanFormOfficetel">오피스텔</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanFormVilla" data-floor-plan-group="forms" value="VILLA">
+                                    <label for="floorPlanFormVilla">빌라/다세대</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanFormApartment" data-floor-plan-group="forms" value="APARTMENT">
+                                    <label for="floorPlanFormApartment">아파트</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanFormEtc" data-floor-plan-group="forms" value="ETC">
+                                    <label for="floorPlanFormEtc">그 외</label>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <label for="floorPlanStructure" class="form-label">구조</label>
-                            <select class="form-select" id="floorPlanStructure" required>
-                                <option value="">구조를 선택하세요.</option>
-                                <option value="OPEN_ONE_ROOM">오픈형 원룸</option>
-                                <option value="SEPARATED_ONE_ROOM">분리형 원룸</option>
-                                <option value="DUPLEX">복층형</option>
-                                <option value="TWO_ROOM">투룸</option>
-                                <option value="THREE_ROOM_OVER">쓰리룸+</option>
-                            </select>
+                        <div class="full-span">
+                            <label class="form-label">구조</label>
+                            <div class="floor-plan-checkbox-grid">
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanStructureOpenOneRoom" data-floor-plan-group="structures" value="OPEN_ONE_ROOM">
+                                    <label for="floorPlanStructureOpenOneRoom">오픈형 원룸</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanStructureSeparatedOneRoom" data-floor-plan-group="structures" value="SEPARATED_ONE_ROOM">
+                                    <label for="floorPlanStructureSeparatedOneRoom">분리형 원룸</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanStructureDuplex" data-floor-plan-group="structures" value="DUPLEX">
+                                    <label for="floorPlanStructureDuplex">복층형</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanStructureTwoRoom" data-floor-plan-group="structures" value="TWO_ROOM">
+                                    <label for="floorPlanStructureTwoRoom">투룸</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanStructureThreeRoomOver" data-floor-plan-group="structures" value="THREE_ROOM_OVER">
+                                    <label for="floorPlanStructureThreeRoomOver">쓰리룸+</label>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <label for="floorPlanEquilibrium" class="form-label">평형</label>
-                            <select class="form-select" id="floorPlanEquilibrium" required>
-                                <option value="">평형을 선택하세요.</option>
-                                <option value="UNDER_5">5평 이하</option>
-                                <option value="BETWEEN_6_10">6~10평</option>
-                                <option value="BETWEEN_11_15">11~15평</option>
-                                <option value="OVER_16">16평 이상</option>
-                            </select>
+                        <div class="full-span">
+                            <label class="form-label">평형</label>
+                            <div class="floor-plan-checkbox-grid">
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanEquilibriumUnder5" data-floor-plan-group="equilibriums" value="UNDER_5">
+                                    <label for="floorPlanEquilibriumUnder5">5평 이하</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanEquilibriumBetween6_10" data-floor-plan-group="equilibriums" value="BETWEEN_6_10">
+                                    <label for="floorPlanEquilibriumBetween6_10">6~10평</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanEquilibriumBetween11_15" data-floor-plan-group="equilibriums" value="BETWEEN_11_15">
+                                    <label for="floorPlanEquilibriumBetween11_15">11~15평</label>
+                                </div>
+                                <div class="floor-plan-checkbox-card">
+                                    <input type="checkbox" class="form-check-input" id="floorPlanEquilibriumOver16" data-floor-plan-group="equilibriums" value="OVER_16">
+                                    <label for="floorPlanEquilibriumOver16">16평 이상</label>
+                                </div>
+                            </div>
                         </div>
                         <div class="full-span">
                             <label for="floorPlanPrompt" class="form-label">도면 프롬프트</label>
@@ -2470,6 +2566,10 @@
             loadFloorPlans();
         });
 
+        document.getElementById('toggle-floor-plans-button').addEventListener('click', function() {
+            toggleFloorPlanListVisibility();
+        });
+
         document.getElementById('floor-plan-form').addEventListener('submit', function(event) {
             event.preventDefault();
             createFloorPlan();
@@ -2492,7 +2592,7 @@
             if (this.files && this.files.length > 0) {
                 statusElement.textContent = `${this.files[0].name} 선택됨. 업로드 후 목록에 추가하세요.`;
             } else {
-                statusElement.textContent = '이미지를 하나씩 업로드해 도면 이미지 목록을 구성하세요.';
+                statusElement.textContent = '이미지를 하나씩 업로드하고, 필요하면 view도 함께 입력하세요.';
             }
         });
     };
@@ -2547,8 +2647,78 @@
     }
 
     function initializeFloorPlanManagement() {
+        toggleFloorPlanListVisibility(true);
         renderFloorPlanImages();
         loadFloorPlans();
+    }
+
+    function getCheckedFloorPlanValues(groupName) {
+        return Array.from(document.querySelectorAll(`[data-floor-plan-group="${groupName}"]:checked`))
+            .map(input => parseStringValue(input.value))
+            .filter(value => value);
+    }
+
+    function setCheckedFloorPlanValues(groupName, values) {
+        const selectedValues = new Set((Array.isArray(values) ? values : []).filter(Boolean));
+        document.querySelectorAll(`[data-floor-plan-group="${groupName}"]`).forEach(input => {
+            input.checked = selectedValues.has(input.value);
+        });
+    }
+
+    // 배열 응답이 없으면 기존 단일 필드 값을 fallback 해서 수정 폼과 목록을 같이 유지한다.
+    function resolveFloorPlanSelectionValues(floorPlan, listKey, singleKey) {
+        const selectionValues = Array.isArray(floorPlan[listKey]) ? floorPlan[listKey].filter(Boolean) : [];
+        if (selectionValues.length > 0) {
+            return selectionValues;
+        }
+        return floorPlan[singleKey] ? [floorPlan[singleKey]] : [];
+    }
+
+    function formatFloorPlanSelectionLabels(values, labelMap) {
+        if (!Array.isArray(values) || values.length === 0) {
+            return '-';
+        }
+        return values
+            .map(value => escapeHtml(labelMap[value] || value))
+            .join(', ');
+    }
+
+    function buildFloorPlanGallery(images, representativeImageUrl) {
+        const galleryImages = Array.isArray(images) && images.length > 0
+            ? images
+            : representativeImageUrl
+                ? [{ url: representativeImageUrl, view: null }]
+                : [];
+
+        if (galleryImages.length === 0) {
+            return '<div class="text-muted small">등록된 도면 이미지가 없습니다.</div>';
+        }
+
+        return `
+            <div class="floor-plan-gallery">
+                ${galleryImages.map((image, index) => `
+                    <div class="floor-plan-gallery-item">
+                        <img src="${escapeHtml(image.url || '')}" alt="도면 view ${index + 1}">
+                        <span class="floor-plan-gallery-view">${escapeHtml(image.view || `view ${index + 1}`)}</span>
+                    </div>
+                `).join('')}
+            </div>
+        `;
+    }
+
+    function toggleFloorPlanListVisibility(forceVisible) {
+        const panel = document.getElementById('floor-plan-list-panel');
+        const button = document.getElementById('toggle-floor-plans-button');
+        if (!panel || !button) {
+            return;
+        }
+
+        const shouldShow = typeof forceVisible === 'boolean'
+            ? forceVisible
+            : panel.classList.contains('d-none');
+
+        panel.classList.toggle('d-none', !shouldShow);
+        button.textContent = shouldShow ? '도면 목록 숨기기' : '도면 목록 보기';
     }
 
     function renderManagedImagePreview(config) {
@@ -3900,9 +4070,13 @@
             const card = document.createElement('div');
             card.className = 'banner-card';
             const imageCount = Array.isArray(floorPlan.images) ? floorPlan.images.length : 0;
-            const representativeView = imageCount > 0 ? floorPlan.images[0]?.view : null;
+            const forms = resolveFloorPlanSelectionValues(floorPlan, 'forms', 'form');
+            const structures = resolveFloorPlanSelectionValues(floorPlan, 'structures', 'structure');
+            const equilibriums = resolveFloorPlanSelectionValues(floorPlan, 'equilibriums', 'equilibrium');
             card.innerHTML = `
-                <img class="banner-card-image" src="${escapeHtml(floorPlan.representativeImageUrl || '')}" alt="도면 #${floorPlan.id}">
+                <div class="banner-card-media">
+                    ${buildFloorPlanGallery(floorPlan.images, floorPlan.representativeImageUrl)}
+                </div>
                 <div class="banner-card-body">
                     <div class="banner-card-title-row">
                         <span class="banner-card-title">${escapeHtml(floorPlan.name || `도면 #${floorPlan.id}`)}</span>
@@ -3915,19 +4089,15 @@
                         </div>
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">주거형태</span>
-                            <span>${escapeHtml(FLOOR_PLAN_FORM_LABELS[floorPlan.form] || floorPlan.form || '-')}</span>
+                            <span>${formatFloorPlanSelectionLabels(forms, FLOOR_PLAN_FORM_LABELS)}</span>
                         </div>
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">구조</span>
-                            <span>${escapeHtml(FLOOR_PLAN_STRUCTURE_LABELS[floorPlan.structure] || floorPlan.structure || '-')}</span>
+                            <span>${formatFloorPlanSelectionLabels(structures, FLOOR_PLAN_STRUCTURE_LABELS)}</span>
                         </div>
                         <div class="floor-plan-summary-item">
                             <span class="floor-plan-summary-item-label">평형</span>
-                            <span>${escapeHtml(FLOOR_PLAN_EQUILIBRIUM_LABELS[floorPlan.equilibrium] || floorPlan.equilibrium || '-')}</span>
-                        </div>
-                        <div class="floor-plan-summary-item">
-                            <span class="floor-plan-summary-item-label">대표 이미지 view</span>
-                            <span>${escapeHtml(representativeView || '-')}</span>
+                            <span>${formatFloorPlanSelectionLabels(equilibriums, FLOOR_PLAN_EQUILIBRIUM_LABELS)}</span>
                         </div>
                         <div class="floor-plan-summary-item" style="grid-column: 1 / -1;">
                             <span class="floor-plan-summary-item-label">도면 프롬프트</span>
@@ -3970,9 +4140,9 @@
 
         document.getElementById('floorPlanEditId').value = floorPlan.id;
         document.getElementById('floorPlanName').value = floorPlan.name || floorPlan.floorPlanName || '';
-        document.getElementById('floorPlanForm').value = floorPlan.form || '';
-        document.getElementById('floorPlanStructure').value = floorPlan.structure || '';
-        document.getElementById('floorPlanEquilibrium').value = floorPlan.equilibrium || '';
+        setCheckedFloorPlanValues('forms', resolveFloorPlanSelectionValues(floorPlan, 'forms', 'form'));
+        setCheckedFloorPlanValues('structures', resolveFloorPlanSelectionValues(floorPlan, 'structures', 'structure'));
+        setCheckedFloorPlanValues('equilibriums', resolveFloorPlanSelectionValues(floorPlan, 'equilibriums', 'equilibrium'));
         document.getElementById('floorPlanPrompt').value = floorPlan.floorPlanPrompt || '';
         document.getElementById('floorPlanImageFile').value = '';
         document.getElementById('floorPlanImageView').value = '';
@@ -3986,6 +4156,9 @@
         document.getElementById('floor-plan-form').reset();
         document.getElementById('floorPlanEditId').value = '';
         document.getElementById('floorPlanImageView').value = '';
+        setCheckedFloorPlanValues('forms', []);
+        setCheckedFloorPlanValues('structures', []);
+        setCheckedFloorPlanValues('equilibriums', []);
         document.getElementById('floorPlanImageUploadStatus').textContent = '이미지를 하나씩 업로드하고, 필요하면 view도 함께 입력하세요.';
         document.getElementById('floor-plan-form-result').innerHTML = '';
         renderFloorPlanImages();
@@ -3996,21 +4169,21 @@
             throw new Error('최소 1개의 도면 이미지를 등록해주세요.');
         }
 
-        const form = parseStringValue(document.getElementById('floorPlanForm').value);
-        const structure = parseStringValue(document.getElementById('floorPlanStructure').value);
-        const equilibrium = parseStringValue(document.getElementById('floorPlanEquilibrium').value);
+        const forms = getCheckedFloorPlanValues('forms');
+        const structures = getCheckedFloorPlanValues('structures');
+        const equilibriums = getCheckedFloorPlanValues('equilibriums');
         const name = parseStringValue(document.getElementById('floorPlanName').value);
         const floorPlanPrompt = parseStringValue(document.getElementById('floorPlanPrompt').value);
 
-        if (!name || !form || !structure || !equilibrium || !floorPlanPrompt) {
+        if (!name || forms.length === 0 || structures.length === 0 || equilibriums.length === 0 || !floorPlanPrompt) {
             throw new Error('도면 이름, 주거형태, 구조, 평형, 도면 프롬프트를 모두 입력해주세요.');
         }
 
         return {
             name,
-            form,
-            structure,
-            equilibrium,
+            forms,
+            structures,
+            equilibriums,
             floorPlanPrompt,
             images: floorPlanAdminState.images.map((image, index) => ({
                 url: image.url,

--- a/src/test/java/or/sopt/houme/domain/house/model/floorPlan/entity/FloorPlanTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/model/floorPlan/entity/FloorPlanTest.java
@@ -22,12 +22,15 @@ class FloorPlanTest {
     void create_throwsWhenFloorPlanNameIsNull() {
         assertThatThrownBy(() -> FloorPlan.create(
                 null,
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.BETWEEN_6_10,
+                List.of(Form.OFFICETEL),
+                List.of(Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.BETWEEN_6_10),
                 "prompt",
                 sampleImages(),
-                sampleImagesJson()
+                sampleImagesJson(),
+                "[\"OFFICETEL\"]",
+                "[\"OPEN_ONE_ROOM\"]",
+                "[\"BETWEEN_6_10\"]"
         ))
                 .isInstanceOf(HouseException.class)
                 .extracting("errorCode")
@@ -39,22 +42,28 @@ class FloorPlanTest {
     void update_throwsWhenFloorPlanNameIsBlank() {
         FloorPlan floorPlan = FloorPlan.create(
                 "유효한 이름",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.BETWEEN_6_10,
+                List.of(Form.OFFICETEL),
+                List.of(Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.BETWEEN_6_10),
                 "prompt",
                 sampleImages(),
-                sampleImagesJson()
+                sampleImagesJson(),
+                "[\"OFFICETEL\"]",
+                "[\"OPEN_ONE_ROOM\"]",
+                "[\"BETWEEN_6_10\"]"
         );
 
         assertThatThrownBy(() -> floorPlan.update(
                 "   ",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.BETWEEN_6_10,
+                List.of(Form.OFFICETEL),
+                List.of(Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.BETWEEN_6_10),
                 "updated prompt",
                 sampleImages(),
-                sampleImagesJson()
+                sampleImagesJson(),
+                "[\"OFFICETEL\"]",
+                "[\"OPEN_ONE_ROOM\"]",
+                "[\"BETWEEN_6_10\"]"
         ))
                 .isInstanceOf(HouseException.class)
                 .extracting("errorCode")
@@ -66,15 +75,20 @@ class FloorPlanTest {
     void create_succeedsWhenFloorPlanNameIsValid() {
         FloorPlan floorPlan = FloorPlan.create(
                 "다용도실이 있는 원룸",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.BETWEEN_6_10,
+                List.of(Form.OFFICETEL),
+                List.of(Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.BETWEEN_6_10),
                 "prompt",
                 sampleImages(),
-                sampleImagesJson()
+                sampleImagesJson(),
+                "[\"OFFICETEL\"]",
+                "[\"OPEN_ONE_ROOM\"]",
+                "[\"BETWEEN_6_10\"]"
         );
 
         assertThat(floorPlan.getFloorPlanName()).isEqualTo("다용도실이 있는 원룸");
+        assertThat(floorPlan.getForm()).isEqualTo(Form.OFFICETEL);
+        assertThat(floorPlan.getFormsJson()).isEqualTo("[\"OFFICETEL\"]");
     }
 
     private FloorPlanImages sampleImages() {

--- a/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
@@ -9,7 +9,10 @@ import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanEquilibriumJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanFormJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanStructureJsonCodec;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +43,15 @@ class FloorPlanServiceImplTest {
 
     @Mock
     FloorPlanImageJsonCodec floorPlanImageJsonCodec;
+
+    @Mock
+    FloorPlanFormJsonCodec floorPlanFormJsonCodec;
+
+    @Mock
+    FloorPlanStructureJsonCodec floorPlanStructureJsonCodec;
+
+    @Mock
+    FloorPlanEquilibriumJsonCodec floorPlanEquilibriumJsonCodec;
 
     @Test
     @DisplayName("사용자가 입력한 값들을 토대로 도면 템플릿을 필터링해서 내려줄 수 있다.")
@@ -84,7 +96,9 @@ class FloorPlanServiceImplTest {
                 .fileExtension(fileExtension)
                 .build();
 
-        when(floorPlanRepository.findAllByStructure(openOneRoom)).thenReturn(List.of(floorPlan1, floorPlan3));
+        when(floorPlanRepository.findAll()).thenReturn(List.of(floorPlan1, floorPlan2, floorPlan3));
+        when(floorPlanFormJsonCodec.read(null)).thenReturn(List.of());
+        when(floorPlanStructureJsonCodec.read(null)).thenReturn(List.of());
 
         // When
         FloorPlanListResponse housingPlan = floorPlanService.getHousingPlan(officetel, openOneRoom);
@@ -160,5 +174,44 @@ class FloorPlanServiceImplTest {
 
         assertThat(result.floorPlans()).hasSize(1);
         assertThat(result.floorPlans().getFirst().imageUrl()).isEqualTo("https://fallback-image");
+    }
+
+    @Test
+    @DisplayName("다중 매핑 JSON이 있으면 공용 도면 조회는 대표 단일 컬럼이 아니라 JSON 값을 기준으로 필터링한다")
+    void getHousingPlan_usesMultiMappingsWhenJsonExists() {
+        FloorPlan matchingFloorPlan = FloorPlan.builder()
+                .id(1L)
+                .form(Form.OFFICETEL)
+                .structure(Structure.OPEN_ONE_ROOM)
+                .equilibrium(Equilibrium.BETWEEN_6_10)
+                .formsJson("[\"APARTMENT\",\"OFFICETEL\"]")
+                .structuresJson("[\"DUPLEX\"]")
+                .url("https://image-1")
+                .filename("file-1.png")
+                .originalFilename("origin-1.png")
+                .fileExtension("png")
+                .build();
+        FloorPlan nonMatchingFloorPlan = FloorPlan.builder()
+                .id(2L)
+                .form(Form.APARTMENT)
+                .structure(Structure.OPEN_ONE_ROOM)
+                .url("https://image-2")
+                .filename("file-2.png")
+                .originalFilename("origin-2.png")
+                .fileExtension("png")
+                .build();
+
+        when(floorPlanRepository.findAll()).thenReturn(List.of(matchingFloorPlan, nonMatchingFloorPlan));
+        when(floorPlanFormJsonCodec.read("[\"APARTMENT\",\"OFFICETEL\"]"))
+                .thenReturn(List.of(Form.APARTMENT, Form.OFFICETEL));
+        when(floorPlanStructureJsonCodec.read("[\"DUPLEX\"]"))
+                .thenReturn(List.of(Structure.DUPLEX));
+        when(floorPlanFormJsonCodec.read(null)).thenReturn(List.of());
+        when(floorPlanStructureJsonCodec.read(null)).thenReturn(List.of());
+
+        FloorPlanListResponse result = floorPlanService.getHousingPlan(Form.APARTMENT, Structure.DUPLEX);
+
+        assertThat(result.floorPlanList()).hasSize(1);
+        assertThat(result.floorPlanList().getFirst().id()).isEqualTo(1L);
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFloorPlanControllerTest.java
@@ -54,9 +54,9 @@ class AdminFloorPlanControllerTest {
     void createFloorPlan_success() throws Exception {
         AdminFloorPlanCreateRequest request = new AdminFloorPlanCreateRequest(
                 "테스트 도면",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.UNDER_5,
+                List.of(Form.OFFICETEL, Form.APARTMENT),
+                List.of(Structure.OPEN_ONE_ROOM, Structure.TWO_ROOM),
+                List.of(Equilibrium.UNDER_5, Equilibrium.BETWEEN_6_10),
                 "도면 프롬프트",
                 List.of(new AdminFloorPlanImageRequest("https://image/1", "fp-1.png", "room-1.png", "png", 1, "창가 뷰"))
         );
@@ -69,7 +69,7 @@ class AdminFloorPlanControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(1L))
                 .andExpect(jsonPath("$.data.name").value("테스트 도면"))
-                .andExpect(jsonPath("$.data.form").value("OFFICETEL"))
+                .andExpect(jsonPath("$.data.forms[0]").value("OFFICETEL"))
                 .andExpect(jsonPath("$.data.images[0].url").value("https://image/1"))
                 .andExpect(jsonPath("$.data.images[0].view").value("창가 뷰"));
     }
@@ -82,7 +82,7 @@ class AdminFloorPlanControllerTest {
         mockMvc.perform(get("/api/v1/admin/floor-plans"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.floorPlans[0].id").value(1L))
-                .andExpect(jsonPath("$.data.floorPlans[0].equilibrium").value("UNDER_5"))
+                .andExpect(jsonPath("$.data.floorPlans[0].equilibriums[0]").value("UNDER_5"))
                 .andExpect(jsonPath("$.data.floorPlans[0].name").value("테스트 도면"))
                 .andExpect(jsonPath("$.data.floorPlans[0].images[0].view").value("창가 뷰"));
     }
@@ -92,18 +92,18 @@ class AdminFloorPlanControllerTest {
     void updateFloorPlan_success() throws Exception {
         AdminFloorPlanUpdateRequest request = new AdminFloorPlanUpdateRequest(
                 "수정 도면",
-                Form.APARTMENT,
-                Structure.TWO_ROOM,
-                Equilibrium.OVER_16,
+                List.of(Form.APARTMENT),
+                List.of(Structure.TWO_ROOM, Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.OVER_16),
                 "수정 프롬프트",
                 List.of(new AdminFloorPlanImageRequest("https://image/2", "fp-2.png", "room-2.png", "png", 1, "강변 뷰"))
         );
         AdminFloorPlanResponse response = new AdminFloorPlanResponse(
                 1L,
                 "수정 도면",
-                Form.APARTMENT,
-                Structure.TWO_ROOM,
-                Equilibrium.OVER_16,
+                List.of(Form.APARTMENT),
+                List.of(Structure.TWO_ROOM, Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.OVER_16),
                 "수정 프롬프트",
                 "https://image/2",
                 List.of(new AdminFloorPlanImageResponse("https://image/2", "fp-2.png", "room-2.png", "png", 1, "강변 뷰"))
@@ -113,10 +113,10 @@ class AdminFloorPlanControllerTest {
 
         mockMvc.perform(patch("/api/v1/admin/floor-plans/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.name").value("수정 도면"))
-                .andExpect(jsonPath("$.data.structure").value("TWO_ROOM"))
+                .andExpect(jsonPath("$.data.structures[0]").value("TWO_ROOM"))
                 .andExpect(jsonPath("$.data.representativeImageUrl").value("https://image/2"))
                 .andExpect(jsonPath("$.data.images[0].view").value("강변 뷰"));
     }
@@ -150,9 +150,9 @@ class AdminFloorPlanControllerTest {
         return new AdminFloorPlanResponse(
                 1L,
                 "테스트 도면",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.UNDER_5,
+                List.of(Form.OFFICETEL),
+                List.of(Structure.OPEN_ONE_ROOM),
+                List.of(Equilibrium.UNDER_5),
                 "도면 프롬프트",
                 "https://image/1",
                 List.of(new AdminFloorPlanImageResponse("https://image/1", "fp-1.png", "room-1.png", "png", 1, "창가 뷰"))

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFloorPlanServiceImplTest.java
@@ -19,8 +19,11 @@ import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.req
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.request.AdminFloorPlanUpdateRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.response.AdminFloorPlanImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.floorplan.response.AdminFloorPlanResponse;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanEquilibriumJsonCodec;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanFormJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImagePresignedUrlGenerator;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanStructureJsonCodec;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,14 +51,23 @@ class AdminFloorPlanServiceImplTest {
     @Mock
     private FloorPlanImageJsonCodec floorPlanImageJsonCodec;
 
+    @Mock
+    private FloorPlanFormJsonCodec floorPlanFormJsonCodec;
+
+    @Mock
+    private FloorPlanStructureJsonCodec floorPlanStructureJsonCodec;
+
+    @Mock
+    private FloorPlanEquilibriumJsonCodec floorPlanEquilibriumJsonCodec;
+
     @Test
     @DisplayName("create()는 다중 이미지 기반 도면을 생성한다")
     void create_success() {
         AdminFloorPlanCreateRequest request = new AdminFloorPlanCreateRequest(
                 "테스트 도면",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.UNDER_5,
+                List.of(Form.OFFICETEL, Form.APARTMENT),
+                List.of(Structure.OPEN_ONE_ROOM, Structure.TWO_ROOM),
+                List.of(Equilibrium.UNDER_5, Equilibrium.BETWEEN_6_10),
                 "도면 프롬프트",
                 List.of(
                         new AdminFloorPlanImageRequest("https://image/1", "fp-1.png", "room-1.png", "png", 1, "창가 뷰"),
@@ -68,26 +80,35 @@ class AdminFloorPlanServiceImplTest {
         );
         FloorPlan floorPlan = FloorPlan.create(
                 "테스트 도면",
-                Form.OFFICETEL,
-                Structure.OPEN_ONE_ROOM,
-                Equilibrium.UNDER_5,
+                List.of(Form.OFFICETEL, Form.APARTMENT),
+                List.of(Structure.OPEN_ONE_ROOM, Structure.TWO_ROOM),
+                List.of(Equilibrium.UNDER_5, Equilibrium.BETWEEN_6_10),
                 "도면 프롬프트",
                 or.sopt.houme.domain.house.model.floorPlan.vo.FloorPlanImages.from(images),
-                "[{\"url\":\"https://image/1\"}]"
+                "[{\"url\":\"https://image/1\"}]",
+                "[\"OFFICETEL\",\"APARTMENT\"]",
+                "[\"OPEN_ONE_ROOM\",\"TWO_ROOM\"]",
+                "[\"UNDER_5\",\"BETWEEN_6_10\"]"
         );
         ReflectionTestUtils.setField(floorPlan, "id", 1L);
 
         when(floorPlanImageJsonCodec.write(anyList())).thenReturn("[{\"url\":\"https://image/1\"}]");
+        when(floorPlanFormJsonCodec.write(anyList())).thenReturn("[\"OFFICETEL\",\"APARTMENT\"]");
+        when(floorPlanStructureJsonCodec.write(anyList())).thenReturn("[\"OPEN_ONE_ROOM\",\"TWO_ROOM\"]");
+        when(floorPlanEquilibriumJsonCodec.write(anyList())).thenReturn("[\"UNDER_5\",\"BETWEEN_6_10\"]");
         when(floorPlanRepository.saveAndFlush(any(FloorPlan.class))).thenReturn(floorPlan);
         when(floorPlanImageJsonCodec.read(anyString())).thenReturn(images);
+        when(floorPlanFormJsonCodec.read(anyString())).thenReturn(List.of(Form.OFFICETEL, Form.APARTMENT));
+        when(floorPlanStructureJsonCodec.read(anyString())).thenReturn(List.of(Structure.OPEN_ONE_ROOM, Structure.TWO_ROOM));
+        when(floorPlanEquilibriumJsonCodec.read(anyString())).thenReturn(List.of(Equilibrium.UNDER_5, Equilibrium.BETWEEN_6_10));
 
         AdminFloorPlanResponse response = adminFloorPlanService.create(request);
 
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.name()).isEqualTo("테스트 도면");
-        assertThat(response.form()).isEqualTo(Form.OFFICETEL);
-        assertThat(response.structure()).isEqualTo(Structure.OPEN_ONE_ROOM);
-        assertThat(response.equilibrium()).isEqualTo(Equilibrium.UNDER_5);
+        assertThat(response.forms()).containsExactly(Form.OFFICETEL, Form.APARTMENT);
+        assertThat(response.structures()).containsExactly(Structure.OPEN_ONE_ROOM, Structure.TWO_ROOM);
+        assertThat(response.equilibriums()).containsExactly(Equilibrium.UNDER_5, Equilibrium.BETWEEN_6_10);
         assertThat(response.images().getFirst().view()).isEqualTo("창가 뷰");
         assertThat(response.images()).hasSize(2);
         assertThat(response.representativeImageUrl()).isEqualTo("https://image/1");
@@ -99,22 +120,25 @@ class AdminFloorPlanServiceImplTest {
     void update_success() {
         FloorPlan floorPlan = FloorPlan.create(
                 "기존 도면",
-                Form.VILLA,
-                Structure.SEPARATED_ONE_ROOM,
-                Equilibrium.BETWEEN_6_10,
+                List.of(Form.VILLA),
+                List.of(Structure.SEPARATED_ONE_ROOM),
+                List.of(Equilibrium.BETWEEN_6_10),
                 "기존 프롬프트",
                 or.sopt.houme.domain.house.model.floorPlan.vo.FloorPlanImages.from(List.of(
                         new FloorPlanImageItem("https://old-image", "old.png", "old-original.png", "png", 1, "기존 뷰")
                 )),
-                "[{\"url\":\"https://old-image\"}]"
+                "[{\"url\":\"https://old-image\"}]",
+                "[\"VILLA\"]",
+                "[\"SEPARATED_ONE_ROOM\"]",
+                "[\"BETWEEN_6_10\"]"
         );
         ReflectionTestUtils.setField(floorPlan, "id", 2L);
 
         AdminFloorPlanUpdateRequest request = new AdminFloorPlanUpdateRequest(
                 "수정 도면",
-                Form.APARTMENT,
-                Structure.TWO_ROOM,
-                Equilibrium.BETWEEN_11_15,
+                List.of(Form.APARTMENT, Form.OFFICETEL),
+                List.of(Structure.TWO_ROOM),
+                List.of(Equilibrium.BETWEEN_11_15, Equilibrium.OVER_16),
                 "수정 프롬프트",
                 List.of(
                         new AdminFloorPlanImageRequest("https://new-image/1", "new-1.png", "new-room-1.png", "png", 1, "한강 뷰"),
@@ -128,15 +152,21 @@ class AdminFloorPlanServiceImplTest {
 
         when(floorPlanRepository.findById(2L)).thenReturn(Optional.of(floorPlan));
         when(floorPlanImageJsonCodec.write(anyList())).thenReturn("[{\"url\":\"https://new-image/1\"}]");
+        when(floorPlanFormJsonCodec.write(anyList())).thenReturn("[\"APARTMENT\",\"OFFICETEL\"]");
+        when(floorPlanStructureJsonCodec.write(anyList())).thenReturn("[\"TWO_ROOM\"]");
+        when(floorPlanEquilibriumJsonCodec.write(anyList())).thenReturn("[\"BETWEEN_11_15\",\"OVER_16\"]");
         when(floorPlanRepository.saveAndFlush(floorPlan)).thenReturn(floorPlan);
         when(floorPlanImageJsonCodec.read(anyString())).thenReturn(updatedImages);
+        when(floorPlanFormJsonCodec.read(anyString())).thenReturn(List.of(Form.APARTMENT, Form.OFFICETEL));
+        when(floorPlanStructureJsonCodec.read(anyString())).thenReturn(List.of(Structure.TWO_ROOM));
+        when(floorPlanEquilibriumJsonCodec.read(anyString())).thenReturn(List.of(Equilibrium.BETWEEN_11_15, Equilibrium.OVER_16));
 
         AdminFloorPlanResponse response = adminFloorPlanService.update(2L, request);
 
         assertThat(response.name()).isEqualTo("수정 도면");
-        assertThat(response.form()).isEqualTo(Form.APARTMENT);
-        assertThat(response.structure()).isEqualTo(Structure.TWO_ROOM);
-        assertThat(response.equilibrium()).isEqualTo(Equilibrium.BETWEEN_11_15);
+        assertThat(response.forms()).containsExactly(Form.APARTMENT, Form.OFFICETEL);
+        assertThat(response.structures()).containsExactly(Structure.TWO_ROOM);
+        assertThat(response.equilibriums()).containsExactly(Equilibrium.BETWEEN_11_15, Equilibrium.OVER_16);
         assertThat(response.images().getFirst().view()).isEqualTo("한강 뷰");
         assertThat(response.representativeImageUrl()).isEqualTo("https://new-image/1");
         assertThat(response.images()).hasSize(2);
@@ -144,6 +174,8 @@ class AdminFloorPlanServiceImplTest {
         assertThat(floorPlan.getFilename()).isEqualTo("new-1.png");
         assertThat(floorPlan.getOriginalFilename()).isEqualTo("new-room-1.png");
         assertThat(floorPlan.getFileExtension()).isEqualTo("png");
+        assertThat(floorPlan.getForm()).isEqualTo(Form.APARTMENT);
+        assertThat(floorPlan.getEquilibrium()).isEqualTo(Equilibrium.BETWEEN_11_15);
     }
 
     @Test


### PR DESCRIPTION
# 이번 PR도 서버 로직은 크게 변하지 않았습니다 UI코드들이 많아서 그래요!

## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #470 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 도면의 평형, 구조, 형태를 다중 선택 할 수 있도록 로직을 수정하였습니다.
- 도면의 모든 view를 확인 할 수 있도록 UI를 수정하였습니다.
- 도면 모두보기를 토글링하여 볼 수 있도록 UI를 수정하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

### 1. 도면의 평형,구조,형태 필드가 JSONB 필드로 '확장' 되었습니다. 
수정이 아니에요.
```
    @JdbcTypeCode(SqlTypes.JSON)
    @Column(name = "forms_json", columnDefinition = "jsonb")
    private String formsJson;

    @JdbcTypeCode(SqlTypes.JSON)
    @Column(name = "structures_json", columnDefinition = "jsonb")
    private String structuresJson;

    @JdbcTypeCode(SqlTypes.JSON)
    @Column(name = "equilibriums_json", columnDefinition = "jsonb")
    private String equilibriumsJson;
```
그 이유는 이전의 데이터들의 정합성 오류가 발생 할 수 있기 때문입니다. 이 또한 페이즈가 넘어감에 따라 사라질 필드라고 알고 계시면 될 것 같습니다.

### 2. 기존 데이터들이 정상적으로 조회되도록 fallback 로직도 함께 구현하였습니다.

```
    // 기존 단일 컬럼 데이터도 계속 조회되도록 JSON 값이 없으면 대표 enum 컬럼으로 fallback 한다.
    private List<Form> resolveForms(FloorPlan floorPlan) {
        List<Form> forms = floorPlanFormJsonCodec.read(floorPlan.getFormsJson());
        if (!forms.isEmpty()) {
            return forms;
        }
        return floorPlan.getForm() == null ? List.of() : List.of(floorPlan.getForm());
    }

```

### 3. JSONB 필드가 늘어나니...
이를 파싱하기 위한 클래스가 늘어나네요.

```
@Component
@RequiredArgsConstructor
public class FloorPlanEquilibriumJsonCodec {

    private static final TypeReference<List<Equilibrium>> FLOOR_PLAN_EQUILIBRIUM_TYPE = new TypeReference<>() {};

    private final ObjectMapper objectMapper;

    public String write(List<Equilibrium> equilibriums) {
        try {
            return objectMapper.writeValueAsString(equilibriums);
        } catch (JsonProcessingException e) {
            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
        }
    }

    public List<Equilibrium> read(String equilibriumsJson) {
        if (equilibriumsJson == null || equilibriumsJson.isBlank()) {
            return List.of();
        }
        try {
            List<Equilibrium> equilibriums = objectMapper.readValue(equilibriumsJson, FLOOR_PLAN_EQUILIBRIUM_TYPE);
            if (equilibriums == null) {
                return List.of();
            }
            return equilibriums.stream().filter(Objects::nonNull).distinct().toList();
        } catch (JsonProcessingException e) {
            throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
        }
    }
}

```

테이블 구조가 간결해지는 대신 로직의 복잡성이 올라가네요. 고민이 되는 부분입니다. (더들리 톤으로)
공통 구조로 엮을 수 있는 로직이 필요할 것 같습니다.


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 평면도에 복수의 형태/구조/평형을 저장하고 반환하도록 API·관리 UI·목록 표시를 다중값으로 전환했습니다. 관리자 대시보드에서 체크박스 기반 다중 선택, 선택 항목의 콤마 구분 표시 및 이미지 갤러리를 제공합니다.
* **Tests**
  * 다중값 스키마에 맞춰 단위/통합 테스트와 컨트롤러 테스트를 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->