### PR TITLE
[CHORE] 배너 및 이미지 템플릿 기반 이미지 생성시 house 엔티티 Null 문제 해결

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImage.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImage.java
@@ -2,8 +2,6 @@ package or.sopt.houme.domain.generateImage.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import or.sopt.houme.domain.banner.model.entity.Banner;
-import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import or.sopt.houme.global.entity.BaseEntity;
@@ -39,20 +37,15 @@ public class GenerateImage extends BaseEntity {
     @Column(name = "generation_type", length = 20)
     private GenerateImageType generationType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "banner_id")
-    private Banner banner;
-
     // 정적 메서드
     public static GenerateImage createGenerateImage(ImageUploadResponseDTO request, House house) {
-        return createGenerateImage(request, house, GenerateImageType.RECOMMEND, null);
+        return createGenerateImage(request, house, GenerateImageType.RECOMMEND);
     }
 
     public static GenerateImage createGenerateImage(
             ImageUploadResponseDTO request,
             House house,
-            GenerateImageType generationType,
-            Banner banner
+            GenerateImageType generationType
     ) {
         return GenerateImage.builder()
                 .url(request.getImageLink())
@@ -61,7 +54,6 @@ public class GenerateImage extends BaseEntity {
                 .fileExtension(request.getContentType())
                 .house(house)
                 .generationType(generationType)
-                .banner(banner)
                 .build();
     }
 
@@ -69,6 +61,9 @@ public class GenerateImage extends BaseEntity {
         if (generationType != null) {
             return generationType;
         }
-        return banner != null ? GenerateImageType.LIST : GenerateImageType.RECOMMEND;
+        if (house != null && house.getBanner() != null) {
+            return GenerateImageType.LIST;
+        }
+        return GenerateImageType.RECOMMEND;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -88,7 +88,7 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
         return queryFactory
                 .selectFrom(generateImage)
                 .join(generateImage.house, house).fetchJoin()
-                .leftJoin(generateImage.banner, banner).fetchJoin()
+                .leftJoin(house.banner, banner).fetchJoin()
                 .where(
                         house.user.id.eq(userId),
                         house.isValid.isTrue()
@@ -152,10 +152,10 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
         }
         if (generationType == GenerateImageType.LIST) {
             return generateImage.generationType.eq(GenerateImageType.LIST)
-                    .or(generateImage.generationType.isNull().and(generateImage.banner.isNotNull()));
+                    .or(generateImage.generationType.isNull().and(generateImage.house.banner.isNotNull()));
         }
         return generateImage.generationType.eq(GenerateImageType.RECOMMEND)
-                .or(generateImage.generationType.isNull().and(generateImage.banner.isNull()));
+                .or(generateImage.generationType.isNull().and(generateImage.house.banner.isNull()));
     }
 
     private BooleanExpression hasBannerMappedRawProducts(
@@ -163,14 +163,6 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
             QBannerCurationRawProduct bannerRawMapping,
             List<Long> rawProductIds
     ) {
-        BooleanExpression mappedByImageBanner = JPAExpressions.selectOne()
-                .from(bannerRawMapping)
-                .where(
-                        bannerRawMapping.banner.id.eq(generateImage.banner.id),
-                        bannerRawMapping.curationRawProduct.id.in(rawProductIds)
-                )
-                .exists();
-
         BooleanExpression mappedByHouseBanner = JPAExpressions.selectOne()
                 .from(bannerRawMapping)
                 .where(
@@ -179,7 +171,7 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
                 )
                 .exists();
 
-        return mappedByImageBanner.or(mappedByHouseBanner);
+        return mappedByHouseBanner;
     }
 
     private BooleanExpression hasUsedRawProducts(

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -163,13 +163,23 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
             QBannerCurationRawProduct bannerRawMapping,
             List<Long> rawProductIds
     ) {
-        return JPAExpressions.selectOne()
+        BooleanExpression mappedByImageBanner = JPAExpressions.selectOne()
                 .from(bannerRawMapping)
                 .where(
                         bannerRawMapping.banner.id.eq(generateImage.banner.id),
                         bannerRawMapping.curationRawProduct.id.in(rawProductIds)
                 )
                 .exists();
+
+        BooleanExpression mappedByHouseBanner = JPAExpressions.selectOne()
+                .from(bannerRawMapping)
+                .where(
+                        bannerRawMapping.banner.id.eq(generateImage.house.banner.id),
+                        bannerRawMapping.curationRawProduct.id.in(rawProductIds)
+                )
+                .exists();
+
+        return mappedByImageBanner.or(mappedByHouseBanner);
     }
 
     private BooleanExpression hasUsedRawProducts(

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageService.java
@@ -1,6 +1,5 @@
 package or.sopt.houme.domain.generateImage.service;
 
-import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.house.model.entity.House;
@@ -17,8 +16,7 @@ public interface GenerateImageService {
     GenerateImage createGenerateImage(
             ImageUploadResponseDTO request,
             House house,
-            GenerateImageType generationType,
-            Banner banner
+            GenerateImageType generationType
     );
 
     // 이미지 ID로 조회

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImpl.java
@@ -1,13 +1,10 @@
 package or.sopt.houme.domain.generateImage.service;
 
 import lombok.RequiredArgsConstructor;
-import or.sopt.houme.domain.banner.model.entity.Banner;
-import or.sopt.houme.domain.house.presentation.dto.request.IsLikeRequest;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.model.entity.House;
-import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.GenerateImageException;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
@@ -25,7 +22,7 @@ public class GenerateImageServiceImpl implements GenerateImageService {
     @Transactional
     @Override
     public GenerateImage createGenerateImage(ImageUploadResponseDTO request, House house) {
-        return createGenerateImage(request, house, GenerateImageType.RECOMMEND, null);
+        return createGenerateImage(request, house, GenerateImageType.RECOMMEND);
     }
 
     @Transactional
@@ -33,10 +30,9 @@ public class GenerateImageServiceImpl implements GenerateImageService {
     public GenerateImage createGenerateImage(
             ImageUploadResponseDTO request,
             House house,
-            GenerateImageType generationType,
-            Banner banner
+            GenerateImageType generationType
     ) {
-        GenerateImage generateImage = GenerateImage.createGenerateImage(request, house, generationType, banner);
+        GenerateImage generateImage = GenerateImage.createGenerateImage(request, house, generationType);
         return generateImageRepository.save(generateImage);
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -19,6 +19,8 @@ import or.sopt.houme.domain.house.presentation.taste.dto.response.TagDTO;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.HouseException;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -149,6 +151,6 @@ public class GenerateImageTransactionService {
     private FloorPlan getFloorPlanOrThrow(House house) {
         return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
                 .map(HouseFloorPlan::getFloorPlan)
-                .orElseThrow(() -> new IllegalStateException("House floorPlan mapping must not be null"));
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -11,6 +11,9 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.house.presentation.taste.dto.response.TagDTO;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
@@ -30,6 +33,7 @@ public class GenerateImageTransactionService {
 
     private final CreditService creditService;
     private final HouseService houseService;
+    private final HouseFloorPlanRepository houseFloorPlanRepository;
     private final GenerateImageService generateImageService;
     private final UserService userService;
 
@@ -61,12 +65,13 @@ public class GenerateImageTransactionService {
         userService.updateHasGeneratedImage(user);
 
         // 반환 리스트 생성
+        FloorPlan floorPlan = getFloorPlanOrThrow(house);
         List<ImageInfoResponse> imageInfoResponses = new ArrayList<>();
         for (int i = 0; i < generateImages.size(); i++) {
             imageInfoResponses.add(
                     ImageInfoResponse.of(generateImages.get(i).getId(), generateImages.get(i).getUrl(),
                             generateImageRequest.floorPlan().isMirror(),
-                            house.getEquilibrium().getDescription(), house.getForm().getDescription(),
+                            floorPlan.getEquilibrium().getDescription(), floorPlan.getForm().getDescription(),
                             priorityIdList.get(i).tagNameKr(), user.getName())
             );
         }
@@ -106,12 +111,13 @@ public class GenerateImageTransactionService {
         userService.updateHasGeneratedImage(user);
 
         // 6. 응답 DTO 생성
+        FloorPlan floorPlan = getFloorPlanOrThrow(house);
         return ImageInfoResponse.of(
                 generateImage.getId(),
                 generateImage.getUrl(),
                 request.floorPlan().isMirror(),
-                house.getEquilibrium().getDescription(),
-                house.getForm().getDescription(),
+                floorPlan.getEquilibrium().getDescription(),
+                floorPlan.getForm().getDescription(),
                 priorityTag.getTagNameKr(),
                 user.getName()
         );
@@ -138,5 +144,11 @@ public class GenerateImageTransactionService {
         creditService.commitCreditDeletion(lockedCredit);
         userService.updateHasGeneratedImage(user);
         return BannerGenerateImageResponse.of(generateImage.getId());
+    }
+
+    private FloorPlan getFloorPlanOrThrow(House house) {
+        return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
+                .map(HouseFloorPlan::getFloorPlan)
+                .orElseThrow(() -> new IllegalStateException("House floorPlan mapping must not be null"));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -124,13 +124,18 @@ public class GenerateImageTransactionService {
             User user,
             Credit lockedCredit,
             Banner banner,
+            Long floorPlanId,
+            boolean isMirror,
+            String finalPrompt,
             ImageUploadResponseDTO imageResponse
     ) {
+        House house = houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
+
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
-                null,
+                house,
                 GenerateImageType.LIST,
-                banner
+                null
         );
 
         creditService.commitCreditDeletion(lockedCredit);

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -53,8 +53,7 @@ public class GenerateImageTransactionService {
                 .map(result -> generateImageService.createGenerateImage(
                         result,
                         house,
-                        generationType,
-                        null
+                        generationType
                 ))
                 .toList();
 
@@ -97,8 +96,7 @@ public class GenerateImageTransactionService {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
-                generationType,
-                null
+                generationType
         );
 
         // 4. 크레딧 차감 확정 (PENDING -> DELETE)
@@ -134,8 +132,7 @@ public class GenerateImageTransactionService {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
-                GenerateImageType.LIST,
-                null
+                GenerateImageType.LIST
         );
 
         creditService.commitCreditDeletion(lockedCredit);

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -36,6 +36,8 @@ import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.model.floorPlan.vo.FloorPlanImageItem;
 import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
@@ -77,6 +79,7 @@ public class GenerateImageFacade {
     private final BannerRepository bannerRepository;
     private final FloorPlanRepository floorPlanRepository;
     private final HouseService houseService;
+    private final HouseFloorPlanRepository houseFloorPlanRepository;
     private final CreditService creditService;
     private final TasteTagService tasteTagService;
     private final UserService userService;
@@ -129,12 +132,13 @@ public class GenerateImageFacade {
 
         // house_floor_plan 생성 및 저장
         houseService.saveHouseFloorPlan(house, generateImageRequest.floorPlan().floorPlanId(), generateImageRequest.floorPlan().isMirror());
+        FloorPlan houseFloorPlan = requireHouseFloorPlan(house);
 
         // 침대 ID 찾기
         Optional<Long> bedId = furnitureService.findBedId(generateImageRequest.selectiveIds());
 
         // 복층이 아닌 경우 침대 추가
-        if (!house.getStructure().equals(Structure.DUPLEX) && bedId.isPresent()) {
+        if (!houseFloorPlan.getStructure().equals(Structure.DUPLEX) && bedId.isPresent()) {
             log.info("복층이 아닌 경우 침대 추가");
             generateImageRequest.selectiveIds().add(bedId.get());
         }
@@ -187,8 +191,8 @@ public class GenerateImageFacade {
 
             // 이미지 반환 ImageInfoResponse 생성
             ImageInfoResponse imageInfoResponse = ImageInfoResponse.of(generateImage.getId(), generateImage.getUrl(),
-                    generateImageRequest.floorPlan().isMirror(), house.getEquilibrium().getDescription(),
-                    house.getForm().getDescription(), tag.getTagNameKr(), user.getName());
+                    generateImageRequest.floorPlan().isMirror(), houseFloorPlan.getEquilibrium().getDescription(),
+                    houseFloorPlan.getForm().getDescription(), tag.getTagNameKr(), user.getName());
 
             // 만약 Fallback 이미지라면, 예외처리
             if (generateImage.getUrl().equals(S3Constant.FALL_BACK_IMAGE)) {
@@ -501,12 +505,13 @@ public class GenerateImageFacade {
 
             // house_floor_plan 생성 및 저장
             houseService.saveHouseFloorPlan(house, generateImageRequest.floorPlan().floorPlanId(), generateImageRequest.floorPlan().isMirror());
+            FloorPlan houseFloorPlan = requireHouseFloorPlan(house);
 
             // 침대 ID 찾기
             Optional<Long> bedId = furnitureService.findBedId(generateImageRequest.selectiveIds());
 
             // 복층이 아닌 경우 침대 추가
-            if (!house.getStructure().equals(Structure.DUPLEX) && bedId.isPresent()) {
+            if (!houseFloorPlan.getStructure().equals(Structure.DUPLEX) && bedId.isPresent()) {
                 log.info("복층이 아닌 경우 침대 추가");
                 generateImageRequest.selectiveIds().add(bedId.get());
             }
@@ -568,7 +573,7 @@ public class GenerateImageFacade {
                     if (results.get(i).getImageLink().equals(S3Constant.FALL_BACK_IMAGE)) {
                         fallbackResponses.add(ImageInfoResponse.of(null, results.get(i).getImageLink(),
                                 generateImageRequest.floorPlan().isMirror(), generateImageRequest.equilibrium(),
-                                house.getForm().getDescription(), priorityIdList.get(i).tagNameKr(), user.getName()));
+                                houseFloorPlan.getForm().getDescription(), priorityIdList.get(i).tagNameKr(), user.getName()));
                     }
                 }
                 // fallback 이미지가 포함되어 있다면 예외처리
@@ -811,10 +816,11 @@ public class GenerateImageFacade {
 
         // 반전여부
         boolean isMirror = houseService.getIsMirrorByHouseId(houseId);
+        FloorPlan floorPlan = requireHouseFloorPlan(houseById);
         // 평형
-        String equilibrium = houseById.getEquilibrium().getDescription();
+        String equilibrium = floorPlan.getEquilibrium().getDescription();
         // 집 형태
-        String houseForm = houseById.getForm().getDescription();
+        String houseForm = floorPlan.getForm().getDescription();
 
         // 태그 찾기
         Tag tag = tagService.findTagByUserIdAndImageId(user.getId(), generateImage.getId());
@@ -918,6 +924,12 @@ public class GenerateImageFacade {
             log.warn("유효성 검증 실패 {}: {}", enumType.getSimpleName(), value);
             throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_REQUEST);
         }
+    }
+
+    private FloorPlan requireHouseFloorPlan(House house) {
+        return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
+                .map(HouseFloorPlan::getFloorPlan)
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
     }
 
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -387,6 +387,9 @@ public class GenerateImageFacade {
                     user,
                     lockedCredit,
                     banner,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    prompt,
                     imageUploadResponseDTO
             );
             log.info("배너 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());
@@ -451,6 +454,9 @@ public class GenerateImageFacade {
                     user,
                     lockedCredit,
                     style,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    prompt,
                     imageUploadResponseDTO
             );
             log.info("스타일 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -176,8 +176,7 @@ public class GenerateImageFacade {
                 generateImage = generateImageService.createGenerateImage(
                         imageUploadResponseDTO,
                         house,
-                        GenerateImageType.RECOMMEND,
-                        null
+                        GenerateImageType.RECOMMEND
                 );
 
             } catch (Exception e) {

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -185,6 +185,9 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
 
     private List<CurationRawProduct> resolveSelectedRawProducts(GenerateImage generateImage) {
         Banner banner = generateImage.getBanner();
+        if (banner == null && generateImage.getHouse() != null) {
+            banner = generateImage.getHouse().getBanner();
+        }
         if (banner != null) {
             Banner bannerWithRawProducts = bannerRepository.findAllByIdInWithRawProducts(List.of(banner.getId())).stream()
                     .findFirst()

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -184,10 +184,7 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
     }
 
     private List<CurationRawProduct> resolveSelectedRawProducts(GenerateImage generateImage) {
-        Banner banner = generateImage.getBanner();
-        if (banner == null && generateImage.getHouse() != null) {
-            banner = generateImage.getHouse().getBanner();
-        }
+        Banner banner = generateImage.getHouse() != null ? generateImage.getHouse().getBanner() : null;
         if (banner != null) {
             Banner bannerWithRawProducts = bannerRepository.findAllByIdInWithRawProducts(List.of(banner.getId())).stream()
                     .findFirst()

--- a/src/main/java/or/sopt/houme/domain/house/model/entity/House.java
+++ b/src/main/java/or/sopt/houme/domain/house/model/entity/House.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.house.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
@@ -25,15 +26,15 @@ public class House {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "form", nullable = false)
+    @Column(name = "form", nullable = true)
     private Form form;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "structure", nullable = false)
+    @Column(name = "structure", nullable = true)
     private Structure structure;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "equilibrium", nullable = false)
+    @Column(name = "equilibrium", nullable = true)
     private Equilibrium equilibrium;
 
     @Enumerated(EnumType.STRING)
@@ -43,6 +44,10 @@ public class House {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "banner_id")
+    private Banner banner;
 
     @OneToMany(mappedBy = "house")
     @Builder.Default

--- a/src/main/java/or/sopt/houme/domain/house/model/entity/House.java
+++ b/src/main/java/or/sopt/houme/domain/house/model/entity/House.java
@@ -5,9 +5,6 @@ import lombok.*;
 import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
 import or.sopt.houme.domain.user.model.entity.User;
 
@@ -24,18 +21,6 @@ public class House {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "form", nullable = true)
-    private Form form;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "structure", nullable = true)
-    private Structure structure;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "equilibrium", nullable = true)
-    private Equilibrium equilibrium;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "activity", nullable = true)

--- a/src/main/java/or/sopt/houme/domain/house/repository/floorPlan/FloorPlanRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/floorPlan/FloorPlanRepository.java
@@ -1,10 +1,19 @@
 package or.sopt.houme.domain.house.repository.floorPlan;
 
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
+import or.sopt.houme.domain.house.model.entity.enums.Form;
+import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FloorPlanRepository extends JpaRepository<FloorPlan, Long>, FloorPlanCustomRepository {
-
+    Optional<FloorPlan> findFirstByFormAndStructureAndEquilibrium(
+            Form form,
+            Structure structure,
+            Equilibrium equilibrium
+    );
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.domain.house.service;
 
+import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.house.presentation.dto.LatestHouseConditionDTO;
 import or.sopt.houme.domain.house.presentation.dto.request.HouseSelectRequest;
 import or.sopt.houme.domain.house.presentation.dto.response.HouseIdResponse;
@@ -31,6 +32,9 @@ public interface HouseService {
 
     // 생성된 이미지 프롬프트 저장
     void saveHousePrompt(House house, String prompt);
+
+    // 템플릿 기반 이미지 생성을 위한 house 저장
+    House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror);
 
     // houseId와 floorPlan 저장
     void saveHouseFloorPlan(House house, Long floorPlanId, boolean isMirror);

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
@@ -117,10 +117,13 @@ public class HouseServiceImpl implements HouseService {
     @Transactional
     @Override
     public House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror) {
+        FloorPlan floorPlan = floorPlanRepository.findById(floorPlanId)
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
+
         House house = House.builder()
-                .form(null)
-                .structure(null)
-                .equilibrium(null)
+                .form(floorPlan.getForm())
+                .structure(floorPlan.getStructure())
+                .equilibrium(floorPlan.getEquilibrium())
                 .activity(null)
                 .user(user)
                 .banner(banner)

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
@@ -102,7 +102,8 @@ public class HouseServiceImpl implements HouseService {
         if (latestHouse == null) {
             throw new GeneralException(ErrorCode.NOT_FOUND_HOUSE);
         }
-        return new LatestHouseConditionDTO(latestHouse.getForm(), latestHouse.getStructure(), latestHouse.getEquilibrium());
+        FloorPlan floorPlan = getFloorPlanOrThrow(latestHouse);
+        return new LatestHouseConditionDTO(floorPlan.getForm(), floorPlan.getStructure(), floorPlan.getEquilibrium());
     }
 
     // house prompt 저장
@@ -121,9 +122,6 @@ public class HouseServiceImpl implements HouseService {
                 .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
 
         House house = House.builder()
-                .form(floorPlan.getForm())
-                .structure(floorPlan.getStructure())
-                .equilibrium(floorPlan.getEquilibrium())
                 .activity(null)
                 .user(user)
                 .banner(banner)
@@ -226,15 +224,22 @@ public class HouseServiceImpl implements HouseService {
 
     // 유효한 요청일 때 house 저장
     private Long saveValidHouse(User user, Form form, Structure structure, Equilibrium equilibrium) {
+        FloorPlan matchedFloorPlan = floorPlanRepository.findFirstByFormAndStructureAndEquilibrium(form, structure, equilibrium)
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
+
         House house = House.builder()
-                .form(form)
-                .structure(structure)
-                .equilibrium(equilibrium)
                 .user(user)
                 .isValid(true)
                 .build();
         House save = houseRepository.save(house);
+        saveHouseFloorPlan(save, matchedFloorPlan.getId(), false);
 
         return save.getId();
+    }
+
+    private FloorPlan getFloorPlanOrThrow(House house) {
+        return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
+                .map(HouseFloorPlan::getFloorPlan)
+                .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.house.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
 import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
@@ -111,6 +112,25 @@ public class HouseServiceImpl implements HouseService {
         house.updatePrompt(prompt);
 
         houseRepository.save(house);
+    }
+
+    @Transactional
+    @Override
+    public House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror) {
+        House house = House.builder()
+                .form(null)
+                .structure(null)
+                .equilibrium(null)
+                .activity(null)
+                .user(user)
+                .banner(banner)
+                .isValid(true)
+                .housePrompt(prompt)
+                .build();
+
+        House savedHouse = houseRepository.save(house);
+        saveHouseFloorPlan(savedHouse, floorPlanId, isMirror);
+        return savedHouse;
     }
 
     // house activity 업데이트

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -268,7 +268,7 @@ public class UserServiceImpl implements UserService {
                             return ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
                                     generateImage.getId(),
                                     floorPlan != null && floorPlan.getEquilibrium() != null ? floorPlan.getEquilibrium().getDescription() : null,
-                                    floorPlan != null && floorPlan.getForm() != null ? floorPlan.getForm().toString() : null,
+                                    floorPlan != null && floorPlan.getForm() != null ? floorPlan.getForm().getDescription() : null,
                                     tag.getTagNameKr(),
                                     findUser.getDisplayName(),
                                     generateImage.getUrl(),

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -21,7 +21,9 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.house.repository.taste.tag.TagRepository;
 import or.sopt.houme.domain.preference.model.entity.Factor;
@@ -74,6 +76,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
+    private final HouseFloorPlanRepository houseFloorPlanRepository;
     private final TagRepository tagRepository;
     private final GenerateImageRepository generateImageRepository;
     private final CreditRepository creditRepository;
@@ -122,13 +125,14 @@ public class UserServiceImpl implements UserService {
             boolean isMirror = houseFloorPlans != null && !houseFloorPlans.isEmpty() && houseFloorPlans.get(0).isReverse();
 
             // 4. DTO 생성
+            FloorPlan floorPlan = resolveFloorPlan(house);
             UserImageHistoryDTO dto = new UserImageHistoryDTO(
                     house.getId(),
                     generateImage.get().getId(),
                     generateImage.get().getUrl(),
                     representativeTag.get().getTagNameKr(),
-                    house.getEquilibrium() != null ? house.getEquilibrium().getDescription() : null,
-                    house.getForm() != null ? house.getForm().getDescription() : null,
+                    floorPlan != null && floorPlan.getEquilibrium() != null ? floorPlan.getEquilibrium().getDescription() : null,
+                    floorPlan != null && floorPlan.getForm() != null ? floorPlan.getForm().getDescription() : null,
                     isMirror
             );
             histories.add(dto);
@@ -259,11 +263,12 @@ public class UserServiceImpl implements UserService {
                             Boolean isLike = likes.get(i); // likes 리스트에서 해당 인덱스의 값 가져오기
                             Tag tag = tags.get(i);
                             Factor factor = factors.get(i);
+                            FloorPlan floorPlan = resolveFloorPlan(house);
 
                             return ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
                                     generateImage.getId(),
-                                    house.getEquilibrium() != null ? house.getEquilibrium().getDescription() : null,
-                                    house.getForm() != null ? house.getForm().toString() : null,
+                                    floorPlan != null && floorPlan.getEquilibrium() != null ? floorPlan.getEquilibrium().getDescription() : null,
+                                    floorPlan != null && floorPlan.getForm() != null ? floorPlan.getForm().toString() : null,
                                     tag.getTagNameKr(),
                                     findUser.getDisplayName(),
                                     generateImage.getUrl(),
@@ -537,6 +542,12 @@ public class UserServiceImpl implements UserService {
             return firstName + "로 생성된 이미지";
         }
         return firstName + " 외 " + remainingCount + "개로 생성된 이미지";
+    }
+
+    private FloorPlan resolveFloorPlan(House house) {
+        return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
+                .map(HouseFloorPlan::getFloorPlan)
+                .orElse(null);
     }
 
     private User findUser(User user) {

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -356,10 +356,6 @@ public class UserServiceImpl implements UserService {
     private Map<Long, Banner> buildBannerMap(List<GenerateImage> generateImages) {
         Set<Long> bannerIds = generateImages.stream()
                 .map(generateImage -> {
-                    Banner imageBanner = generateImage.getBanner();
-                    if (imageBanner != null) {
-                        return imageBanner;
-                    }
                     House house = generateImage.getHouse();
                     return house != null ? house.getBanner() : null;
                 })
@@ -520,10 +516,7 @@ public class UserServiceImpl implements UserService {
      * 생성 이미지에 연결된 배너를 배너 맵 기준으로 보정하여 반환합니다.
      */
     private Banner resolveBanner(GenerateImage generateImage, Map<Long, Banner> bannersById) {
-        Banner banner = generateImage.getBanner();
-        if (banner == null && generateImage.getHouse() != null) {
-            banner = generateImage.getHouse().getBanner();
-        }
+        Banner banner = generateImage.getHouse() != null ? generateImage.getHouse().getBanner() : null;
         if (banner != null) {
             return bannersById.getOrDefault(banner.getId(), banner);
         }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -127,8 +127,8 @@ public class UserServiceImpl implements UserService {
                     generateImage.get().getId(),
                     generateImage.get().getUrl(),
                     representativeTag.get().getTagNameKr(),
-                    house.getEquilibrium(),
-                    house.getForm(),
+                    house.getEquilibrium() != null ? house.getEquilibrium().getDescription() : null,
+                    house.getForm() != null ? house.getForm().getDescription() : null,
                     isMirror
             );
             histories.add(dto);
@@ -262,8 +262,8 @@ public class UserServiceImpl implements UserService {
 
                             return ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse.of(
                                     generateImage.getId(),
-                                    house.getEquilibrium().getDescription(),
-                                    house.getForm().toString(),
+                                    house.getEquilibrium() != null ? house.getEquilibrium().getDescription() : null,
+                                    house.getForm() != null ? house.getForm().toString() : null,
                                     tag.getTagNameKr(),
                                     findUser.getDisplayName(),
                                     generateImage.getUrl(),
@@ -355,7 +355,14 @@ public class UserServiceImpl implements UserService {
      */
     private Map<Long, Banner> buildBannerMap(List<GenerateImage> generateImages) {
         Set<Long> bannerIds = generateImages.stream()
-                .map(GenerateImage::getBanner)
+                .map(generateImage -> {
+                    Banner imageBanner = generateImage.getBanner();
+                    if (imageBanner != null) {
+                        return imageBanner;
+                    }
+                    House house = generateImage.getHouse();
+                    return house != null ? house.getBanner() : null;
+                })
                 .filter(Objects::nonNull)
                 .map(Banner::getId)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -514,6 +521,9 @@ public class UserServiceImpl implements UserService {
      */
     private Banner resolveBanner(GenerateImage generateImage, Map<Long, Banner> bannersById) {
         Banner banner = generateImage.getBanner();
+        if (banner == null && generateImage.getHouse() != null) {
+            banner = generateImage.getHouse().getBanner();
+        }
         if (banner != null) {
             return bannersById.getOrDefault(banner.getId(), banner);
         }

--- a/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
@@ -158,21 +158,33 @@ class GenerateImageRepositoryImplTest {
                 .build();
         em.persist(related2);
 
+        House nonMatchedHouse = House.builder()
+                .user(user)
+                .form(Form.OFFICETEL)
+                .structure(Structure.OPEN_ONE_ROOM)
+                .equilibrium(Equilibrium.UNDER_5)
+                .activity(Activity.REMOTE_WORK)
+                .isValid(true)
+                .build();
+        em.persist(nonMatchedHouse);
+
         GenerateImage nonMatched = GenerateImage.builder()
                 .url("https://cdn.com/non-matched.png")
                 .filename("non-matched.png")
                 .originalFilename("non-matched-origin.png")
                 .fileExtension("png")
-                .house(house)
+                .house(nonMatchedHouse)
                 .generationType(GenerateImageType.LIST)
                 .build();
         em.persist(nonMatched);
 
-        // 배너 + 배너 매핑(native) : current/related1이 동일 배너를 바라보도록 구성
+        // 배너 + 배너 매핑(native) : house가 배너를 바라보도록 구성
         em.createNativeQuery("insert into banners(id) values (100)").executeUpdate();
-        em.createNativeQuery("update generate_images set banner_id = 100 where id in (:currentId, :related1Id)")
-                .setParameter("currentId", current.getId())
-                .setParameter("related1Id", related1.getId())
+        em.createNativeQuery("update houses set banner_id = 100 where id = :houseId")
+                .setParameter("houseId", house.getId())
+                .executeUpdate();
+        em.createNativeQuery("update generate_images set generation_type = 'RECOMMEND' where id = :seedImageId")
+                .setParameter("seedImageId", generateImage.getId())
                 .executeUpdate();
         em.createNativeQuery("""
                 insert into banner_curation_raw_products(banner_id, curation_raw_product_id)

--- a/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
@@ -8,9 +8,6 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageUsedProduct;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.global.config.QuerydslConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,9 +56,6 @@ class GenerateImageRepositoryImplTest {
 
         house = House.builder()
                 .user(user)
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .activity(Activity.REMOTE_WORK)
                 .isValid(true)
                 .build();
@@ -160,9 +154,6 @@ class GenerateImageRepositoryImplTest {
 
         House nonMatchedHouse = House.builder()
                 .user(user)
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .activity(Activity.REMOTE_WORK)
                 .isValid(true)
                 .build();

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImplTest.java
@@ -3,9 +3,6 @@ package or.sopt.houme.domain.generateImage.service;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.model.entity.House;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.domain.user.repository.UserRepository;
@@ -62,9 +59,6 @@ class GenerateImageServiceImplTest {
 
         savedHouse = houseRepository.save(
                 House.builder()
-                        .form(Form.OFFICETEL)
-                        .structure(Structure.OPEN_ONE_ROOM)
-                        .equilibrium(Equilibrium.UNDER_5)
                         .isValid(true)
                         .user(savedUser)
                         .build()

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
@@ -1,0 +1,159 @@
+package or.sopt.houme.domain.generateImage.service;
+
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.credit.model.entity.Credit;
+import or.sopt.houme.domain.credit.service.CreditService;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.house.model.entity.House;
+import or.sopt.houme.domain.house.service.HouseService;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[GenerateImageTransaction Service] Test")
+class GenerateImageTransactionServiceTest {
+
+    @InjectMocks
+    private GenerateImageTransactionService generateImageTransactionService;
+
+    @Mock
+    private CreditService creditService;
+
+    @Mock
+    private HouseService houseService;
+
+    @Mock
+    private GenerateImageService generateImageService;
+
+    @Mock
+    private UserService userService;
+
+    @Test
+    @DisplayName("배너 이미지 저장 성공 시 House 생성, 이미지 저장, 크레딧 확정, 사용자 상태 업데이트를 수행한다")
+    void saveBannerImageAndConfirmCredit_success() {
+        User user = mock(User.class);
+        Credit lockedCredit = mock(Credit.class);
+        Banner banner = mock(Banner.class);
+        House house = mock(House.class);
+
+        Long floorPlanId = 3L;
+        boolean isMirror = true;
+        String finalPrompt = "final prompt";
+        ImageUploadResponseDTO imageResponse = ImageUploadResponseDTO.from(
+                "file.jpg",
+                "origin.jpg",
+                "https://cdn.example.com/file.jpg",
+                "image/jpeg"
+        );
+
+        GenerateImage generateImage = GenerateImage.builder()
+                .id(101L)
+                .url("https://cdn.example.com/file.jpg")
+                .filename("file.jpg")
+                .originalFilename("origin.jpg")
+                .fileExtension("image/jpeg")
+                .house(house)
+                .generationType(GenerateImageType.LIST)
+                .build();
+
+        when(houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror))
+                .thenReturn(house);
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+                .thenReturn(generateImage);
+
+        BannerGenerateImageResponse response = generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                banner,
+                floorPlanId,
+                isMirror,
+                finalPrompt,
+                imageResponse
+        );
+
+        assertThat(response.imageId()).isEqualTo(101L);
+        verify(houseService).createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
+        verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.LIST);
+        verify(creditService).commitCreditDeletion(lockedCredit);
+        verify(userService).updateHasGeneratedImage(user);
+    }
+
+    @Test
+    @DisplayName("이미지 저장 단계에서 예외가 발생하면 크레딧 확정과 사용자 상태 업데이트를 수행하지 않는다")
+    void saveBannerImageAndConfirmCredit_failBeforeCreditCommit() {
+        User user = mock(User.class);
+        Credit lockedCredit = mock(Credit.class);
+        Banner banner = mock(Banner.class);
+        House house = mock(House.class);
+        ImageUploadResponseDTO imageResponse = ImageUploadResponseDTO.from(
+                "file.jpg",
+                "origin.jpg",
+                "https://cdn.example.com/file.jpg",
+                "image/jpeg"
+        );
+
+        when(houseService.createTemplateHouse(user, banner, "prompt", 1L, false)).thenReturn(house);
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+                .thenThrow(new RuntimeException("image save failed"));
+
+        assertThatThrownBy(() -> generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                user, lockedCredit, banner, 1L, false, "prompt", imageResponse
+        )).isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("image save failed");
+
+        verify(creditService, never()).commitCreditDeletion(any());
+        verify(userService, never()).updateHasGeneratedImage(any());
+    }
+
+    @Test
+    @DisplayName("크레딧 확정 단계에서 예외가 발생하면 사용자 상태 업데이트를 수행하지 않는다")
+    void saveBannerImageAndConfirmCredit_failOnCreditCommit() {
+        User user = mock(User.class);
+        Credit lockedCredit = mock(Credit.class);
+        Banner banner = mock(Banner.class);
+        House house = mock(House.class);
+        ImageUploadResponseDTO imageResponse = ImageUploadResponseDTO.from(
+                "file.jpg",
+                "origin.jpg",
+                "https://cdn.example.com/file.jpg",
+                "image/jpeg"
+        );
+
+        GenerateImage generateImage = GenerateImage.builder()
+                .id(102L)
+                .url("https://cdn.example.com/file.jpg")
+                .filename("file.jpg")
+                .originalFilename("origin.jpg")
+                .fileExtension("image/jpeg")
+                .house(house)
+                .generationType(GenerateImageType.LIST)
+                .build();
+
+        when(houseService.createTemplateHouse(user, banner, "prompt", 2L, true)).thenReturn(house);
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+                .thenReturn(generateImage);
+        doThrow(new RuntimeException("credit commit failed"))
+                .when(creditService).commitCreditDeletion(lockedCredit);
+
+        assertThatThrownBy(() -> generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                user, lockedCredit, banner, 2L, true, "prompt", imageResponse
+        )).isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("credit commit failed");
+
+        verify(creditService).commitCreditDeletion(lockedCredit);
+        verify(userService, never()).updateHasGeneratedImage(any());
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -284,8 +284,6 @@ class GenerateImageFacadeTest {
 
         when(tasteTagService.getPriorityId(generateImageRequest.moodBoardIds()))
                 .thenReturn(tag);
-        when(houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId()))
-                .thenReturn(Optional.of(HouseFloorPlan.builder().house(house).floorPlan(floorPlan).isReverse(false).build()));
 
         PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(
                 1L, tag.getId(), floorPlan.getEquilibrium(),

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -27,7 +27,9 @@ import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.generateImage.service.openai.facade.OpenAiFacade;
@@ -96,6 +98,9 @@ class GenerateImageFacadeTest {
     HouseService houseService;
 
     @Mock
+    HouseFloorPlanRepository houseFloorPlanRepository;
+
+    @Mock
     CreditService creditService;
 
     @Mock
@@ -141,12 +146,14 @@ class GenerateImageFacadeTest {
                 .role(Role.ROLE_USER)
                 .build();
 
-        House house = House.builder()
-                .id(1L)
+        FloorPlan floorPlan = FloorPlan.builder()
                 .form(Form.OFFICETEL)
                 .structure(Structure.OPEN_ONE_ROOM)
-                .activity(Activity.READING)
                 .equilibrium(Equilibrium.UNDER_5)
+                .build();
+        House house = House.builder()
+                .id(1L)
+                .activity(Activity.READING)
                 .user(user)
                 .isValid(true)
                 .build();
@@ -165,12 +172,14 @@ class GenerateImageFacadeTest {
                 .build();
 
         when(houseService.updateHouseActivity(generateImageRequest.houseId(), Activity.valueOf(generateImageRequest.activity()))).thenReturn(house);
+        when(houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId()))
+                .thenReturn(Optional.of(HouseFloorPlan.builder().house(house).floorPlan(floorPlan).isReverse(false).build()));
 
         when(tasteTagService.getPriorityId(generateImageRequest.moodBoardIds()))
                 .thenReturn(tag);
 
         PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(
-                1L, tag.getId(), house.getEquilibrium(),
+                1L, tag.getId(), floorPlan.getEquilibrium(),
                 PromptFurnitureListDTO.of(List.of())
         );
 
@@ -210,7 +219,7 @@ class GenerateImageFacadeTest {
         assertThat(imageInfoResponse).isNotNull();
         assertThat(imageInfoResponse.tagName()).isEqualTo(tag.getTagNameKr());
         assertThat(imageInfoResponse.imageUrl()).isEqualTo(imageLink);
-        assertThat(imageInfoResponse.houseForm()).isEqualTo(house.getForm().getDescription());
+        assertThat(imageInfoResponse.houseForm()).isEqualTo(floorPlan.getForm().getDescription());
         assertThat(imageInfoResponse.name()).isEqualTo(user.getName());
     }
 
@@ -230,12 +239,14 @@ class GenerateImageFacadeTest {
                 .role(Role.ROLE_USER)
                 .build();
 
-        House house = House.builder()
-                .id(1L)
+        FloorPlan floorPlan = FloorPlan.builder()
                 .form(Form.OFFICETEL)
                 .structure(Structure.OPEN_ONE_ROOM)
-                .activity(Activity.REMOTE_WORK)
                 .equilibrium(Equilibrium.UNDER_5)
+                .build();
+        House house = House.builder()
+                .id(1L)
+                .activity(Activity.REMOTE_WORK)
                 .user(user)
                 .isValid(true)
                 .build();
@@ -273,9 +284,11 @@ class GenerateImageFacadeTest {
 
         when(tasteTagService.getPriorityId(generateImageRequest.moodBoardIds()))
                 .thenReturn(tag);
+        when(houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId()))
+                .thenReturn(Optional.of(HouseFloorPlan.builder().house(house).floorPlan(floorPlan).isReverse(false).build()));
 
         PromptRequestDTO promptRequestDTO = PromptRequestDTO.of(
-                1L, tag.getId(), house.getEquilibrium(),
+                1L, tag.getId(), floorPlan.getEquilibrium(),
                 PromptFurnitureListDTO.of(generateImageRequest.selectiveIds())
         );
 
@@ -286,7 +299,7 @@ class GenerateImageFacadeTest {
         String pullPrompt = "pull_prompt";
 
         ImageInfoResponse tempImageInfoResponse = new ImageInfoResponse(
-                1L, imageLink, false, house.getEquilibrium().getDescription(), house.getForm().getDescription(), tag.getTagNameKr(), user.getName()
+                1L, imageLink, false, floorPlan.getEquilibrium().getDescription(), floorPlan.getForm().getDescription(), tag.getTagNameKr(), user.getName()
                 );
 
         ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
@@ -331,7 +344,7 @@ class GenerateImageFacadeTest {
         assertThat(imageInfoResponse).isNotNull();
         assertThat(imageInfoResponse.tagName()).isEqualTo(tag.getTagNameKr());
         assertThat(imageInfoResponse.imageUrl()).isEqualTo(imageLink);
-        assertThat(imageInfoResponse.houseForm()).isEqualTo(house.getForm().getDescription());
+        assertThat(imageInfoResponse.houseForm()).isEqualTo(floorPlan.getForm().getDescription());
         assertThat(imageInfoResponse.name()).isEqualTo(user.getName());
     }
 

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -161,8 +161,7 @@ class GenerateImageFacadeTest {
         when(generateImageService.createGenerateImage(
                 imageUploadResponseDTO,
                 house,
-                GenerateImageType.RECOMMEND,
-                null
+                GenerateImageType.RECOMMEND
         )).thenReturn(generateImage);
 
         // When

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -1,9 +1,20 @@
 package or.sopt.houme.domain.generateImage.service.facade;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
+import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
+import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.credit.model.entity.Credit;
+import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.generateImage.infrastructure.gemini.service.GeminiImageService;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
@@ -16,8 +27,11 @@ import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.generateImage.service.openai.facade.OpenAiFacade;
+import or.sopt.houme.domain.generateImage.service.prompt.PromptService;
 import or.sopt.houme.domain.generateImage.service.prompt.dto.PromptFurnitureListDTO;
 import or.sopt.houme.domain.generateImage.service.prompt.dto.PromptRequestDTO;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
@@ -27,6 +41,7 @@ import or.sopt.houme.domain.house.service.taste.TasteService;
 import or.sopt.houme.domain.house.service.taste.TasteTagService;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,6 +56,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +70,27 @@ class GenerateImageFacadeTest {
 
     @Mock
     OpenAiFacade openAiFacade;
+
+    @Mock
+    GeminiImageService geminiImageService;
+
+    @Mock
+    PromptService promptService;
+
+    @Mock
+    BannerRepository bannerRepository;
+
+    @Mock
+    FloorPlanRepository floorPlanRepository;
+
+    @Mock
+    CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    FloorPlanImageJsonCodec floorPlanImageJsonCodec;
+
+    @Mock
+    ObjectMapper objectMapper;
 
     @Mock
     HouseService houseService;
@@ -294,5 +333,82 @@ class GenerateImageFacadeTest {
         assertThat(imageInfoResponse.imageUrl()).isEqualTo(imageLink);
         assertThat(imageInfoResponse.houseForm()).isEqualTo(house.getForm().getDescription());
         assertThat(imageInfoResponse.name()).isEqualTo(user.getName());
+    }
+
+    @Test
+    @DisplayName("배너 템플릿 이미지 생성은 saveBannerImageAndConfirmCredit 경로를 호출해 LIST 이미지 저장 플로우를 실행한다")
+    void generateBannerImageByGemini_callsSaveBannerImageAndConfirmCredit() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .name("test_user")
+                .build();
+
+        Credit lockedCredit = Credit.builder()
+                .id(10L)
+                .status(CreditStatus.PENDING)
+                .user(user)
+                .build();
+
+        Banner banner = Banner.builder()
+                .id(100L)
+                .bannerType(BannerType.BANNER)
+                .bannerImageUrl("https://banner-image")
+                .stylePrompt("배너 스타일 프롬프트")
+                .styleAnswerChipsJson("[{\"id\":1}]")
+                .bannerRawProducts(List.of())
+                .build();
+
+        FloorPlan floorPlan = FloorPlan.builder()
+                .id(11L)
+                .url("https://floorplan-image")
+                .floorPlanPrompt("도면 프롬프트")
+                .imagesJson("[]")
+                .build();
+
+        BannerGenerateImageRequest request = new BannerGenerateImageRequest(
+                100L,
+                1L,
+                11L,
+                "TOP",
+                false
+        );
+
+        ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
+                "generated.webp",
+                "generated-original.webp",
+                "https://generated-image",
+                "image/webp"
+        );
+
+        when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
+        when(bannerRepository.findByIdWithRawProducts(100L, BannerType.BANNER, false)).thenReturn(Optional.of(banner));
+        when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
+        when(objectMapper.readValue(eq("[{\"id\":1}]"), any(TypeReference.class)))
+                .thenReturn(List.of(new BannerStyleAnswerChip(1L, 1, "답변", "선택 프롬프트", null)));
+        when(floorPlanImageJsonCodec.read("[]")).thenReturn(List.of());
+        when(geminiImageService.createImageWithReferences(any(), any()))
+                .thenReturn(imageUploadResponseDTO);
+        when(generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                eq(user),
+                eq(lockedCredit),
+                eq(banner),
+                eq(11L),
+                eq(false),
+                any(),
+                eq(imageUploadResponseDTO)
+        )).thenReturn(BannerGenerateImageResponse.of(999L));
+
+        BannerGenerateImageResponse response = generateImageFacade.generateBannerImageByGemini(user, request);
+
+        assertThat(response.imageId()).isEqualTo(999L);
+        verify(generateImageTransactionService).saveBannerImageAndConfirmCredit(
+                eq(user),
+                eq(lockedCredit),
+                eq(banner),
+                eq(11L),
+                eq(false),
+                any(),
+                eq(imageUploadResponseDTO)
+        );
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -24,6 +24,7 @@ import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImagesResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.SimilarItemsResponse;
+import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -88,12 +89,16 @@ class GenerateImageResultServiceImplTest {
         Banner bannerRef = Banner.builder()
                 .id(10L)
                 .build();
+        House house = House.builder()
+                .id(100L)
+                .banner(bannerRef)
+                .build();
 
         GenerateImage listImage = GenerateImage.builder()
                 .id(1L)
                 .url("https://generated-image")
                 .generationType(GenerateImageType.LIST)
-                .banner(bannerRef)
+                .house(house)
                 .build();
 
         CurationRawProduct rawProduct = CurationRawProduct.builder()
@@ -135,10 +140,14 @@ class GenerateImageResultServiceImplTest {
     @DisplayName("유사 상품 조회는 가구타입 우선 후보를 먼저 채우고 최대 4개를 반환한다")
     void getSimilarItems_prioritizesFurnitureTypeAndLimitsToFour() {
         Banner bannerRef = Banner.builder().id(10L).build();
+        House house = House.builder()
+                .id(100L)
+                .banner(bannerRef)
+                .build();
         GenerateImage listImage = GenerateImage.builder()
                 .id(1L)
                 .generationType(GenerateImageType.LIST)
-                .banner(bannerRef)
+                .house(house)
                 .build();
 
         CurationRawProduct selected = CurationRawProduct.builder()
@@ -189,10 +198,14 @@ class GenerateImageResultServiceImplTest {
     @DisplayName("related-images는 LIST 타입 기준으로 현재 이미지를 제외하고 최신순/중복제거 결과를 반환한다")
     void getRelatedImages_returnsLatestDistinctImagesExcludingCurrent() {
         Banner bannerRef = Banner.builder().id(10L).build();
+        House house = House.builder()
+                .id(100L)
+                .banner(bannerRef)
+                .build();
         GenerateImage current = GenerateImage.builder()
                 .id(1L)
                 .generationType(GenerateImageType.LIST)
-                .banner(bannerRef)
+                .house(house)
                 .build();
 
         CurationRawProduct selected = CurationRawProduct.builder()

--- a/src/test/java/or/sopt/houme/domain/house/repository/HouseCustomRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/repository/HouseCustomRepositoryImplTest.java
@@ -4,9 +4,6 @@ import jakarta.persistence.EntityManager;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.global.config.QuerydslConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,9 +51,6 @@ class HouseCustomRepositoryImplTest {
 
         // 🏠 House 생성 및 저장
         mockHouse = House.builder()
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .activity(Activity.READING)
                 .user(mockUser)
                 .isValid(true)

--- a/src/test/java/or/sopt/houme/domain/house/repository/taste/TagRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/repository/taste/TagRepositoryImplTest.java
@@ -4,9 +4,6 @@ import jakarta.persistence.EntityManager;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseTaste;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.house.model.taste.entity.Taste;
@@ -63,9 +60,6 @@ class TagRepositoryImplTest {
 
         // 🏠 집 생성
         mockHouse = House.builder()
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .activity(Activity.READING)
                 .user(mockUser)
                 .isValid(true)

--- a/src/test/java/or/sopt/houme/domain/house/service/HouseServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/HouseServiceImplTest.java
@@ -8,6 +8,9 @@ import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.domain.user.repository.UserRepository;
@@ -42,6 +45,9 @@ class HouseServiceImplTest {
     @Mock
     private HouseRepository houseRepository;
 
+    @Mock
+    private HouseFloorPlanRepository houseFloorPlanRepository;
+
     private User savedUser;
     private House savedHouse;
 
@@ -62,9 +68,6 @@ class HouseServiceImplTest {
 
         savedHouse = House.builder()
                 .id(1L)
-                        .form(Form.OFFICETEL)
-                        .structure(Structure.OPEN_ONE_ROOM)
-                        .equilibrium(Equilibrium.UNDER_5)
                         .isValid(true)
                         .user(savedUser)
                         .build();
@@ -107,7 +110,14 @@ class HouseServiceImplTest {
     @DisplayName("User를 받아서 최근에 입력한 House 조건들을 받을 수 있다.")
     void getHouseOptionsResponse_ShouldReturnValidHouse() {
         // Given
+        FloorPlan floorPlan = FloorPlan.builder()
+                .form(Form.OFFICETEL)
+                .structure(Structure.OPEN_ONE_ROOM)
+                .equilibrium(Equilibrium.UNDER_5)
+                .build();
         when(houseRepository.findLatestHouse(savedUser)).thenReturn(savedHouse);
+        when(houseFloorPlanRepository.findHouseFloorPlanByHouseId(savedHouse.getId()))
+                .thenReturn(Optional.of(HouseFloorPlan.builder().house(savedHouse).floorPlan(floorPlan).isReverse(false).build()));
 
         // When
         LatestHouseConditionDTO latestHouse = houseService.findLatestHouse(savedUser);

--- a/src/test/java/or/sopt/houme/domain/preference/service/PromptPreferenceServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/preference/service/PromptPreferenceServiceImplTest.java
@@ -3,9 +3,6 @@ package or.sopt.houme.domain.preference.service;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.model.entity.House;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.preference.model.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -69,9 +66,6 @@ class PromptPreferenceServiceImplTest {
         User save = userRepository.save(user);
 
         House house = House.builder()
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .isValid(true)
                 .user(save)
                 .build();

--- a/src/test/java/or/sopt/houme/domain/user/repository/UserRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/repository/UserRepositoryImplTest.java
@@ -6,9 +6,6 @@ import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
-import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
-import or.sopt.houme.domain.house.model.entity.enums.Form;
-import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseTaste;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.house.model.taste.entity.Taste;
@@ -106,9 +103,6 @@ class UserRepositoryImplTest {
 
         // 4. House 2개 생성
         House house1 = House.builder()
-                .form(Form.OFFICETEL)
-                .structure(Structure.OPEN_ONE_ROOM)
-                .equilibrium(Equilibrium.UNDER_5)
                 .activity(Activity.REMOTE_WORK)
                 .user(mockUser)
                 .isValid(true)
@@ -116,9 +110,6 @@ class UserRepositoryImplTest {
         em.persist(house1);
 
         House house2 = House.builder()
-                .form(Form.APARTMENT)
-                .structure(Structure.DUPLEX)
-                .equilibrium(Equilibrium.BETWEEN_6_10)
                 .activity(Activity.READING)
                 .user(mockUser)
                 .isValid(true)

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -21,8 +21,12 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImageUsedProduct;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
+import or.sopt.houme.domain.house.model.entity.enums.Structure;
+import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.preference.model.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -61,6 +65,7 @@ class UserServiceImplTest {
 
     private final UserRepository userRepository = mock(UserRepository.class);
     private final HouseRepository houseRepository = mock(HouseRepository.class);
+    private final HouseFloorPlanRepository houseFloorPlanRepository = mock(HouseFloorPlanRepository.class);
     private final TagRepository tagRepository = mock(TagRepository.class);
     private final GenerateImageRepository generateImageRepository = mock(GenerateImageRepository.class);
     private final CreditRepository creditRepository = mock(CreditRepository.class);
@@ -79,6 +84,7 @@ class UserServiceImplTest {
     private final UserServiceImpl userService = new UserServiceImpl(
             userRepository,
             houseRepository,
+            houseFloorPlanRepository,
             tagRepository,
             generateImageRepository,
             creditRepository,
@@ -108,9 +114,8 @@ class UserServiceImplTest {
                 .build();
 
         house = House.builder()
+                .id(20L)
                 .user(user)
-                .form(Form.APARTMENT)
-                .equilibrium(Equilibrium.UNDER_5)
                 .build();
 
         tag = Tag.builder()
@@ -157,6 +162,10 @@ class UserServiceImplTest {
     void getUserImageHistoryList_MultipleGenerateImages_ReturnsFirst() {
         // given
         Long userId = user.getId();
+        FloorPlan floorPlan = FloorPlan.builder()
+                .form(Form.APARTMENT)
+                .equilibrium(Equilibrium.UNDER_5)
+                .build();
 
         given(userRepository.findById(userId))
                 .willReturn(Optional.of(user));
@@ -185,6 +194,8 @@ class UserServiceImplTest {
         // 3. 대표 태그 반환
         given(tagRepository.findMostFrequentTagByHouseId(house.getId()))
                 .willReturn(Optional.ofNullable(tag));
+        given(houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId()))
+                .willReturn(Optional.of(HouseFloorPlan.builder().house(house).floorPlan(floorPlan).isReverse(false).build()));
 
         // when
         UserImageHistoryListResponse response = userService.getUserImageHistoryList(user);
@@ -215,7 +226,10 @@ class UserServiceImplTest {
 
         House house = House.builder()
                 .id(houseId)
+                .build();
+        FloorPlan floorPlan = FloorPlan.builder()
                 .form(Form.OFFICETEL)
+                .structure(Structure.OPEN_ONE_ROOM)
                 .equilibrium(Equilibrium.UNDER_5)
                 .build();
 
@@ -251,6 +265,8 @@ class UserServiceImplTest {
         // generateImages 리스트 2개 반환
         given(generateImageRepository.findGenerateImagesByHouseId(house.getId()))
                 .willReturn(List.of(generateImage1, generateImage2));
+        given(houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId()))
+                .willReturn(Optional.of(HouseFloorPlan.builder().house(house).floorPlan(floorPlan).isReverse(false).build()));
 
         given(generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage1.getId()))
                 .willReturn(Optional.of(generateImagePreference1));
@@ -368,9 +384,6 @@ class UserServiceImplTest {
 
         House houseWithBanner = House.builder()
                 .id(house.getId())
-                .form(house.getForm())
-                .structure(house.getStructure())
-                .equilibrium(house.getEquilibrium())
                 .activity(house.getActivity())
                 .user(user)
                 .banner(banner)

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -366,12 +366,22 @@ class UserServiceImplTest {
                 .build();
         banner.getBannerRawProducts().add(BannerCurationRawProduct.of(banner, bannerRawProduct));
 
+        House houseWithBanner = House.builder()
+                .id(house.getId())
+                .form(house.getForm())
+                .structure(house.getStructure())
+                .equilibrium(house.getEquilibrium())
+                .activity(house.getActivity())
+                .user(user)
+                .banner(banner)
+                .isValid(true)
+                .build();
+
         GenerateImage bannerImage = GenerateImage.builder()
                 .id(201L)
                 .url("https://cdn.com/banner-image.png")
-                .house(house)
+                .house(houseWithBanner)
                 .generationType(GenerateImageType.LIST)
-                .banner(banner)
                 .build();
         ReflectionTestUtils.setField(bannerImage, "createdAt", LocalDateTime.of(2026, 3, 24, 11, 0));
 

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -293,7 +293,7 @@ class UserServiceImplTest {
         // 공통 속성 검증
         response.histories().forEach(history -> {
             assertThat(history.equilibrium()).isEqualTo("5평 이하");
-            assertThat(history.houseForm()).isEqualTo("OFFICETEL");
+            assertThat(history.houseForm()).isEqualTo("오피스텔");
             assertThat(history.tasteTag()).isEqualTo("모던");
             assertThat(history.name()).isEqualTo("테스트유저");
             assertThat(history.isLike()).isTrue();


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #466 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 배너 및 스타일 템플릿 기반 이미지 생성시 house 엔티티는 생성하지 않았지만,
- house 엔티티가 없을 때, 기존에 존재하던 house로 이미지에 접근하던 모든 API에서 배너 기반 이미지에 접근하지 못하는 큰 문제가 있었습니다.
- 그에 따라 배너 및 스타일 템플릿 기반 이미지 생성 API에서 이미지 생성 이전에 house 엔티티를 생성하고 이미지 생성 후 update하여 house 엔티티를 생성하도록 수정헀습니다.
- 또한, generateImage와 banner가 직접 매핑되었지만 이를 삭제하고, house와 banner 엔티티가 매핑되도록 수정했습니다.
- 이는 기존에 house(이미지 생성을 위한 메타데이터 엔티티)와 generateImage(실제 생성된 이미지 엔티티)를 분리하는 설계 관점을 지키기 위한 PR입니다.   

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- floorPlan에서 Form, Structure, Equilibrium을 저장하고 있는데, 현재 house에서도 동일하게 Form Structure Equilibrium 필드를 저장하고 있습니다. 이는 어떻게 통합하는게 좋을까요??
- 제가 최근에 구현한 도면 관련 API에서 도면 필터링에 필요하여 floorPlan으로 이동했는데, house에서 삭제하고 기존 house에서 사용하고 있던 것들을 floorPlan에서 데이터를 가져오도록 API들을 수정하는게 좋을까요?? 의견이 궁금합니다!
@gdbs1107 @PBEM22 

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 이미지 생성 흐름에서 배너 연계를 엔티티 수준으로 하우스에 일원화해 배너 판단과 결과 해석을 일관되게 개선
  * 플로어플랜 기반 조회로 form/structure/equilibrium 정보를 안전하게 해결하여 null-safe 처리 및 저장·조회 로직 안정화
  * 이미지 생성 관련 호출 시 불필요한 배너 인자 제거로 API 호출 흐름 단순화

* **New Features**
  * 플로어플랜(템플릿) 기반 하우스 생성 API 추가로 템플릿 기반 이미지 생성 워크플로우 지원 및 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->