### PR TITLE
[CHORE] 1,3퍼널 기본 이미지 생성 API V4 (템플릿X)

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/ActivityFurniture.java
@@ -1,0 +1,39 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.sopt.houme.domain.house.model.entity.enums.Activity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "activity_furnitures",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_activity_furnitures_activity_furniture",
+                        columnNames = {"activity", "furniture_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_activity_furnitures_activity_priority", columnList = "activity, priority")
+        }
+)
+public class ActivityFurniture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "furniture_id", nullable = false)
+    private Furniture furniture;
+
+    @Column(name = "priority", nullable = false)
+    private int priority;
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/ActivityFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/ActivityFurnitureRepository.java
@@ -1,0 +1,16 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
+import or.sopt.houme.domain.house.model.entity.enums.Activity;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ActivityFurnitureRepository extends JpaRepository<ActivityFurniture, Long> {
+
+    @EntityGraph(attributePaths = {"furniture", "furniture.furnitureType"})
+    List<ActivityFurniture> findAllByActivityOrderByPriorityAscIdAsc(Activity activity);
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -108,7 +108,7 @@ public class GenerateImageController {
         return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
     }
 
-    @Operation(summary = "V4 템플릿 기반 이미지 생성 API",
+    @Operation(summary = "V4 이미지 생성 API",
             description = "도면/뷰, 무드보드, 주요활동, 가구를 기반으로 Gemini 모델로 이미지 1장을 생성합니다.")
     @PostMapping("/v4/generated-images/generate")
     public ResponseEntity<ApiResponse<BannerGenerateImageResponse>> generateImageV4ByGemini(

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
@@ -105,6 +106,18 @@ public class GenerateImageController {
         ImageInfoListResponse imageInfoListResponse = generateImageFacade.generateImageBy2eaGemini(userDetails.getUser(), request);
 
         return ResponseEntity.ok(ApiResponse.ok(imageInfoListResponse));
+    }
+
+    @Operation(summary = "V4 템플릿 기반 이미지 생성 API",
+            description = "도면/뷰, 무드보드, 주요활동, 가구를 기반으로 Gemini 모델로 이미지 1장을 생성합니다.")
+    @PostMapping("/v4/generated-images/generate")
+    public ResponseEntity<ApiResponse<BannerGenerateImageResponse>> generateImageV4ByGemini(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid GenerateImageV4Request request
+    ) {
+        BannerGenerateImageResponse response =
+                generateImageFacade.generateImageV4ByGemini(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @Operation(summary = "배너 템플릿 기반 인테리어 이미지 생성 API",

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/GenerateImageV4Request.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/GenerateImageV4Request.java
@@ -1,0 +1,25 @@
+package or.sopt.houme.domain.generateImage.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record GenerateImageV4Request(
+        @NotNull(message = "도면 식별자는 필수입니다.")
+        Long floorPlanId,
+        @NotBlank(message = "floorPlanView는 필수입니다.")
+        String floorPlanView,
+        @NotNull(message = "좌우반전 여부는 필수입니다.")
+        Boolean isMirror,
+        @NotNull(message = "moodBoardIds는 필수입니다.")
+        @Size(min = 1, max = 5, message = "무드보드는 최소 1개에서 5개까지 입력 가능합니다.")
+        List<Long> moodBoardIds,
+        @NotBlank(message = "주요 활동은 필수입니다.")
+        String activity,
+        @NotNull(message = "furnitureIds는 필수입니다.")
+        @Size(max = 6, message = "최대 6개까지만 입력 가능합니다.")
+        List<Long> furnitureIds
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -148,6 +148,39 @@ public class GenerateImageTransactionService {
         return BannerGenerateImageResponse.of(generateImage.getId());
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BannerGenerateImageResponse saveV4ImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Long floorPlanId,
+            boolean isMirror,
+            String finalPrompt,
+            ImageUploadResponseDTO imageResponse,
+            Activity activity,
+            java.util.List<Long> furnitureIds,
+            java.util.List<Long> moodBoardIds
+    ) {
+        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror);
+        houseService.updateHouseActivity(house.getId(), activity);
+
+        if (furnitureIds != null && !furnitureIds.isEmpty()) {
+            houseService.saveHouseFurniture(house, furnitureIds);
+        }
+        if (moodBoardIds != null && !moodBoardIds.isEmpty()) {
+            houseService.saveHouseTaste(house, moodBoardIds);
+        }
+
+        GenerateImage generateImage = generateImageService.createGenerateImage(
+                imageResponse,
+                house,
+                GenerateImageType.LIST
+        );
+
+        creditService.commitCreditDeletion(lockedCredit);
+        userService.updateHasGeneratedImage(user);
+        return BannerGenerateImageResponse.of(generateImage.getId());
+    }
+
     private FloorPlan getFloorPlanOrThrow(House house) {
         return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
                 .map(HouseFloorPlan::getFloorPlan)

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -528,7 +528,7 @@ public class GenerateImageFacade {
                     combinedFurnitureIds
             );
 
-            String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
+            String floorPlanImageUrl = resolveFloorPlanImageUrlStrict(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildV4ReferenceImageUrls(floorPlanImageUrl, matchedFurnitureTags);
             String prompt = buildV4Prompt(floorPlan, selectedTag, matchedFurnitureTags);
 
@@ -805,6 +805,23 @@ public class GenerateImageFacade {
                 .filter(url -> url != null && !url.isBlank())
                 .findFirst()
                 .orElse(floorPlan.getUrl());
+    }
+
+    private String resolveFloorPlanImageUrlStrict(FloorPlan floorPlan, String floorPlanView) {
+        List<FloorPlanImageItem> images = floorPlanImageJsonCodec.read(floorPlan.getImagesJson());
+        String normalizedView = floorPlanView == null ? "" : floorPlanView.trim();
+
+        if (normalizedView.isEmpty()) {
+            throw new HouseException(ErrorCode.INVALID_FLOOR_PLAN_VIEW);
+        }
+
+        return images.stream()
+                .filter(Objects::nonNull)
+                .filter(item -> item.url() != null && !item.url().isBlank())
+                .filter(item -> item.view() != null && item.view().trim().equalsIgnoreCase(normalizedView))
+                .map(FloorPlanImageItem::url)
+                .findFirst()
+                .orElseThrow(() -> new HouseException(ErrorCode.INVALID_FLOOR_PLAN_VIEW));
     }
 
     private List<String> buildReferenceImageUrls(

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -13,12 +13,18 @@ import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.generateImage.presentation.dto.SelectedTagInfo;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
@@ -85,6 +91,8 @@ public class GenerateImageFacade {
     private final UserService userService;
     private final TagService tagService;
     private final FurnitureService furnitureService;
+    private final FurnitureTagRepository furnitureTagRepository;
+    private final ActivityFurnitureRepository activityFurnitureRepository;
     private final CurationRawProductRepository curationRawProductRepository;
     private final FloorPlanImageJsonCodec floorPlanImageJsonCodec;
     private final ObjectMapper objectMapper;
@@ -487,6 +495,86 @@ public class GenerateImageFacade {
         }
     }
 
+    public BannerGenerateImageResponse generateImageV4ByGemini(User user, GenerateImageV4Request request) {
+        Credit lockedCredit = null;
+
+        try {
+            log.info(
+                    "V4 이미지 생성 시작 userId={}, floorPlanId={}, view={}, isMirror={}, moodBoardCount={}, furnitureCount={}",
+                    user.getId(),
+                    request.floorPlanId(),
+                    request.floorPlanView(),
+                    request.isMirror(),
+                    request.moodBoardIds().size(),
+                    request.furnitureIds().size()
+            );
+
+            lockedCredit = creditService.tryLockAndGetCredit(user);
+
+            Activity activity = enumValueOf(Activity.class, request.activity());
+            Tag selectedTag = tasteTagService.getPriorityId(request.moodBoardIds());
+            FloorPlan floorPlan = floorPlanRepository.findById(request.floorPlanId())
+                    .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
+
+            List<Long> combinedFurnitureIds = buildCombinedFurnitureIds(activity, request.furnitureIds());
+            List<FurnitureTag> matchedFurnitureTags = furnitureTagRepository.findAllByFurnitureIdInAndTagId(
+                    combinedFurnitureIds,
+                    selectedTag.getId()
+            );
+
+            String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
+            List<String> referenceImageUrls = buildV4ReferenceImageUrls(floorPlanImageUrl, matchedFurnitureTags);
+            String prompt = buildV4Prompt(floorPlan, selectedTag, matchedFurnitureTags);
+
+            log.info(
+                    "V4 이미지 생성 프롬프트/참고이미지 tagId={}, prompt={}, referenceImageCount={}",
+                    selectedTag.getId(),
+                    prompt,
+                    referenceImageUrls.size()
+            );
+
+            ImageUploadResponseDTO imageUploadResponseDTO =
+                    geminiImageService.createImageWithReferences(prompt, referenceImageUrls);
+
+            if (imageUploadResponseDTO.getImageLink().equals(S3Constant.FALL_BACK_IMAGE)) {
+                log.error("V4 이미지 생성 중 폴백 이미지가 생성되었습니다.");
+                throw new ImageFallbackException(ErrorCode.GENERATED_IMAGE_EXCEPTION, null);
+            }
+
+            return generateImageTransactionService.saveV4ImageAndConfirmCredit(
+                    user,
+                    lockedCredit,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    prompt,
+                    imageUploadResponseDTO,
+                    activity,
+                    combinedFurnitureIds,
+                    request.moodBoardIds()
+            );
+        } catch (ValidException validException) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw validException;
+        } catch (GeneralException e) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error("V4 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw new GenerateImageException(ErrorCode.GENERATED_IMAGE_EXCEPTION);
+        } finally {
+            if (lockedCredit != null) {
+                creditService.releaseLock(user);
+            }
+        }
+    }
+
     private ImageInfoListResponse generateImageBy2eaInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         // finally 블록에서 사용하기 위해 선언
@@ -797,6 +885,51 @@ public class GenerateImageFacade {
         if (floorPlan.getFloorPlanPrompt() != null && !floorPlan.getFloorPlanPrompt().isBlank()) {
             parts.add(floorPlan.getFloorPlanPrompt());
         }
+        return String.join("\n\n", parts);
+    }
+
+    private List<Long> buildCombinedFurnitureIds(Activity activity, List<Long> requestFurnitureIds) {
+        LinkedHashSet<Long> ids = new LinkedHashSet<>();
+        if (requestFurnitureIds != null) {
+            ids.addAll(requestFurnitureIds);
+        }
+
+        List<ActivityFurniture> activityMappings =
+                activityFurnitureRepository.findAllByActivityOrderByPriorityAscIdAsc(activity);
+        activityMappings.stream()
+                .map(ActivityFurniture::getFurniture)
+                .filter(Objects::nonNull)
+                .map(Furniture::getId)
+                .filter(Objects::nonNull)
+                .forEach(ids::add);
+
+        return List.copyOf(ids);
+    }
+
+    private List<String> buildV4ReferenceImageUrls(String floorPlanImageUrl, List<FurnitureTag> furnitureTags) {
+        LinkedHashSet<String> urls = new LinkedHashSet<>();
+        if (floorPlanImageUrl != null && !floorPlanImageUrl.isBlank()) {
+            urls.add(floorPlanImageUrl);
+        }
+        furnitureTags.stream()
+                .map(FurnitureTag::getFurnitureUrl)
+                .filter(url -> url != null && !url.isBlank())
+                .forEach(urls::add);
+        return List.copyOf(urls);
+    }
+
+    private String buildV4Prompt(FloorPlan floorPlan, Tag selectedTag, List<FurnitureTag> furnitureTags) {
+        List<String> parts = new ArrayList<>();
+        if (floorPlan.getFloorPlanPrompt() != null && !floorPlan.getFloorPlanPrompt().isBlank()) {
+            parts.add(floorPlan.getFloorPlanPrompt());
+        }
+        if (selectedTag.getTagPrompt() != null && !selectedTag.getTagPrompt().isBlank()) {
+            parts.add(selectedTag.getTagPrompt());
+        }
+        furnitureTags.stream()
+                .map(FurnitureTag::getFurniturePrompt)
+                .filter(prompt -> prompt != null && !prompt.isBlank())
+                .forEach(parts::add);
         return String.join("\n\n", parts);
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -521,6 +521,12 @@ public class GenerateImageFacade {
                     combinedFurnitureIds,
                     selectedTag.getId()
             );
+            log.info(
+                    "V4 이미지 생성에 사용된 furniture_tag ids: {} (tagId={}, furnitureIds={})",
+                    matchedFurnitureTags.stream().map(FurnitureTag::getId).toList(),
+                    selectedTag.getId(),
+                    combinedFurnitureIds
+            );
 
             String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildV4ReferenceImageUrls(floorPlanImageUrl, matchedFurnitureTags);

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/prompt/PromptServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/prompt/PromptServiceImpl.java
@@ -49,7 +49,15 @@ public class PromptServiceImpl implements PromptService {
         PromptFurnitureListDTO promptFurnitureListDTO = requestDTO.promptFurnitureListDTO();
         List<Long> furnitureIds = promptFurnitureListDTO.furnitureTagIds();
 
-        List<String> furniturePrompts = furnitureTagRepository.findAllByFurnitureIdInAndTagId(furnitureIds, tagId.getId()).stream()
+        List<FurnitureTag> matchedFurnitureTags = furnitureTagRepository.findAllByFurnitureIdInAndTagId(furnitureIds, tagId.getId());
+        log.info(
+                "이미지 생성에 사용된 furniture_tag ids: {} (tagId={}, furnitureIds={})",
+                matchedFurnitureTags.stream().map(FurnitureTag::getId).toList(),
+                tagId.getId(),
+                furnitureIds
+        );
+
+        List<String> furniturePrompts = matchedFurnitureTags.stream()
                 .map(FurnitureTag::getFurniturePrompt)
                 .toList();
 

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     INVALID_GENERATE_IMAGE_REQUEST(HttpStatus.BAD_REQUEST, 40028, "이미지 생성 요청 값이 유효하지 않습니다."),
     INVALID_GENERATE_IMAGE_RESULT_REQUEST(HttpStatus.BAD_REQUEST, 40029, "이미지 결과 조회 요청 값이 유효하지 않습니다."),
     INVALID_GENERATE_IMAGE_TYPE(HttpStatus.BAD_REQUEST, 40030, "해당 API에서 지원하지 않는 이미지 생성 타입입니다."),
+    INVALID_FLOOR_PLAN_VIEW(HttpStatus.BAD_REQUEST, 40031, "도면 뷰 문자열을 찾을 수 없습니다."),
 
     // 네이버 쇼핑 API 관련 예외
     NAVER_API_DATA_PARSE_ERROR(HttpStatus.BAD_REQUEST, 40013, "네이버 API 응답의 productId 필드를 숫자로 변환하는 중 오류가 발생했습니다."),

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -51,7 +51,9 @@ import or.sopt.houme.domain.house.service.taste.TasteTagService;
 import or.sopt.houme.domain.user.model.entity.*;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.domain.user.util.floorplan.FloorPlanImageJsonCodec;
+import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
+import or.sopt.houme.global.api.handler.HouseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,9 +67,13 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -551,6 +557,88 @@ class GenerateImageFacadeTest {
                 eq(Activity.REMOTE_WORK),
                 eq(List.of(7L, 8L)),
                 eq(List.of(1L, 2L))
+        );
+    }
+
+    @Test
+    @DisplayName("V4 이미지 생성은 존재하지 않는 floorPlanView 입력 시 예외를 던진다")
+    void generateImageV4ByGemini_throwsWhenFloorPlanViewNotFound() {
+        User user = User.builder()
+                .id(1L)
+                .name("test_user")
+                .build();
+
+        Credit lockedCredit = Credit.builder()
+                .id(10L)
+                .status(CreditStatus.PENDING)
+                .user(user)
+                .build();
+
+        GenerateImageV4Request request = new GenerateImageV4Request(
+                11L,
+                "창가 뷰",
+                true,
+                List.of(1L, 2L),
+                "REMOTE_WORK",
+                List.of(7L)
+        );
+
+        Tag selectedTag = Tag.builder()
+                .id(100L)
+                .tagPrompt("스타일 프롬프트")
+                .build();
+
+        FloorPlan floorPlan = FloorPlan.builder()
+                .id(11L)
+                .url("https://floorplan-default")
+                .floorPlanPrompt("도면 프롬프트")
+                .imagesJson("[]")
+                .build();
+
+        ActivityFurniture mapping = ActivityFurniture.builder()
+                .id(1L)
+                .activity(Activity.REMOTE_WORK)
+                .furniture(Furniture.builder().id(8L).build())
+                .priority(1)
+                .build();
+
+        FurnitureTag furnitureTag = FurnitureTag.builder()
+                .id(1L)
+                .furniture(Furniture.builder().id(7L).build())
+                .tag(selectedTag)
+                .furnitureUrl("https://furniture-7")
+                .furniturePrompt("선택 가구 프롬프트")
+                .priority(1)
+                .searchKeyword("k1")
+                .build();
+
+        when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
+        when(tasteTagService.getPriorityId(request.moodBoardIds())).thenReturn(selectedTag);
+        when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
+        when(activityFurnitureRepository.findAllByActivityOrderByPriorityAscIdAsc(Activity.REMOTE_WORK))
+                .thenReturn(List.of(mapping));
+        when(furnitureTagRepository.findAllByFurnitureIdInAndTagId(List.of(7L, 8L), 100L))
+                .thenReturn(List.of(furnitureTag));
+        when(floorPlanImageJsonCodec.read("[]"))
+                .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "정면")));
+
+        assertThatThrownBy(() -> generateImageFacade.generateImageV4ByGemini(user, request))
+                .isInstanceOf(HouseException.class)
+                .extracting(ex -> ((HouseException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_FLOOR_PLAN_VIEW);
+
+        verify(creditService).rollbackCreditPending(lockedCredit);
+        verify(geminiImageService, never()).createImageWithReferences(any(), any());
+        verify(generateImageTransactionService, never()).saveV4ImageAndConfirmCredit(
+                any(),
+                any(),
+                anyLong(),
+                anyBoolean(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
         );
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -9,11 +9,17 @@ import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
+import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.generateImage.infrastructure.gemini.service.GeminiImageService;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
@@ -29,6 +35,7 @@ import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
+import or.sopt.houme.domain.house.model.floorPlan.vo.FloorPlanImageItem;
 import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.service.HouseService;
@@ -60,6 +67,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +95,12 @@ class GenerateImageFacadeTest {
 
     @Mock
     CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    FurnitureTagRepository furnitureTagRepository;
+
+    @Mock
+    ActivityFurnitureRepository activityFurnitureRepository;
 
     @Mock
     FloorPlanImageJsonCodec floorPlanImageJsonCodec;
@@ -420,6 +434,123 @@ class GenerateImageFacadeTest {
                 eq(false),
                 any(),
                 eq(imageUploadResponseDTO)
+        );
+    }
+
+    @Test
+    @DisplayName("V4 이미지 생성은 활동 연계 가구를 포함한 reference 이미지로 호출 후 저장한다")
+    void generateImageV4ByGemini_callsSaveV4ImageAndConfirmCredit() {
+        User user = User.builder()
+                .id(1L)
+                .name("test_user")
+                .build();
+
+        Credit lockedCredit = Credit.builder()
+                .id(10L)
+                .status(CreditStatus.PENDING)
+                .user(user)
+                .build();
+
+        GenerateImageV4Request request = new GenerateImageV4Request(
+                11L,
+                "창가 뷰",
+                true,
+                List.of(1L, 2L),
+                "REMOTE_WORK",
+                List.of(7L)
+        );
+
+        Tag selectedTag = Tag.builder()
+                .id(100L)
+                .tagPrompt("스타일 프롬프트")
+                .build();
+
+        FloorPlan floorPlan = FloorPlan.builder()
+                .id(11L)
+                .url("https://floorplan-default")
+                .floorPlanPrompt("도면 프롬프트")
+                .imagesJson("[]")
+                .build();
+
+        Furniture selectedFurniture = Furniture.builder().id(7L).build();
+        Furniture activityFurniture = Furniture.builder().id(8L).build();
+
+        ActivityFurniture mapping = ActivityFurniture.builder()
+                .id(1L)
+                .activity(Activity.REMOTE_WORK)
+                .furniture(activityFurniture)
+                .priority(1)
+                .build();
+
+        FurnitureTag selectedFurnitureTag = FurnitureTag.builder()
+                .id(1L)
+                .furniture(selectedFurniture)
+                .tag(selectedTag)
+                .furnitureUrl("https://furniture-7")
+                .furniturePrompt("선택 가구 프롬프트")
+                .priority(1)
+                .searchKeyword("k1")
+                .build();
+        FurnitureTag activityFurnitureTag = FurnitureTag.builder()
+                .id(2L)
+                .furniture(activityFurniture)
+                .tag(selectedTag)
+                .furnitureUrl("https://furniture-8")
+                .furniturePrompt("활동 가구 프롬프트")
+                .priority(2)
+                .searchKeyword("k2")
+                .build();
+
+        ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
+                "generated.webp",
+                "generated-original.webp",
+                "https://generated-image",
+                "image/webp"
+        );
+
+        when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
+        when(tasteTagService.getPriorityId(request.moodBoardIds())).thenReturn(selectedTag);
+        when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
+        when(activityFurnitureRepository.findAllByActivityOrderByPriorityAscIdAsc(Activity.REMOTE_WORK))
+                .thenReturn(List.of(mapping));
+        when(furnitureTagRepository.findAllByFurnitureIdInAndTagId(List.of(7L, 8L), 100L))
+                .thenReturn(List.of(selectedFurnitureTag, activityFurnitureTag));
+        when(floorPlanImageJsonCodec.read("[]"))
+                .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
+        when(geminiImageService.createImageWithReferences(any(), any()))
+                .thenReturn(imageUploadResponseDTO);
+        when(generateImageTransactionService.saveV4ImageAndConfirmCredit(
+                eq(user),
+                eq(lockedCredit),
+                eq(11L),
+                eq(true),
+                any(),
+                eq(imageUploadResponseDTO),
+                eq(Activity.REMOTE_WORK),
+                eq(List.of(7L, 8L)),
+                eq(List.of(1L, 2L))
+        )).thenReturn(BannerGenerateImageResponse.of(999L));
+
+        BannerGenerateImageResponse response = generateImageFacade.generateImageV4ByGemini(user, request);
+
+        assertThat(response.imageId()).isEqualTo(999L);
+        verify(geminiImageService).createImageWithReferences(
+                any(),
+                argThat(urls -> urls.size() == 3
+                        && urls.get(0).equals("https://floorplan-view")
+                        && urls.contains("https://furniture-7")
+                        && urls.contains("https://furniture-8"))
+        );
+        verify(generateImageTransactionService).saveV4ImageAndConfirmCredit(
+                eq(user),
+                eq(lockedCredit),
+                eq(11L),
+                eq(true),
+                any(),
+                eq(imageUploadResponseDTO),
+                eq(Activity.REMOTE_WORK),
+                eq(List.of(7L, 8L)),
+                eq(List.of(1L, 2L))
         );
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #488

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 v3 이미지 생성에서 요청값과 내부 엔티티 생성 로직을 수정함에 따라 v4로 버전업 했습니다.
- 해당 API를 한줄 요약하자면,
  - 템플릿 없이, 사용자가 선택한 도면 + 무드보드 + 주요활동 + 가구 -> 이미지 생성

## POST `/api/v4/generated-images/generate`
- 요청값은 아래와 같습니다.
```json
{
  "floorPlanId": 2,
  "floorPlanView": "창가 뷰",
  "isMirror": true,
  "moodBoardIds": [1, 2],
  "activity": "REMOTE_WORK",
  "furnitureIds": [3, 5]
}
```
- API의 작동 과정은 아래와 같습니다.
  - `GenerateImageFacade.generateImageV4ByGemini()` : 오케스트레이팅
  - `creditService.tryLockAndGetCredit(user)` : 크레딧 락
  - `tasteTagService.getPriorityId(request.moodBoardIds())` : 최종 스타일 태그 1개 선택 (기존에도 사용하던 무드보드로 하나의 스타일을 선정하는 로직입니다.)
  - `activity` 검증 및 `floorPlan` 조회
  - `buildCombinedFurnitureIds(activity, request.furnitureIds())` : 주요활동의 연계 가구 및 요청 가구 조회
  - 선정된 스타일 태그와 가구가 매핑되는 `furniture_tag` 조회
  - 도면 이미지 조회
  - `floor_plan_prompt` + `tag_prompt` + `furniture_prompt` 결합 (도면 + 스타일 + 가구 프롬프트, 스타일 이미지가 직접 들어가지 않기 떄문에 스타일 프롬프트에서 스타일 설명이 필요 -> 기획 의도한 "약한 참조")
  - 조회된 floorPlan 이미지 + furnitureTag + 최종 프롬프트
  - 이미지 생성이 완료된 후 `return generateImageTransactionService.saveV4ImageAndConfirmCredit()` 에서 house 엔티티를 저장하고 크레딧 `PENDING` -> 크레딧 삭제 합니다.
  - 크레딧 락, 삭제, 이미지 폴백의 기존 이미지 파이프라인을 구성하는 메서드는 재사용했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
https://www.notion.so/X-33debc1c3e8980c3912dc2cd15b8c2aa?source=copy_link
- 이미지 생성 테스트를 보기 좋게 노션으로 정리했습니다. 노션에서 이미지 생성 결과들 확인해주세요.

## 📬 Postman



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능

* **V4 이미지 생성 기능 추가**
  * 도면 뷰 선택, 미러 옵션, 활동별 추천 가구, 무드보드 통합 등 향상된 파라미터를 지원하는 새로운 이미지 생성 엔드포인트 추가
  * 사용자가 도면과 가구를 더 정교하게 선택하여 맞춤형 이미지 생성 가능

## Chores

* **에러 처리 개선**
  * 도면 뷰 검증 오류 처리 로직 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->