### PR TITLE
[FEATURE] 1,3번 이미지 생성 퍼널에서 주요활동 및 가구 전체 조회 API

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
@@ -16,9 +16,6 @@ import or.sopt.houme.domain.house.model.entity.enums.Activity;
                         name = "uk_activity_furnitures_activity_furniture",
                         columnNames = {"activity", "furniture_id"}
                 )
-        },
-        indexes = {
-                @Index(name = "idx_activity_furnitures_activity_priority", columnList = "activity, priority")
         }
 )
 public class ActivityFurniture {

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
@@ -1,0 +1,39 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.sopt.houme.domain.house.model.entity.enums.Activity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "activity_furnitures",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_activity_furnitures_activity_furniture",
+                        columnNames = {"activity", "furniture_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_activity_furnitures_activity_priority", columnList = "activity, priority")
+        }
+)
+public class ActivityFurniture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "furniture_id", nullable = false)
+    private Furniture furniture;
+
+    @Column(name = "priority", nullable = false)
+    private int priority;
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/Furniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/Furniture.java
@@ -45,6 +45,10 @@ public class Furniture {
     @Column(name = "object365_word", nullable = true)
     private String object365Word;
 
+    // 대시보드 가구 노출 우선순위
+    @Column(name = "priority")
+    private Integer priority;
+
     public void setFurnitureTags(List<FurnitureTag> furnitureTags) {
         this.furnitureTags = furnitureTags;
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/FurnitureType.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/FurnitureType.java
@@ -25,6 +25,9 @@ public class FurnitureType {
     @Column(name = "is_required")
     private Boolean isRequired;
 
+    @Column(name = "priority")
+    private Integer priority;
+
     public void updateFurnitureType(String nameKr, String nameEng) {
         if (nameKr != null && !nameKr.isBlank()){
             this.nameKr = nameKr;

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
@@ -3,6 +3,8 @@ package or.sopt.houme.domain.furniture.presentation.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityFurnitureMappingsResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
@@ -17,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class FurnitureController {
 
@@ -36,12 +38,20 @@ public class FurnitureController {
                     "    - 식탁, 의자\n" +
                     "    - 옷장\n" +
                     "    - 소파")
-    @GetMapping("/dashboard-info")
+    @GetMapping("/v1/dashboard-info")
     public ResponseEntity<ApiResponse<FurnitureAndActivityResponse>> getFurnitureAndActivity() {
 
         FurnitureAndActivityResponse furnitureAndActivity = furnitureService.getFurnitureAndActivity();
 
         return ResponseEntity.ok(ApiResponse.ok(furnitureAndActivity));
+    }
+
+    @Operation(summary = "주요활동별 매핑 가구 조회 API",
+            description = "주요활동 선택 UI에서 사용할 활동별 가구 매핑 목록을 조회합니다.")
+    @GetMapping("/v2/dashboard/activities")
+    public ResponseEntity<ApiResponse<ActivityFurnitureMappingsResponse>> getActivityFurnitureMappings() {
+        List<ActivityWithFurnitureResponse> activities = furnitureService.getActivityFurnitureMappings();
+        return ResponseEntity.ok(ApiResponse.ok(ActivityFurnitureMappingsResponse.of(activities)));
     }
 
     @Operation(summary = "생성된 이미지에서 가구 카테고리 조회 API",
@@ -60,7 +70,7 @@ public class FurnitureController {
                     "- 책 선반 : WHITE_BOOKSHELF\n" +
                     "- 장식장 : DISPLAY_CABINET\n" +
                     "- 2인용 소파 : TWO_SEATER_SOFA")
-    @GetMapping("/generated-images/{imageId}/curations/categories")
+    @GetMapping("/v1/generated-images/{imageId}/curations/categories")
     public ResponseEntity<ApiResponse<FurnitureCategoriesResponse>> getFurnitureCategories(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @RequestParam List<String> detectedObjects) {
         FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyle(userDetails.getUser(), imageId, detectedObjects);
 
@@ -69,7 +79,7 @@ public class FurnitureController {
 
     @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
             description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다.")
-    @GetMapping("/generated-images/{imageId}/curations/products/{categoryId}")
+    @GetMapping("/v1/generated-images/{imageId}/curations/products/{categoryId}")
     public ResponseEntity<ApiResponse<FurnitureProductsInfoResponse>> getFurnitureProductInfoFromNaverApi(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @PathVariable Long categoryId) {
         FurnitureProductsInfoResponse response = furnitureFacade.getFurnitureProductInfoFromNaverApi(userDetails.getUser(), imageId, categoryId);
 
@@ -82,7 +92,7 @@ public class FurnitureController {
                     "- searchKeyword로 검색어를 커스텀할 수 있습니다.\n" +
                     "- pHash(0~100)사이값을 입력하여, pHash와 colorHash의 비율을 커스텀할 수 있습니다.\n" +
                     "  - colorHash는 100-pHash로 산정됩니다.")
-    @GetMapping("/generated-images/{tagId}/curations/products/{furnitureId}/for-plan")
+    @GetMapping("/v1/generated-images/{tagId}/curations/products/{furnitureId}/for-plan")
     public ResponseEntity<ApiResponse<FurnitureProductsInfoResponseForPlan>> getFurnitureProductInfoFromNaverApiForPlan(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long tagId,
@@ -106,7 +116,7 @@ public class FurnitureController {
                     "- searchKeyword로 검색어를 커스텀할 수 있습니다.\n" +
                     "- pHash(0~100)사이값을 입력하여, pHash와 colorHash의 비율을 커스텀할 수 있습니다.\n" +
                     "- V2: mallName/네이버페이 필터 파라미터 적용 (allowedMalls는 서버 프로퍼티 사용, payFilter는 빈 값)" )
-    @GetMapping("/generated-images/{tagId}/curations/products/{furnitureId}/for-plan/detail")
+    @GetMapping("/v1/generated-images/{tagId}/curations/products/{furnitureId}/for-plan/detail")
     public ResponseEntity<ApiResponse<FurnitureProductsInfoResponseForPlan>> getFurnitureProductInfoFromNaverApiForPlanV2(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long tagId,
@@ -129,4 +139,3 @@ public class FurnitureController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }
-

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityFurnitureMappingsResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.DashboardCategoriesResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
@@ -49,9 +50,22 @@ public class FurnitureController {
     @Operation(summary = "주요활동별 매핑 가구 조회 API",
             description = "주요활동 선택 UI에서 사용할 활동별 가구 매핑 목록을 조회합니다.")
     @GetMapping("/v2/dashboard/activities")
-    public ResponseEntity<ApiResponse<ActivityFurnitureMappingsResponse>> getActivityFurnitureMappings() {
+    public ResponseEntity<ApiResponse<ActivityFurnitureMappingsResponse>> getActivityFurnitureMappings(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         List<ActivityWithFurnitureResponse> activities = furnitureService.getActivityFurnitureMappings();
         return ResponseEntity.ok(ApiResponse.ok(ActivityFurnitureMappingsResponse.of(activities)));
+    }
+
+    @Operation(summary = "대시보드 가구 카테고리 조회 API",
+            description = "대시보드에서 사용할 가구 카테고리 목록을 조회합니다.")
+    @GetMapping("/v2/dashboard/categories")
+    public ResponseEntity<ApiResponse<DashboardCategoriesResponse>> getDashboardCategories(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                DashboardCategoriesResponse.of(furnitureService.getDashboardCategories())
+        ));
     }
 
     @Operation(summary = "생성된 이미지에서 가구 카테고리 조회 API",

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/FurnitureItem.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/FurnitureItem.java
@@ -14,6 +14,10 @@ public record FurnitureItem(
     private static final Set<String> REMOVABLE_CATEGORIES = Set.of("침대", "소파");
 
     public static FurnitureItem from(Furniture furniture) {
+        return from(furniture, furniture.getPriority());
+    }
+
+    public static FurnitureItem from(Furniture furniture, Integer priority) {
         String categoryName = furniture.getFurnitureType().getNameKr();
         String rawLabel = furniture.getFurnitureNameKr();
 
@@ -27,7 +31,7 @@ public record FurnitureItem(
                 furniture.getId(),
                 furniture.getFurnitureNameEng(),
                 cleanLabel,
-                furniture.getPriority()
+                priority
         );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/FurnitureItem.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/FurnitureItem.java
@@ -7,7 +7,8 @@ import java.util.Set;
 public record FurnitureItem(
         Long id,
         String code,
-        String label
+        String label,
+        Integer priority
 ) {
     // 이름에서 제거할 카테고리 목록 ("~~ 침대", "~~ 소파")
     private static final Set<String> REMOVABLE_CATEGORIES = Set.of("침대", "소파");
@@ -25,7 +26,8 @@ public record FurnitureItem(
         return new FurnitureItem(
                 furniture.getId(),
                 furniture.getFurnitureNameEng(),
-                cleanLabel
+                cleanLabel,
+                furniture.getPriority()
         );
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ActivityFurnitureMappingsResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ActivityFurnitureMappingsResponse.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import java.util.List;
+
+public record ActivityFurnitureMappingsResponse(
+        List<ActivityWithFurnitureResponse> activities
+) {
+    public static ActivityFurnitureMappingsResponse of(List<ActivityWithFurnitureResponse> activities) {
+        return new ActivityFurnitureMappingsResponse(activities);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ActivityWithFurnitureResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/ActivityWithFurnitureResponse.java
@@ -1,0 +1,16 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.presentation.dto.FurnitureItem;
+import or.sopt.houme.domain.house.model.entity.enums.Activity;
+
+import java.util.List;
+
+public record ActivityWithFurnitureResponse(
+        String code,
+        String label,
+        List<FurnitureItem> furnitures
+) {
+    public static ActivityWithFurnitureResponse of(Activity activity, List<FurnitureItem> furnitures) {
+        return new ActivityWithFurnitureResponse(activity.name(), activity.getDescription(), furnitures);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/DashboardCategoriesResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/DashboardCategoriesResponse.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import java.util.List;
+
+public record DashboardCategoriesResponse(
+        List<FurnitureCategoryGroup> categories
+) {
+    public static DashboardCategoriesResponse of(List<FurnitureCategoryGroup> categories) {
+        return new DashboardCategoriesResponse(categories);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/ActivityFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/ActivityFurnitureRepository.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ActivityFurnitureRepository extends JpaRepository<ActivityFurniture, Long> {
+
+    @EntityGraph(attributePaths = {"furniture", "furniture.furnitureType"})
+    List<ActivityFurniture> findAllByOrderByPriorityAscIdAsc();
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.furniture.service;
 
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -12,6 +13,9 @@ public interface FurnitureService {
 
     // 주요활동, 가구들 제공
     FurnitureAndActivityResponse getFurnitureAndActivity();
+
+    // 주요활동별 매핑 가구 제공
+    List<ActivityWithFurnitureResponse> getActivityFurnitureMappings();
 
     FurnitureCategoriesResponse getFurnitureCategoriesByStyle(User user, Long imageId, List<String> detectedObjects);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.furniture.service;
 
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoryGroup;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -16,6 +17,9 @@ public interface FurnitureService {
 
     // 주요활동별 매핑 가구 제공
     List<ActivityWithFurnitureResponse> getActivityFurnitureMappings();
+
+    // 대시보드 카테고리 제공
+    List<FurnitureCategoryGroup> getDashboardCategories();
 
     FurnitureCategoriesResponse getFurnitureCategoriesByStyle(User user, Long imageId, List<String> detectedObjects);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -93,23 +93,20 @@ public class FurnitureServiceImpl implements FurnitureService {
                         )
                 ));
 
-        Map<Long, Integer> furnitureTypePriorityById = furnitureTypes.stream()
-                .collect(Collectors.toMap(FurnitureType::getId, FurnitureType::getPriority));
-
         // 각 FurnitureType에 해당하는 FurnitureGroup 생성
         return furnitureTypes.stream()
+                .sorted(
+                        Comparator.comparing(
+                                        FurnitureType::getPriority,
+                                        Comparator.nullsLast(Comparator.naturalOrder())
+                                )
+                                .thenComparing(FurnitureType::getId, Comparator.nullsLast(Comparator.naturalOrder()))
+                )
                 .map(furnitureType -> {
                     // 없으면 빈 리스트
                     List<FurnitureItem> items = furnitureByCategory.getOrDefault(furnitureType.getId(), Collections.emptyList());
                     return FurnitureCategoryGroup.from(furnitureType, items);
                 })
-                .sorted(
-                        Comparator.comparing(
-                                        (FurnitureCategoryGroup group) -> furnitureTypePriorityById.get(group.categoryId()),
-                                        Comparator.nullsLast(Comparator.naturalOrder())
-                                )
-                                .thenComparing(FurnitureCategoryGroup::categoryId, Comparator.nullsLast(Comparator.naturalOrder()))
-                )
                 .toList();
     }
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -115,9 +115,7 @@ public class FurnitureServiceImpl implements FurnitureService {
         List<ActivityFurniture> mappings = activityFurnitureRepository.findAllByOrderByPriorityAscIdAsc();
         Map<Activity, List<FurnitureItem>> grouped = new LinkedHashMap<>();
 
-        for (ActivityFurniture mapping : mappings.stream()
-                .sorted(Comparator.comparingInt(ActivityFurniture::getPriority).thenComparing(ActivityFurniture::getId))
-                .toList()) {
+        for (ActivityFurniture mapping : mappings) {
             grouped.computeIfAbsent(mapping.getActivity(), key -> new ArrayList<>())
                     .add(FurnitureItem.from(mapping.getFurniture(), mapping.getPriority()));
         }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -55,7 +55,19 @@ public class FurnitureServiceImpl implements FurnitureService {
     @Cacheable(value = "furnitureAndActivityCache")
     @Override
     public FurnitureAndActivityResponse getFurnitureAndActivity() {
+        List<FurnitureCategoryGroup> list = getDashboardCategories();
 
+        // 주요 활동 담기
+        List<ActivityItem> activities = Arrays.stream(Activity.values())
+                .map(ActivityItem::from)
+                .toList();
+
+        // 반환 Response 생성
+        return FurnitureAndActivityResponse.of(activities, list);
+    }
+
+    @Override
+    public List<FurnitureCategoryGroup> getDashboardCategories() {
         // 모든 카테고리 가져오기
         List<FurnitureType> furnitureTypes = furnitureTypeRepository.findAll();
 
@@ -76,7 +88,7 @@ public class FurnitureServiceImpl implements FurnitureService {
                 ));
 
         // 각 FurnitureType에 해당하는 FurnitureGroup 생성
-        List<FurnitureCategoryGroup> list = furnitureTypes.stream()
+        return furnitureTypes.stream()
                 .map(furnitureType -> {
                     // 없으면 빈 리스트
                     List<FurnitureItem> items = furnitureByCategory.getOrDefault(furnitureType.getId(), Collections.emptyList());
@@ -84,14 +96,6 @@ public class FurnitureServiceImpl implements FurnitureService {
                 })
                 .sorted(Comparator.comparing(FurnitureCategoryGroup::categoryId)) // 카테고리 ID로 정렬
                 .toList();
-
-        // 주요 활동 담기
-        List<ActivityItem> activities = Arrays.stream(Activity.values())
-                .map(ActivityItem::from)
-                .toList();
-
-        // 반환 Response 생성
-        return FurnitureAndActivityResponse.of(activities, list);
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -113,7 +113,7 @@ public class FurnitureServiceImpl implements FurnitureService {
     @Override
     public List<ActivityWithFurnitureResponse> getActivityFurnitureMappings() {
         List<ActivityFurniture> mappings = activityFurnitureRepository.findAllByOrderByPriorityAscIdAsc();
-        Map<Activity, List<FurnitureItem>> grouped = new EnumMap<>(Activity.class);
+        Map<Activity, List<FurnitureItem>> grouped = new LinkedHashMap<>();
 
         for (ActivityFurniture mapping : mappings.stream()
                 .sorted(Comparator.comparingInt(ActivityFurniture::getPriority).thenComparing(ActivityFurniture::getId))
@@ -122,10 +122,10 @@ public class FurnitureServiceImpl implements FurnitureService {
                     .add(FurnitureItem.from(mapping.getFurniture(), mapping.getPriority()));
         }
 
-        return Arrays.stream(Activity.values())
-                .map(activity -> ActivityWithFurnitureResponse.of(
-                        activity,
-                        grouped.getOrDefault(activity, List.of())
+        return grouped.entrySet().stream()
+                .map(entry -> ActivityWithFurnitureResponse.of(
+                        entry.getKey(),
+                        entry.getValue()
                 ))
                 .toList();
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -115,9 +115,11 @@ public class FurnitureServiceImpl implements FurnitureService {
         List<ActivityFurniture> mappings = activityFurnitureRepository.findAllByOrderByPriorityAscIdAsc();
         Map<Activity, List<FurnitureItem>> grouped = new EnumMap<>(Activity.class);
 
-        for (ActivityFurniture mapping : mappings) {
+        for (ActivityFurniture mapping : mappings.stream()
+                .sorted(Comparator.comparingInt(ActivityFurniture::getPriority).thenComparing(ActivityFurniture::getId))
+                .toList()) {
             grouped.computeIfAbsent(mapping.getActivity(), key -> new ArrayList<>())
-                    .add(FurnitureItem.from(mapping.getFurniture()));
+                    .add(FurnitureItem.from(mapping.getFurniture(), mapping.getPriority()));
         }
 
         return Arrays.stream(Activity.values())

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -5,12 +5,15 @@ import or.sopt.houme.domain.furniture.infrastructure.client.FastApiImageHashClie
 import or.sopt.houme.domain.furniture.infrastructure.client.NaverShopApiClient;
 import or.sopt.houme.domain.furniture.presentation.dto.ActivityItem;
 import or.sopt.houme.domain.furniture.presentation.dto.FurnitureItem;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoryGroup;
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
@@ -43,6 +46,7 @@ public class FurnitureServiceImpl implements FurnitureService {
     private final HouseRepository houseRepository;
     private final FurnitureTagRepository furnitureTagRepository;
     private final FurnitureTypeRepository furnitureTypeRepository;
+    private final ActivityFurnitureRepository activityFurnitureRepository;
 
     private final NaverShopApiClient naverShopApiClient;
     private final FastApiImageHashClient imageHashClient;
@@ -88,6 +92,24 @@ public class FurnitureServiceImpl implements FurnitureService {
 
         // 반환 Response 생성
         return FurnitureAndActivityResponse.of(activities, list);
+    }
+
+    @Override
+    public List<ActivityWithFurnitureResponse> getActivityFurnitureMappings() {
+        List<ActivityFurniture> mappings = activityFurnitureRepository.findAllByOrderByPriorityAscIdAsc();
+        Map<Activity, List<FurnitureItem>> grouped = new EnumMap<>(Activity.class);
+
+        for (ActivityFurniture mapping : mappings) {
+            grouped.computeIfAbsent(mapping.getActivity(), key -> new ArrayList<>())
+                    .add(FurnitureItem.from(mapping.getFurniture()));
+        }
+
+        return Arrays.stream(Activity.values())
+                .map(activity -> ActivityWithFurnitureResponse.of(
+                        activity,
+                        grouped.getOrDefault(activity, List.of())
+                ))
+                .toList();
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -81,11 +81,20 @@ public class FurnitureServiceImpl implements FurnitureService {
                         Collectors.collectingAndThen(
                                 Collectors.mapping(FurnitureItem::from, Collectors.toList()),
                                 list -> {
-                                    list.sort(Comparator.comparing(FurnitureItem::id, Comparator.nullsLast(Comparator.naturalOrder())));     // FurnitureItem 리스트 id 기준으로 정렬
+                                    list.sort(
+                                            Comparator.comparing(
+                                                            FurnitureItem::priority,
+                                                            Comparator.nullsLast(Comparator.naturalOrder())
+                                                    )
+                                                    .thenComparing(FurnitureItem::id, Comparator.nullsLast(Comparator.naturalOrder()))
+                                    );
                                     return list;
                                 }
                         )
                 ));
+
+        Map<Long, Integer> furnitureTypePriorityById = furnitureTypes.stream()
+                .collect(Collectors.toMap(FurnitureType::getId, FurnitureType::getPriority));
 
         // 각 FurnitureType에 해당하는 FurnitureGroup 생성
         return furnitureTypes.stream()
@@ -94,7 +103,13 @@ public class FurnitureServiceImpl implements FurnitureService {
                     List<FurnitureItem> items = furnitureByCategory.getOrDefault(furnitureType.getId(), Collections.emptyList());
                     return FurnitureCategoryGroup.from(furnitureType, items);
                 })
-                .sorted(Comparator.comparing(FurnitureCategoryGroup::categoryId)) // 카테고리 ID로 정렬
+                .sorted(
+                        Comparator.comparing(
+                                        (FurnitureCategoryGroup group) -> furnitureTypePriorityById.get(group.categoryId()),
+                                        Comparator.nullsLast(Comparator.naturalOrder())
+                                )
+                                .thenComparing(FurnitureCategoryGroup::categoryId, Comparator.nullsLast(Comparator.naturalOrder()))
+                )
                 .toList();
     }
 

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.furniture.service;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoryGroup;
 import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
@@ -147,6 +148,39 @@ class FurnitureServiceImplTest {
         assertThat(furnitureAndActivity.categories().get(2).nameKr()).isEqualTo("수납");
         assertThat(furnitureAndActivity.categories().get(3).nameKr()).isEqualTo("테이블");
         assertThat(furnitureAndActivity.categories().get(4).nameKr()).isEqualTo("그 외");
+    }
+
+    @Test
+    @DisplayName("대시보드 카테고리만 별도로 조회할 수 있다.")
+    void getDashboardCategories() {
+        // Given
+        FurnitureType bedType = FurnitureType.builder()
+                .id(1L)
+                .nameKr("침대")
+                .nameEng("BED")
+                .build();
+        FurnitureType sofaType = FurnitureType.builder()
+                .id(2L)
+                .nameKr("소파")
+                .nameEng("SOFA")
+                .build();
+        List<FurnitureType> categoryList = List.of(bedType, sofaType);
+
+        List<Furniture> furnitureList = List.of(
+                createFurniture(10L, "SINGLE", "싱글", bedType),
+                createFurniture(20L, "SINGLE_SOFA", "1인용 소파", sofaType)
+        );
+
+        when(furnitureTypeRepository.findAll()).thenReturn(categoryList);
+        when(furnitureRepository.findAllWithFurnitureType()).thenReturn(furnitureList);
+
+        // When
+        List<FurnitureCategoryGroup> categories = furnitureService.getDashboardCategories();
+
+        // Then
+        assertThat(categories).hasSize(2);
+        assertThat(categories.get(0).nameKr()).isEqualTo("침대");
+        assertThat(categories.get(1).nameKr()).isEqualTo("소파");
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -1,11 +1,14 @@
 package or.sopt.houme.domain.furniture.service;
 
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTypes;
+import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.house.model.entity.House;
@@ -62,6 +65,8 @@ class FurnitureServiceImplTest {
 
     @Mock
     FurnitureTypeRepository furnitureTypeRepository;
+    @Mock
+    ActivityFurnitureRepository activityFurnitureRepository;
 
     @Test
     @DisplayName("주요활동, 가구들에 대한 정보들을 받을 수 있다.")
@@ -216,6 +221,57 @@ class FurnitureServiceImplTest {
         assertThat(response.categories())
                 .extracting(FurnitureCategoriesResponse.FurnitureCategoryResponse::categoryName)
                 .containsExactly("식탁", "의자", "침대");
+    }
+
+    @Test
+    @DisplayName("주요활동별 매핑 가구를 조회할 수 있다.")
+    void getActivityFurnitureMappings() {
+        // Given
+        FurnitureType tableType = FurnitureType.builder()
+                .id(4L)
+                .nameKr("테이블")
+                .nameEng("TABLE")
+                .build();
+
+        FurnitureType selectiveType = FurnitureType.builder()
+                .id(5L)
+                .nameKr("그 외")
+                .nameEng("SELECTIVE")
+                .build();
+
+        Furniture desk = createFurniture(10L, "DESK", "업무용 책상", tableType);
+        Furniture bookshelf = createFurniture(11L, "BOOKSHELF", "책 선반", selectiveType);
+
+        ActivityFurniture remoteWork = ActivityFurniture.builder()
+                .id(1L)
+                .activity(Activity.REMOTE_WORK)
+                .furniture(desk)
+                .priority(1)
+                .build();
+
+        ActivityFurniture reading = ActivityFurniture.builder()
+                .id(2L)
+                .activity(Activity.READING)
+                .furniture(bookshelf)
+                .priority(1)
+                .build();
+
+        when(activityFurnitureRepository.findAllByOrderByPriorityAscIdAsc())
+                .thenReturn(List.of(remoteWork, reading));
+
+        // When
+        List<ActivityWithFurnitureResponse> responses = furnitureService.getActivityFurnitureMappings();
+
+        // Then
+        assertThat(responses).hasSize(Activity.values().length);
+        assertThat(responses.get(0).code()).isEqualTo(Activity.REMOTE_WORK.name());
+        assertThat(responses.get(0).furnitures())
+                .extracting(furniture -> furniture.label())
+                .containsExactly("업무용 책상");
+        assertThat(responses.get(1).code()).isEqualTo(Activity.READING.name());
+        assertThat(responses.get(1).furnitures())
+                .extracting(furniture -> furniture.label())
+                .containsExactly("책 선반");
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -328,7 +328,7 @@ class FurnitureServiceImplTest {
         List<ActivityWithFurnitureResponse> responses = furnitureService.getActivityFurnitureMappings();
 
         // Then
-        assertThat(responses).hasSize(Activity.values().length);
+        assertThat(responses).hasSize(2);
         assertThat(responses.get(0).code()).isEqualTo(Activity.REMOTE_WORK.name());
         assertThat(responses.get(0).furnitures())
                 .extracting(furniture -> furniture.label())

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -184,6 +184,37 @@ class FurnitureServiceImplTest {
     }
 
     @Test
+    @DisplayName("대시보드 카테고리는 furnitureType priority 오름차순으로 정렬된다.")
+    void getDashboardCategories_sortedByFurnitureTypePriority() {
+        // Given
+        FurnitureType sofaType = FurnitureType.builder()
+                .id(10L)
+                .nameKr("소파")
+                .nameEng("SOFA")
+                .priority(2)
+                .build();
+        FurnitureType bedType = FurnitureType.builder()
+                .id(20L)
+                .nameKr("침대/프레임")
+                .nameEng("BED")
+                .priority(1)
+                .build();
+
+        when(furnitureTypeRepository.findAll()).thenReturn(List.of(sofaType, bedType));
+        when(furnitureRepository.findAllWithFurnitureType()).thenReturn(List.of(
+                createFurniture(1L, "SINGLE_SOFA", "1인용 소파", sofaType),
+                createFurniture(2L, "SINGLE", "싱글", bedType)
+        ));
+
+        // When
+        List<FurnitureCategoryGroup> categories = furnitureService.getDashboardCategories();
+
+        // Then
+        assertThat(categories).extracting(FurnitureCategoryGroup::nameKr)
+                .containsExactly("침대/프레임", "소파");
+    }
+
+    @Test
     @DisplayName("감지된 단어와 선택 가구의 교집합만 추려 priority 오름차순으로 정렬된다")
     void categories_intersection_sorted() {
         // Given


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #487 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이미지 생성 퍼널에서 이전에 쓰이던 `/api/v1/dashboard-info`를 버전업하고, 주요활동과 가구 조회를 분리하였습니다.
- 기존에 Activity에 따라서 연계 가구를 매핑 관리해야해서, house.activity (ENUM)과 furniture를 연결하는 매핑 테이블을 만들었습니다.

## GET `/api/v2/dashboard/activities`
  
<img width="380" height="366" alt="image" src="https://github.com/user-attachments/assets/1edbf661-bc71-435d-9837-769f19afe1b3" />

  - 엑세스토큰 필요
  - 아이콘은 클라이언트에서 유틸로 분리하여 매핑한다고 합니다.
  - priority로 응답 순서를 보장합니다.


## GET `/api/v2/dashboard/categories`
<img width="201" height="353" alt="image" src="https://github.com/user-attachments/assets/74b0307b-c48f-4fbc-96a8-03ac8cd30486" />

  - 엑세스토큰 필요
  - 기존 v1 API에서 주요활동만 뺀 단순한 조회 API입니다.
  - priority로 응답 순서를 보장합니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
@gdbs1107 
- 어드민 API에서 주요활동과 연계 가구에 대한 CRUD가 필요할 것 같습니다! 아래 사진의 DB를 건드릴 수 있도록이요!
- 그리고 `furniture_type`, `furniture`에 `prioriry` 필드가 추가되었습니다! 이 부분도 어드민에서 CRUD할 수 있도록 하면 좋을 것 같습니다.

<img width="688" height="131" alt="image" src="https://github.com/user-attachments/assets/ff97907e-2d57-4ba3-95e7-23e2e9291408" />


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
### 예시 응답 JSON
```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "activities": [
      {
        "code": "REMOTE_WORK",
        "label": "재택근무형",
        "furnitures": [
          {
            "id": 7,
            "code": "DESK",
            "label": "업무용 책상"
          }
        ]
      },
      {
        "code": "READING",
        "label": "독서형",
        "furnitures": [
          {
            "id": 12,
            "code": "BOOKSHELF",
            "label": "책 선반"
          }
        ]
      },
      {
        "code": "FLOOR_LIVING",
        "label": "좌식 생활형",
        "furnitures": [
          {
            "id": 9,
            "code": "LOW_TABLE",
            "label": "좌식 테이블"
          }
        ]
      },
      {
        "code": "HOME_CAFE",
        "label": "홈카페형",
        "furnitures": [
          {
            "id": 8,
            "code": "DINING_TABLE",
            "label": "식탁"
          }
        ]
      }
    ]
  }
}
```

```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "categories": [
      {
        "categoryId": 1,
        "nameKr": "침대/프레임",
        "nameEng": "BED",
        "furnitures": [
          {
            "id": 1,
            "code": "SINGLE",
            "label": "싱글"
          },
          {
            "id": 2,
            "code": "SUPER_SINGLE",
            "label": "슈퍼싱글"
          },
          {
            "id": 3,
            "code": "DOUBLE",
            "label": "더블"
          },
          {
            "id": 4,
            "code": "QUEEN_OVER",
            "label": "퀸 이상"
          }
        ]
      },
      {
        "categoryId": 2,
        "nameKr": "소파",
        "nameEng": "SOFA",
        "furnitures": [
          {
            "id": 5,
            "code": "SINGLE_SOFA",
            "label": "1인용"
          },
          {
            "id": 6,
            "code": "TWO_SEATER_SOFA",
            "label": "2인용"
          }
        ]
      },
      {
        "categoryId": 3,
        "nameKr": "테이블",
        "nameEng": "TABLE",
        "furnitures": [
          {
            "id": 7,
            "code": "DESK",
            "label": "업무용 책상"
          },
          {
            "id": 8,
            "code": "DINING_TABLE",
            "label": "식탁"
          },
          {
            "id": 9,
            "code": "LOW_TABLE",
            "label": "좌식 테이블"
          }
        ]
      },
      {
        "categoryId": 4,
        "nameKr": "그 외",
        "nameEng": "SELECTIVE",
        "furnitures": [
          {
            "id": 10,
            "code": "MOVABLE_TV",
            "label": "이동식 TV"
          },
          {
            "id": 11,
            "code": "FULL_LENGTH_MIRROR",
            "label": "전신 거울"
          },
          {
            "id": 12,
            "code": "BOOKSHELF",
            "label": "책 선반"
          },
          {
            "id": 13,
            "code": "DECORATIVE_CABINET",
            "label": "장식장"
          }
        ]
      }
    ]
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 액티비티별 가구 매핑 조회 API(v2) 추가
  * 대시보드 카테고리 조회 API(v2) 추가
  * 가구/액티비티 관련 응답에 우선순위(priority) 포함

* **동작 변경 / 개선**
  * 가구 카테고리 및 액티비티 매핑에 우선순위 기반 정렬 도입
  * 기존 엔드포인트들에 API 버전(v1) 프리픽스 적용(기본 매핑 경로 변경)

* **테스트**
  * 대시보드 및 액티비티 매핑 관련 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->