### PR TITLE
[CHORE] 상품 조회 응답에 색상 리스트 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/banner/presentation/controller/BannerController.java
+++ b/src/main/java/or/sopt/houme/domain/banner/presentation/controller/BannerController.java
@@ -9,8 +9,10 @@ import or.sopt.houme.domain.banner.presentation.dto.response.LandingListResponse
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleDetailResponse;
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleListResponse;
 import or.sopt.houme.domain.banner.service.BannerService;
+import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,7 +56,12 @@ public class BannerController {
 
     @GetMapping("/other-styles/{styleId}")
     @Operation(summary = "스타일 디테일 페이지 조회 API")
-    public ResponseEntity<ApiResponse<OtherStyleDetailResponse>> getOtherStyleDetail(@PathVariable Long styleId) {
-        return ResponseEntity.ok(ApiResponse.ok(bannerExploreService.getOtherStyleDetail(styleId)));
+    public ResponseEntity<ApiResponse<OtherStyleDetailResponse>> getOtherStyleDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long styleId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                bannerExploreService.getOtherStyleDetail(userDetails != null ? userDetails.getUser() : null, styleId)
+        ));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/OtherStyleDetailProductResponse.java
+++ b/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/OtherStyleDetailProductResponse.java
@@ -1,6 +1,9 @@
 package or.sopt.houme.domain.banner.presentation.dto.response;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+
+import java.util.List;
 
 public record OtherStyleDetailProductResponse(
         Long id,
@@ -9,10 +12,16 @@ public record OtherStyleDetailProductResponse(
         Long originalPrice,
         Integer discountRate,
         Long finalPrice,
-        String linkUrl
+        String linkUrl,
+        List<ProductColorResponse> colors,
+        boolean isLiked
 ) {
 
-    public static OtherStyleDetailProductResponse from(CurationRawProduct product) {
+    public static OtherStyleDetailProductResponse from(
+            CurationRawProduct product,
+            List<ProductColorResponse> colors,
+            boolean isLiked
+    ) {
         return new OtherStyleDetailProductResponse(
                 product.getId(),
                 product.getProductName(),
@@ -20,7 +29,9 @@ public record OtherStyleDetailProductResponse(
                 product.getListPrice(),
                 product.getDiscountRate(),
                 product.getDiscountPrice(),
-                product.getProductSiteUrl()
+                product.getProductSiteUrl(),
+                colors,
+                isLiked
         );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/banner/service/BannerService.java
+++ b/src/main/java/or/sopt/houme/domain/banner/service/BannerService.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.banner.presentation.dto.response.BannerExploreListRe
 import or.sopt.houme.domain.banner.presentation.dto.response.LandingListResponse;
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleDetailResponse;
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleListResponse;
+import or.sopt.houme.domain.user.model.entity.User;
 
 public interface BannerService {
     LandingListResponse getLandings();
@@ -15,5 +16,5 @@ public interface BannerService {
 
     OtherStyleListResponse getOtherStyles(Integer size);
 
-    OtherStyleDetailResponse getOtherStyleDetail(Long styleId);
+    OtherStyleDetailResponse getOtherStyleDetail(User user, Long styleId);
 }

--- a/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
@@ -18,7 +18,17 @@ import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleDetailPro
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleDetailResponse;
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleListResponse;
 import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleResponse;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.Jjym;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 import or.sopt.houme.global.api.handler.BannerException;
@@ -26,7 +36,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +51,9 @@ public class BannerServiceImpl implements BannerService {
     private static final TypeReference<List<BannerStyleAnswerChip>> STYLE_ANSWER_CHIP_TYPE = new TypeReference<>() {};
 
     private final BannerRepository bannerRepository;
+    private final CurationRawProductColorRepository curationRawProductColorRepository;
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+    private final JjymRepository jjymRepository;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -101,15 +119,24 @@ public class BannerServiceImpl implements BannerService {
     }
 
     @Override
-    public OtherStyleDetailResponse getOtherStyleDetail(Long styleId) {
+    public OtherStyleDetailResponse getOtherStyleDetail(User user, Long styleId) {
         Banner style = bannerRepository.findByIdWithRawProducts(styleId, BannerType.STYLE, false)
                 .orElseThrow(() -> new BannerException(ErrorCode.NOT_FOUND_STYLE));
 
-        List<OtherStyleDetailProductResponse> products = style.getBannerRawProducts().stream()
+        List<CurationRawProduct> rawProducts = style.getBannerRawProducts().stream()
                 .sorted((left, right) -> Long.compare(safeMappingId(left), safeMappingId(right)))
                 .map(BannerCurationRawProduct::getCurationRawProduct)
                 .filter(java.util.Objects::nonNull)
-                .map(OtherStyleDetailProductResponse::from)
+                .toList();
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = buildColorsByRawProductId(rawProducts);
+        Set<Long> likedRawProductIds = resolveLikedRawProductIds(user, rawProducts);
+
+        List<OtherStyleDetailProductResponse> products = rawProducts.stream()
+                .map(rawProduct -> OtherStyleDetailProductResponse.from(
+                        rawProduct,
+                        colorsByRawProductId.getOrDefault(rawProduct.getId(), List.of()),
+                        likedRawProductIds.contains(rawProduct.getId())
+                ))
                 .toList();
 
         return OtherStyleDetailResponse.of(
@@ -151,5 +178,98 @@ public class BannerServiceImpl implements BannerService {
             return Long.MAX_VALUE;
         }
         return mapping.getId();
+    }
+
+    private Map<Long, List<ProductColorResponse>> buildColorsByRawProductId(List<CurationRawProduct> rawProducts) {
+        List<Long> rawProductIds = rawProducts.stream()
+                .map(CurationRawProduct::getId)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (rawProductIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, LinkedHashSet<String>> colorSetByRawProductId = new LinkedHashMap<>();
+        for (CurationRawProductColor color : curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds)) {
+            Long rawProductId = color.getCurationRawProduct().getId();
+            String colorName = resolveColorName(color);
+            if (colorName == null) {
+                continue;
+            }
+            colorSetByRawProductId.computeIfAbsent(rawProductId, ignored -> new LinkedHashSet<>())
+                    .add(colorName);
+        }
+
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = new LinkedHashMap<>();
+        for (Map.Entry<Long, LinkedHashSet<String>> entry : colorSetByRawProductId.entrySet()) {
+            List<ProductColorResponse> colors = entry.getValue().stream()
+                    .map(ProductColorResponse::fromName)
+                    .toList();
+            colorsByRawProductId.put(entry.getKey(), colors);
+        }
+        return colorsByRawProductId;
+    }
+
+    private Set<Long> resolveLikedRawProductIds(User user, List<CurationRawProduct> rawProducts) {
+        if (user == null || rawProducts.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Long> productIds = rawProducts.stream()
+                .map(CurationRawProduct::getProductId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (productIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<Long, CurationRawProduct> rawProductByProductId = rawProducts.stream()
+                .filter(rawProduct -> rawProduct.getProductId() != null)
+                .collect(Collectors.toMap(
+                        CurationRawProduct::getProductId,
+                        rawProduct -> rawProduct,
+                        (left, right) -> left
+                ));
+
+        Map<Long, Long> recommendFurnitureIdByProductId = recommendFurnitureRepository
+                .findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, productIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        RecommendFurniture::getFurnitureProductId,
+                        RecommendFurniture::getId,
+                        (left, right) -> left
+                ));
+
+        List<Long> recommendFurnitureIds = recommendFurnitureIdByProductId.values().stream().distinct().toList();
+        if (recommendFurnitureIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<Long> likedRecommendFurnitureIds = jjymRepository
+                .findAllByUserIdAndRecommendFurnitureIdIn(user.getId(), recommendFurnitureIds)
+                .stream()
+                .map(Jjym::getRecommendFurniture)
+                .filter(java.util.Objects::nonNull)
+                .map(RecommendFurniture::getId)
+                .collect(Collectors.toSet());
+
+        return recommendFurnitureIdByProductId.entrySet().stream()
+                .filter(entry -> likedRecommendFurnitureIds.contains(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .map(rawProductByProductId::get)
+                .filter(java.util.Objects::nonNull)
+                .map(CurationRawProduct::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private String resolveColorName(CurationRawProductColor color) {
+        if (color.getClientColorName() != null && !color.getClientColorName().isBlank()) {
+            return color.getClientColorName();
+        }
+        if (color.getRawColorName() != null && !color.getRawColorName().isBlank()) {
+            return color.getRawColorName();
+        }
+        return null;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ProductColorResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ProductColorResponse.java
@@ -1,0 +1,19 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.service.ColorHexMapper;
+
+import java.util.List;
+
+public record ProductColorResponse(
+        String name,
+        String value
+) {
+    public static ProductColorResponse fromName(String colorName) {
+        String hexValue = null;
+        List<String> mapped = ColorHexMapper.toHexCodes(List.of(colorName));
+        if (!mapped.isEmpty() && mapped.getFirst() != null && mapped.getFirst().startsWith("#")) {
+            hexValue = mapped.getFirst();
+        }
+        return new ProductColorResponse(colorName, hexValue);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GenerateImageResultProductResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GenerateImageResultProductResponse.java
@@ -1,6 +1,9 @@
 package or.sopt.houme.domain.generateImageResult.presentation.dto.response;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+
+import java.util.List;
 
 public record GenerateImageResultProductResponse(
         Long id,
@@ -9,10 +12,16 @@ public record GenerateImageResultProductResponse(
         Long originalPrice,
         Integer discountRate,
         Long finalPrice,
-        String linkUrl
+        String linkUrl,
+        List<ProductColorResponse> colors,
+        boolean isLiked
 ) {
 
-    public static GenerateImageResultProductResponse from(CurationRawProduct product) {
+    public static GenerateImageResultProductResponse from(
+            CurationRawProduct product,
+            List<ProductColorResponse> colors,
+            boolean isLiked
+    ) {
         return new GenerateImageResultProductResponse(
                 product.getId(),
                 product.getProductName(),
@@ -20,7 +29,9 @@ public record GenerateImageResultProductResponse(
                 product.getListPrice(),
                 product.getDiscountRate(),
                 product.getDiscountPrice(),
-                product.getProductSiteUrl()
+                product.getProductSiteUrl(),
+                colors,
+                isLiked
         );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/SimilarItemResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/SimilarItemResponse.java
@@ -1,6 +1,9 @@
 package or.sopt.houme.domain.generateImageResult.presentation.dto.response;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+
+import java.util.List;
 
 public record SimilarItemResponse(
         Long id,
@@ -10,10 +13,16 @@ public record SimilarItemResponse(
         Long originalPrice,
         Integer discountRate,
         Long finalPrice,
-        String linkUrl
+        String linkUrl,
+        List<ProductColorResponse> colors,
+        boolean isLiked
 ) {
 
-    public static SimilarItemResponse from(CurationRawProduct product) {
+    public static SimilarItemResponse from(
+            CurationRawProduct product,
+            List<ProductColorResponse> colors,
+            boolean isLiked
+    ) {
         return new SimilarItemResponse(
                 product.getId(),
                 product.getBrand(),
@@ -22,7 +31,9 @@ public record SimilarItemResponse(
                 product.getListPrice(),
                 product.getDiscountRate(),
                 product.getDiscountPrice(),
-                product.getProductSiteUrl()
+                product.getProductSiteUrl(),
+                colors,
+                isLiked
         );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -5,9 +5,17 @@ import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
+import or.sopt.houme.domain.furniture.model.entity.Jjym;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageUsedProduct;
@@ -35,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,8 +54,11 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
     private final GenerateImageRepository generateImageRepository;
     private final BannerRepository bannerRepository;
     private final GenerateImageUsedProductRepository generateImageUsedProductRepository;
+    private final CurationRawProductColorRepository curationRawProductColorRepository;
     private final CurationRawProductRepository curationRawProductRepository;
     private final CurationRawProductFurnitureTagRepository curationRawProductFurnitureTagRepository;
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+    private final JjymRepository jjymRepository;
     private final HouseService houseService;
 
     private static final int RELATED_IMAGE_LIMIT = 10;
@@ -63,8 +75,16 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
         }
 
         boolean isMirror = resolveIsMirror(generateImage);
-        List<GenerateImageResultProductResponse> products = resolveSelectedRawProducts(generateImage).stream()
-                .map(GenerateImageResultProductResponse::from)
+        List<CurationRawProduct> selectedProducts = resolveSelectedRawProducts(generateImage);
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = buildColorsByRawProductId(selectedProducts);
+        Set<Long> likedRawProductIds = resolveLikedRawProductIds(user, selectedProducts);
+
+        List<GenerateImageResultProductResponse> products = selectedProducts.stream()
+                .map(rawProduct -> GenerateImageResultProductResponse.from(
+                        rawProduct,
+                        colorsByRawProductId.getOrDefault(rawProduct.getId(), List.of()),
+                        likedRawProductIds.contains(rawProduct.getId())
+                ))
                 .toList();
 
         return GenerateImageResultResponse.of(
@@ -134,8 +154,15 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
                 selectedRawProductIds
         );
 
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = buildColorsByRawProductId(recommendedProducts);
+        Set<Long> likedRawProductIds = resolveLikedRawProductIds(user, recommendedProducts);
+
         return SimilarItemsResponse.of(recommendedProducts.stream()
-                .map(SimilarItemResponse::from)
+                .map(rawProduct -> SimilarItemResponse.from(
+                        rawProduct,
+                        colorsByRawProductId.getOrDefault(rawProduct.getId(), List.of()),
+                        likedRawProductIds.contains(rawProduct.getId())
+                ))
                 .toList());
     }
 
@@ -297,5 +324,98 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
             return Long.MAX_VALUE;
         }
         return mapping.getId();
+    }
+
+    private Map<Long, List<ProductColorResponse>> buildColorsByRawProductId(List<CurationRawProduct> rawProducts) {
+        List<Long> rawProductIds = rawProducts.stream()
+                .map(CurationRawProduct::getId)
+                .filter(Objects::nonNull)
+                .toList();
+        if (rawProductIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, LinkedHashSet<String>> colorSetByRawProductId = new LinkedHashMap<>();
+        for (CurationRawProductColor color : curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds)) {
+            Long rawProductId = color.getCurationRawProduct().getId();
+            String colorName = resolveColorName(color);
+            if (colorName == null) {
+                continue;
+            }
+            colorSetByRawProductId.computeIfAbsent(rawProductId, ignored -> new LinkedHashSet<>())
+                    .add(colorName);
+        }
+
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = new LinkedHashMap<>();
+        for (Map.Entry<Long, LinkedHashSet<String>> entry : colorSetByRawProductId.entrySet()) {
+            List<ProductColorResponse> colors = entry.getValue().stream()
+                    .map(ProductColorResponse::fromName)
+                    .toList();
+            colorsByRawProductId.put(entry.getKey(), colors);
+        }
+        return colorsByRawProductId;
+    }
+
+    private String resolveColorName(CurationRawProductColor color) {
+        if (color.getClientColorName() != null && !color.getClientColorName().isBlank()) {
+            return color.getClientColorName();
+        }
+        if (color.getRawColorName() != null && !color.getRawColorName().isBlank()) {
+            return color.getRawColorName();
+        }
+        return null;
+    }
+
+    private Set<Long> resolveLikedRawProductIds(User user, List<CurationRawProduct> rawProducts) {
+        if (user == null || rawProducts.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Long> productIds = rawProducts.stream()
+                .map(CurationRawProduct::getProductId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (productIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<Long, CurationRawProduct> rawProductByProductId = rawProducts.stream()
+                .filter(rawProduct -> rawProduct.getProductId() != null)
+                .collect(Collectors.toMap(
+                        CurationRawProduct::getProductId,
+                        rawProduct -> rawProduct,
+                        (left, right) -> left
+                ));
+
+        Map<Long, Long> recommendFurnitureIdByProductId = recommendFurnitureRepository
+                .findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, productIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        RecommendFurniture::getFurnitureProductId,
+                        RecommendFurniture::getId,
+                        (left, right) -> left
+                ));
+
+        List<Long> recommendFurnitureIds = recommendFurnitureIdByProductId.values().stream().distinct().toList();
+        if (recommendFurnitureIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<Long> likedRecommendFurnitureIds = jjymRepository
+                .findAllByUserIdAndRecommendFurnitureIdIn(user.getId(), recommendFurnitureIds)
+                .stream()
+                .map(Jjym::getRecommendFurniture)
+                .filter(Objects::nonNull)
+                .map(RecommendFurniture::getId)
+                .collect(Collectors.toSet());
+
+        return recommendFurnitureIdByProductId.entrySet().stream()
+                .filter(entry -> likedRecommendFurnitureIds.contains(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .map(rawProductByProductId::get)
+                .filter(Objects::nonNull)
+                .map(CurationRawProduct::getId)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
@@ -8,11 +8,21 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
 import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.banner.presentation.dto.response.LandingListResponse;
+import or.sopt.houme.domain.banner.presentation.dto.response.OtherStyleDetailResponse;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -25,6 +35,15 @@ class BannerServiceImplTest {
 
     @Mock
     private BannerRepository bannerRepository;
+
+    @Mock
+    private CurationRawProductColorRepository curationRawProductColorRepository;
+
+    @Mock
+    private RecommendFurnitureRepository recommendFurnitureRepository;
+
+    @Mock
+    private JjymRepository jjymRepository;
 
     @Mock
     private ObjectMapper objectMapper;
@@ -49,5 +68,60 @@ class BannerServiceImplTest {
         assertThat(response.landings()).hasSize(1);
         assertThat(response.landings().getFirst().name()).isEqualTo("랜딩 제목");
         assertThat(response.landings().getFirst().imageUrl()).isEqualTo("https://landing-image");
+    }
+
+    @Test
+    @DisplayName("getOtherStyleDetail()는 스타일 상품의 색상 목록을 함께 반환한다")
+    void getOtherStyleDetail_includesProductColors() {
+        CurationRawProduct rawProduct = CurationRawProduct.builder()
+                .id(100L)
+                .productId(1000L)
+                .productName("스타일 상품")
+                .productImageUrl("https://image")
+                .listPrice(10000L)
+                .discountRate(10)
+                .discountPrice(9000L)
+                .productSiteUrl("https://link")
+                .build();
+
+        Banner style = Banner.builder()
+                .id(1L)
+                .bannerType(BannerType.STYLE)
+                .bannerTitle("모던 스타일")
+                .bannerImageUrl("https://style")
+                .styleDescription("스타일 설명")
+                .bannerRawProducts(new java.util.ArrayList<>())
+                .build();
+        style.getBannerRawProducts().add(BannerCurationRawProduct.of(style, rawProduct));
+
+        when(bannerRepository.findByIdWithRawProducts(1L, BannerType.STYLE, false)).thenReturn(Optional.of(style));
+        when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(100L)))
+                .thenReturn(List.of(
+                        CurationRawProductColor.builder()
+                                .id(1L)
+                                .curationRawProduct(rawProduct)
+                                .clientColorName("화이트")
+                                .build(),
+                        CurationRawProductColor.builder()
+                                .id(2L)
+                                .curationRawProduct(rawProduct)
+                                .rawColorName("우드")
+                                .build()
+                ));
+        when(recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, List.of(1000L)))
+                .thenReturn(List.of(RecommendFurniture.builder()
+                        .id(1L)
+                        .source(CurationSource.RAW)
+                        .furnitureProductId(1000L)
+                        .build()));
+        when(jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(1L, List.of(1L))).thenReturn(List.of());
+
+        or.sopt.houme.domain.user.model.entity.User user = or.sopt.houme.domain.user.model.entity.User.builder().id(1L).build();
+        OtherStyleDetailResponse response = bannerService.getOtherStyleDetail(user, 1L);
+
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().getFirst().colors()).extracting("name").containsExactly("화이트", "우드");
+        assertThat(response.products().getFirst().colors()).extracting("value").containsExactly("#FFFFFF", "#A67B5B");
+        assertThat(response.products().getFirst().isLiked()).isFalse();
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -10,12 +10,18 @@ import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
@@ -57,10 +63,19 @@ class GenerateImageResultServiceImplTest {
     private GenerateImageUsedProductRepository generateImageUsedProductRepository;
 
     @Mock
+    private CurationRawProductColorRepository curationRawProductColorRepository;
+
+    @Mock
     private CurationRawProductRepository curationRawProductRepository;
 
     @Mock
     private CurationRawProductFurnitureTagRepository curationRawProductFurnitureTagRepository;
+
+    @Mock
+    private RecommendFurnitureRepository recommendFurnitureRepository;
+
+    @Mock
+    private JjymRepository jjymRepository;
 
     @Mock
     private HouseService houseService;
@@ -88,7 +103,6 @@ class GenerateImageResultServiceImplTest {
         Banner bannerRef = Banner.builder()
                 .id(10L)
                 .build();
-
         GenerateImage listImage = GenerateImage.builder()
                 .id(1L)
                 .url("https://generated-image")
@@ -98,6 +112,7 @@ class GenerateImageResultServiceImplTest {
 
         CurationRawProduct rawProduct = CurationRawProduct.builder()
                 .id(101L)
+                .productId(1001L)
                 .productName("테스트 상품")
                 .productImageUrl("https://product-image")
                 .listPrice(39900L)
@@ -118,8 +133,28 @@ class GenerateImageResultServiceImplTest {
 
         when(generateImageService.findGenerateImage(1L)).thenReturn(listImage);
         when(bannerRepository.findAllByIdInWithRawProducts(List.of(10L))).thenReturn(List.of(bannerWithRawProducts));
+        when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(101L)))
+                .thenReturn(List.of(
+                        CurationRawProductColor.builder()
+                                .id(1L)
+                                .curationRawProduct(rawProduct)
+                                .clientColorName("화이트")
+                                .build(),
+                        CurationRawProductColor.builder()
+                                .id(2L)
+                                .curationRawProduct(rawProduct)
+                                .rawColorName("아이보리")
+                                .build()
+                ));
+        when(recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, List.of(1001L)))
+                .thenReturn(List.of(RecommendFurniture.builder()
+                        .id(501L)
+                        .source(CurationSource.RAW)
+                        .furnitureProductId(1001L)
+                        .build()));
+        when(jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(1L, List.of(501L))).thenReturn(List.of());
 
-        User user = mock(User.class);
+        User user = User.builder().id(1L).build();
 
         GenerateImageResultResponse response = generateImageResultService.getListResultItems(user, 1L);
 
@@ -129,6 +164,9 @@ class GenerateImageResultServiceImplTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().getFirst().id()).isEqualTo(101L);
         assertThat(response.products().getFirst().name()).isEqualTo("테스트 상품");
+        assertThat(response.products().getFirst().colors()).extracting("name").containsExactly("화이트", "아이보리");
+        assertThat(response.products().getFirst().colors()).extracting("value").containsExactly("#FFFFFF", "#FFF8E1");
+        assertThat(response.products().getFirst().isLiked()).isFalse();
     }
 
     @Test
@@ -143,6 +181,7 @@ class GenerateImageResultServiceImplTest {
 
         CurationRawProduct selected = CurationRawProduct.builder()
                 .id(101L)
+                .productId(1001L)
                 .brand("선택브랜드")
                 .productName("선택 상품")
                 .build();
@@ -165,10 +204,10 @@ class GenerateImageResultServiceImplTest {
                 .furnitureTag(furnitureTag)
                 .build();
 
-        CurationRawProduct c1 = CurationRawProduct.builder().id(201L).productName("furniture-type-1").build();
-        CurationRawProduct c2 = CurationRawProduct.builder().id(202L).productName("furniture-type-2").build();
-        CurationRawProduct c3 = CurationRawProduct.builder().id(203L).productName("furniture-type-3").build();
-        CurationRawProduct c4 = CurationRawProduct.builder().id(204L).productName("furniture-type-4").build();
+        CurationRawProduct c1 = CurationRawProduct.builder().id(201L).productId(2001L).productName("furniture-type-1").build();
+        CurationRawProduct c2 = CurationRawProduct.builder().id(202L).productId(2002L).productName("furniture-type-2").build();
+        CurationRawProduct c3 = CurationRawProduct.builder().id(203L).productId(2003L).productName("furniture-type-3").build();
+        CurationRawProduct c4 = CurationRawProduct.builder().id(204L).productId(2004L).productName("furniture-type-4").build();
 
         when(generateImageService.findGenerateImage(1L)).thenReturn(listImage);
         when(bannerRepository.findAllByIdInWithRawProducts(List.of(10L))).thenReturn(List.of(bannerWithRawProducts));
@@ -176,13 +215,38 @@ class GenerateImageResultServiceImplTest {
                 .thenReturn(List.of(selectedProductMapping));
         when(curationRawProductRepository.findAllSimilarByFurnitureTypeIds(eq(List.of(1L)), eq(List.of(101L)), any()))
                 .thenReturn(List.of(c1, c2, c3, c4));
+        when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(201L, 202L, 203L, 204L)))
+                .thenReturn(List.of(
+                        CurationRawProductColor.builder()
+                                .id(11L)
+                                .curationRawProduct(c1)
+                                .clientColorName("오크")
+                                .build(),
+                        CurationRawProductColor.builder()
+                                .id(12L)
+                                .curationRawProduct(c2)
+                                .rawColorName("블랙")
+                                .build()
+                ));
+        when(recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, List.of(2001L, 2002L, 2003L, 2004L)))
+                .thenReturn(List.of(
+                        RecommendFurniture.builder().id(701L).source(CurationSource.RAW).furnitureProductId(2001L).build(),
+                        RecommendFurniture.builder().id(702L).source(CurationSource.RAW).furnitureProductId(2002L).build(),
+                        RecommendFurniture.builder().id(703L).source(CurationSource.RAW).furnitureProductId(2003L).build(),
+                        RecommendFurniture.builder().id(704L).source(CurationSource.RAW).furnitureProductId(2004L).build()
+                ));
+        when(jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(1L, List.of(701L, 702L, 703L, 704L))).thenReturn(List.of());
 
-        User user = mock(User.class);
+        User user = User.builder().id(1L).build();
         SimilarItemsResponse response = generateImageResultService.getSimilarItems(user, 1L);
 
         assertThat(response.products()).hasSize(4);
         assertThat(response.products().get(0).id()).isEqualTo(201L);
         assertThat(response.products().get(3).id()).isEqualTo(204L);
+        assertThat(response.products().get(0).colors()).extracting("name").containsExactly("오크");
+        assertThat(response.products().get(1).colors()).extracting("name").containsExactly("블랙");
+        assertThat(response.products().get(2).colors()).isEmpty();
+        assertThat(response.products().get(0).isLiked()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #483 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 스타일 디테일 페이지 조회시 상품의 색상 리스트 응답을 추가했습니다.
- 목록형 결과 페이지 조회시 선택한 상품 & 스타일과 비슷한 상품 응답에 색상 리스트 응답을 추가했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재 로직으로는 generateImage에서 banner를 매핑하고 있어, PR #482 가 병합되면 house에서 banner를 매핑하여 조회하도록 수정하겠습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 응답에 색상 목록 표시 추가
  * 상품별 사용자 좋아요(isLiked) 상태 노출 추가
  * 인증된 사용자 컨텍스트 전달로 개인화된 응답 지원

* **테스트**
  * 색상 및 좋아요 상태를 검증하는 단위 테스트 추가 및 기존 테스트 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->