### PR TITLE
[FEATURE] 상품 검색 v2 - 사전 토큰화 기반 키워드 검색 구현 (#491)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ src/main/resources/application-prod.yml
 
 ### 로컬 DB 쿼리 무시 ###
 seed_local_houme.sql
+
+### Claude Code ###
+CLAUDE.md

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationProductSearchKeyword.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationProductSearchKeyword.java
@@ -1,0 +1,54 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+@Entity
+@Table(
+        name = "curation_product_search_keywords",
+        indexes = {
+                @Index(name = "idx_search_keyword_product_id", columnList = "curation_raw_product_id")
+        }
+)
+@Comment("상품 커스텀 검색 키워드 매핑 테이블")
+public class CurationProductSearchKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("식별자")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_raw_product_id", nullable = false)
+    @Comment("매핑된 상품")
+    private CurationRawProduct curationRawProduct;
+
+    @Column(name = "keyword", nullable = false)
+    @Comment("커스텀 검색 키워드 (상품명/브랜드와 무관하지만 이 상품을 찾아야 하는 대체 키워드)")
+    private String keyword;
+
+    public static CurationProductSearchKeyword of(CurationRawProduct product, String keyword) {
+        return CurationProductSearchKeyword.builder()
+                .curationRawProduct(product)
+                .keyword(keyword)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -117,6 +117,10 @@ public class CurationRawProduct {
     @Comment("노출 여부")
     private Boolean isExposed = true;
 
+    @Column(name = "search_tokens", columnDefinition = "text")
+    @Comment("검색용 사전 토큰화 데이터 (상품명/브랜드/가구유형/커스텀 키워드 공백 구분)")
+    private String searchTokens;
+
     @OneToMany(mappedBy = "curationRawProduct", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     @Comment("수동 매핑된 가구 태그(다중 매핑)")
@@ -253,6 +257,10 @@ public class CurationRawProduct {
 
     public void updateExposure(boolean isExposed) {
         this.isExposed = isExposed;
+    }
+
+    public void updateSearchTokens(String searchTokens) {
+        this.searchTokens = searchTokens;
     }
 
     private static String normalizeSource(String source) {

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductController.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductD
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductFilterResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductListResponse;
 import or.sopt.houme.domain.furniture.service.CurationProductService;
+import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -57,6 +58,7 @@ public class CurationProductController {
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(curationProductService.getProductDetail(id, userDetails.getUser())));
+        User user = userDetails != null ? userDetails.getUser() : null;
+        return ResponseEntity.ok(ApiResponse.ok(curationProductService.getProductDetail(id, user)));
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2Controller.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2Controller.java
@@ -1,0 +1,47 @@
+package or.sopt.houme.domain.furniture.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductListResponse;
+import or.sopt.houme.domain.furniture.service.CurationProductService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/curations/products")
+@RequiredArgsConstructor
+@Tag(name = "상품 큐레이션 API")
+@Validated
+public class CurationProductV2Controller {
+
+    private final CurationProductService curationProductService;
+
+    @GetMapping
+    @Operation(
+            summary = "[v2] 상품 리스트 조회 및 검색 API",
+            description = "사전 토큰화 기반 검색 엔진을 적용한 상품 탭 메인 API입니다. " +
+                          "v1 대비 상품명·브랜드명 외에 가구 유형명 및 어드민 설정 커스텀 키워드까지 검색됩니다."
+    )
+    public ResponseEntity<ApiResponse<CurationProductListResponse>> getProducts(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) List<Long> types,
+            @RequestParam(required = false) List<String> priceRanges,
+            @RequestParam(required = false) List<Long> colors,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") @Positive @Max(100) Integer size
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                curationProductService.getProductsV2(keyword, types, priceRanges, colors, cursor, size)
+        ));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationProductSearchKeywordRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationProductSearchKeywordRepository.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationProductSearchKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CurationProductSearchKeywordRepository extends JpaRepository<CurationProductSearchKeyword, Long> {
+    List<CurationProductSearchKeyword> findAllByCurationRawProductId(Long productId);
+    List<CurationProductSearchKeyword> findAllByCurationRawProductIdIn(List<Long> productIds);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepository.java
@@ -47,6 +47,16 @@ public interface CurationRawProductRepository extends JpaRepository<CurationRawP
 
     List<CurationRawProduct> findAllByProductIdIn(List<Long> productIds);
 
+    @Query("""
+            select distinct rp from CurationRawProduct rp
+            left join fetch rp.furnitureTagMappings mapping
+            left join fetch mapping.furnitureTag tag
+            left join fetch tag.furniture furniture
+            left join fetch furniture.furnitureType
+            where rp.id in :ids
+            """)
+    List<CurationRawProduct> findAllByIdWithFurnitureTags(@Param("ids") List<Long> ids);
+
     @Query("select rp from CurationRawProduct rp where (rp.isExposed = true or rp.isExposed is null) order by rp.id desc")
     Page<CurationRawProduct> findAllByIsExposedTrueOrNullOrderByIdDesc(Pageable pageable);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
@@ -19,6 +19,15 @@ public interface CurationRawProductRepositoryCustom {
             Pageable pageable
     );
 
+    Slice<CurationRawProduct> findAllByCurationFiltersV2(
+            String keyword,
+            List<Long> typeIds,
+            List<PriceRangeFilter> priceRanges,
+            List<String> colorNames,
+            Long cursor,
+            Pageable pageable
+    );
+
     Page<CurationRawProduct> findExposedRawProductsExcludingLikedByUser(Long userId, Pageable pageable);
 
     List<CurationRawProduct> findAllSimilarByFurnitureTypeIds(

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -165,9 +165,9 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             finalWhere.and(rawProduct.id.lt(cursor));
         }
 
-        // v2: search_tokens 기반 검색 (pg_trgm GIN 인덱스 활용)
+        // v2: search_tokens 기반 검색 (pg_trgm GIN 인덱스 활용, 토큰은 lowercase 저장이므로 contains 사용)
         if (keyword != null && !keyword.isBlank()) {
-            finalWhere.and(rawProduct.searchTokens.containsIgnoreCase(keyword));
+            finalWhere.and(rawProduct.searchTokens.contains(keyword.toLowerCase()));
         }
 
         if (typeIds != null && !typeIds.isEmpty()) {

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -143,6 +143,84 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
     }
 
     @Override
+    public Slice<CurationRawProduct> findAllByCurationFiltersV2(
+            String keyword,
+            List<Long> typeIds,
+            List<PriceRangeFilter> priceRanges,
+            List<String> colorNames,
+            Long cursor,
+            Pageable pageable
+    ) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
+        QFurnitureTag fTag = QFurnitureTag.furnitureTag;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType fType = QFurnitureType.furnitureType;
+        QCurationRawProductColor color = QCurationRawProductColor.curationRawProductColor;
+
+        BooleanBuilder finalWhere = new BooleanBuilder();
+
+        finalWhere.and(rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull()));
+        if (cursor != null) {
+            finalWhere.and(rawProduct.id.lt(cursor));
+        }
+
+        // v2: search_tokens 기반 검색 (pg_trgm GIN 인덱스 활용)
+        if (keyword != null && !keyword.isBlank()) {
+            finalWhere.and(rawProduct.searchTokens.containsIgnoreCase(keyword));
+        }
+
+        if (typeIds != null && !typeIds.isEmpty()) {
+            finalWhere.and(rawProduct.id.in(
+                    queryFactory.select(mapping.curationRawProduct.id)
+                            .from(mapping)
+                            .join(mapping.furnitureTag, fTag)
+                            .join(fTag.furniture, furniture)
+                            .leftJoin(furniture.furnitureType, fType)
+                            .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
+            ));
+        }
+
+        if (priceRanges != null && !priceRanges.isEmpty()) {
+            BooleanBuilder priceGroupBuilder = new BooleanBuilder();
+            for (PriceRangeFilter range : priceRanges) {
+                BooleanBuilder rangeBuilder = new BooleanBuilder();
+                if (range.min() != null) rangeBuilder.and(rawProduct.discountPrice.goe(range.min()));
+                if (range.max() != null) rangeBuilder.and(rawProduct.discountPrice.loe(range.max()));
+                priceGroupBuilder.or(rangeBuilder);
+            }
+            finalWhere.and(priceGroupBuilder);
+        }
+
+        if (colorNames != null && !colorNames.isEmpty()) {
+            BooleanBuilder colorGroupBuilder = new BooleanBuilder();
+            for (String colorName : colorNames) {
+                colorGroupBuilder.or(color.clientColorName.containsIgnoreCase(colorName));
+            }
+            finalWhere.and(rawProduct.id.in(
+                    queryFactory.select(color.curationRawProduct.id)
+                            .from(color)
+                            .where(colorGroupBuilder)
+            ));
+        }
+
+        List<CurationRawProduct> content = queryFactory
+                .selectFrom(rawProduct)
+                .where(finalWhere)
+                .orderBy(rawProduct.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
     public Page<CurationRawProduct> findExposedRawProductsExcludingLikedByUser(Long userId, Pageable pageable) {
         QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
         QJjym jjym = QJjym.jjym;

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductService.java
@@ -19,5 +19,14 @@ public interface CurationProductService {
             Integer size
     );
 
+    CurationProductListResponse getProductsV2(
+            String keyword,
+            List<Long> typeIds,
+            List<String> priceRangeIds,
+            List<Long> colorIds,
+            Long cursor,
+            Integer size
+    );
+
     CurationProductDetailResponse getProductDetail(Long id, User user);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -102,12 +102,13 @@ public class CurationProductServiceImpl implements CurationProductService {
                 ))
                 .toList();
 
-        Long nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).id();
+        boolean hasNext = productSlice.hasNext();
+        Long nextCursor = hasNext ? products.get(products.size() - 1).id() : null;
         List<CurationProductAppliedFilterResponse> appliedFilters = buildAppliedFilters(typeIds, priceRangeIds, colorIds);
 
         return new CurationProductListResponse(
                 products,
-                new CurationProductMetaResponse(nextCursor, productSlice.hasNext(), appliedFilters)
+                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters)
         );
     }
 
@@ -237,12 +238,13 @@ public class CurationProductServiceImpl implements CurationProductService {
                 ))
                 .toList();
 
-        Long nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).id();
+        boolean hasNext = productSlice.hasNext();
+        Long nextCursor = hasNext ? products.get(products.size() - 1).id() : null;
         List<CurationProductAppliedFilterResponse> appliedFilters = buildAppliedFilters(typeIds, priceRangeIds, colorIds);
 
         return new CurationProductListResponse(
                 products,
-                new CurationProductMetaResponse(nextCursor, productSlice.hasNext(), appliedFilters)
+                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters)
         );
     }
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -144,6 +144,7 @@ public class CurationProductServiceImpl implements CurationProductService {
 
     private List<CurationRawProductRepositoryCustom.PriceRangeFilter> extractPriceFilters(List<String> priceRangeIds) {
         if (priceRangeIds == null || priceRangeIds.isEmpty()) return List.of();
+        if (priceRangeIds.stream().anyMatch(id -> "P0".equalsIgnoreCase(id))) return List.of();
 
         List<PriceRangeFilterResponse> allPriceMetadata = getPriceRangeFilters();
         return priceRangeIds.stream()

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -196,6 +196,56 @@ public class CurationProductServiceImpl implements CurationProductService {
     }
 
     @Override
+    public CurationProductListResponse getProductsV2(
+            String keyword,
+            List<Long> typeIds,
+            List<String> priceRangeIds,
+            List<Long> colorIds,
+            Long cursor,
+            Integer size
+    ) {
+        validatePaginationParams(size);
+
+        Pageable pageable = PageRequest.of(0, size);
+        List<String> colorNames = extractColorNames(colorIds);
+        List<CurationRawProductRepositoryCustom.PriceRangeFilter> priceFilters = extractPriceFilters(priceRangeIds);
+
+        List<Long> filteredTypeIds = preprocessTypeIds(typeIds);
+        if (typeIds != null && typeIds.contains(0L)) {
+            filteredTypeIds = null;
+        }
+
+        Slice<CurationRawProduct> productSlice = curationRawProductRepository.findAllByCurationFiltersV2(
+                keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable
+        );
+
+        List<CurationProductResponse> products = productSlice.getContent().stream()
+                .map(p -> new CurationProductResponse(
+                        p.getId(),
+                        p.getProductId(),
+                        extractCategoryName(p),
+                        p.getSource(),
+                        p.getBrand(),
+                        p.getProductName(),
+                        p.getProductImageUrl(),
+                        p.getListPrice(),
+                        p.getDiscountRate(),
+                        p.getDiscountPrice(),
+                        p.getProductMallName(),
+                        p.getProductSiteUrl()
+                ))
+                .toList();
+
+        Long nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).id();
+        List<CurationProductAppliedFilterResponse> appliedFilters = buildAppliedFilters(typeIds, priceRangeIds, colorIds);
+
+        return new CurationProductListResponse(
+                products,
+                new CurationProductMetaResponse(nextCursor, productSlice.hasNext(), appliedFilters)
+        );
+    }
+
+    @Override
     public CurationProductDetailResponse getProductDetail(Long id, User user) {
         CurationRawProduct product = curationRawProductRepository.findByIdAndIsExposedTrueOrNull(id)
                 .orElseThrow(() -> new FurnitureException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT));

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenBackfillRunner.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenBackfillRunner.java
@@ -19,10 +19,16 @@ public class CurationProductTokenBackfillRunner implements ApplicationRunner {
 
     private final CurationProductTokenService curationProductTokenService;
 
+    private static final int MAX_ITERATIONS = 10000;
+
     @Override
     public void run(ApplicationArguments args) {
         curationProductTokenService.initPgTrgm();
-        backfill();
+        try {
+            backfill();
+        } catch (Exception e) {
+            log.error("search_tokens 백필 중 오류 발생 — 서버 기동은 계속됩니다: {}", e.getMessage(), e);
+        }
     }
 
     private void backfill() {
@@ -34,15 +40,25 @@ public class CurationProductTokenBackfillRunner implements ApplicationRunner {
 
         log.info("search_tokens 백필 시작: {}건", nullCount);
         long processed = 0;
+        int iterations = 0;
 
-        while (true) {
+        while (iterations++ < MAX_ITERATIONS) {
             List<Long> ids = curationProductTokenService.findNullTokenProductIds(BATCH_SIZE);
             if (ids.isEmpty()) break;
-            curationProductTokenService.refreshTokensForProducts(ids);
+            try {
+                curationProductTokenService.refreshTokensForProducts(ids);
+            } catch (Exception e) {
+                log.error("search_tokens 백필 배치 오류 (ids={}): {}", ids, e.getMessage(), e);
+                break;
+            }
             processed += ids.size();
             log.info("search_tokens 백필 진행: {}/{}", processed, nullCount);
         }
 
-        log.info("search_tokens 백필 완료: {}건 처리", processed);
+        if (iterations >= MAX_ITERATIONS) {
+            log.warn("search_tokens 백필 최대 반복 횟수 도달 — 일부 상품이 처리되지 않았을 수 있습니다.");
+        } else {
+            log.info("search_tokens 백필 완료: {}건 처리", processed);
+        }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenBackfillRunner.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenBackfillRunner.java
@@ -1,0 +1,48 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(10)
+public class CurationProductTokenBackfillRunner implements ApplicationRunner {
+
+    private static final int BATCH_SIZE = 200;
+
+    private final CurationProductTokenService curationProductTokenService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        curationProductTokenService.initPgTrgm();
+        backfill();
+    }
+
+    private void backfill() {
+        long nullCount = curationProductTokenService.countNullTokenProducts();
+        if (nullCount == 0) {
+            log.info("search_tokens 백필 불필요: 모든 상품에 토큰이 존재합니다.");
+            return;
+        }
+
+        log.info("search_tokens 백필 시작: {}건", nullCount);
+        long processed = 0;
+
+        while (true) {
+            List<Long> ids = curationProductTokenService.findNullTokenProductIds(BATCH_SIZE);
+            if (ids.isEmpty()) break;
+            curationProductTokenService.refreshTokensForProducts(ids);
+            processed += ids.size();
+            log.info("search_tokens 백필 진행: {}/{}", processed, nullCount);
+        }
+
+        log.info("search_tokens 백필 완료: {}건 처리", processed);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenService.java
@@ -1,0 +1,111 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.furniture.model.entity.CurationProductSearchKeyword;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.repository.CurationProductSearchKeywordRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CurationProductTokenService {
+
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final CurationProductSearchKeywordRepository searchKeywordRepository;
+    private final CurationProductTokenizer tokenizer;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void refreshTokensForProducts(List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) return;
+
+        List<CurationRawProduct> products = curationRawProductRepository.findAllById(productIds);
+        Map<Long, List<String>> keywordsByProductId = loadCustomKeywords(productIds);
+
+        for (CurationRawProduct product : products) {
+            List<String> furnitureTypeNames = extractFurnitureTypeNames(product);
+            List<String> customKeywords = keywordsByProductId.getOrDefault(product.getId(), List.of());
+
+            String tokens = tokenizer.buildTokens(
+                    product.getProductName(),
+                    product.getBrand(),
+                    furnitureTypeNames,
+                    customKeywords
+            );
+            product.updateSearchTokens(tokens);
+        }
+
+        curationRawProductRepository.saveAll(products);
+    }
+
+    public void initPgTrgm() {
+        try {
+            jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+            jdbcTemplate.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_search_tokens_trgm " +
+                    "ON curation_raw_products USING gin (search_tokens gin_trgm_ops)"
+            );
+            log.info("pg_trgm 인덱스 초기화 완료");
+        } catch (Exception e) {
+            log.warn("pg_trgm 인덱스 초기화 실패 (권한 부족 또는 이미 존재): {}", e.getMessage());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public long countNullTokenProducts() {
+        Long count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM curation_raw_products WHERE search_tokens IS NULL",
+                Long.class
+        );
+        return count != null ? count : 0L;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findNullTokenProductIds(int limit) {
+        return jdbcTemplate.queryForList(
+                "SELECT id FROM curation_raw_products WHERE search_tokens IS NULL LIMIT ?",
+                Long.class,
+                limit
+        );
+    }
+
+    private List<String> extractFurnitureTypeNames(CurationRawProduct product) {
+        return product.getFurnitureTagMappings().stream()
+                .map(CurationRawProductFurnitureTag::getFurnitureTag)
+                .filter(tag -> tag != null && tag.getFurniture() != null)
+                .flatMap(tag -> {
+                    List<String> names = new ArrayList<>();
+                    Furniture furniture = tag.getFurniture();
+                    if (furniture.getFurnitureNameKr() != null) names.add(furniture.getFurnitureNameKr());
+                    FurnitureType type = furniture.getFurnitureType();
+                    if (type != null && type.getNameKr() != null) names.add(type.getNameKr());
+                    return names.stream();
+                })
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, List<String>> loadCustomKeywords(List<Long> productIds) {
+        List<CurationProductSearchKeyword> keywords = searchKeywordRepository.findAllByCurationRawProductIdIn(productIds);
+        Map<Long, List<String>> map = new HashMap<>();
+        for (CurationProductSearchKeyword kw : keywords) {
+            map.computeIfAbsent(kw.getCurationRawProduct().getId(), k -> new ArrayList<>())
+               .add(kw.getKeyword());
+        }
+        return map;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenService.java
@@ -33,7 +33,7 @@ public class CurationProductTokenService {
     public void refreshTokensForProducts(List<Long> productIds) {
         if (productIds == null || productIds.isEmpty()) return;
 
-        List<CurationRawProduct> products = curationRawProductRepository.findAllById(productIds);
+        List<CurationRawProduct> products = curationRawProductRepository.findAllByIdWithFurnitureTags(productIds);
         Map<Long, List<String>> keywordsByProductId = loadCustomKeywords(productIds);
 
         for (CurationRawProduct product : products) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
@@ -42,7 +42,7 @@ public class CurationProductTokenizer {
             tokens.add(trimmed);
 
             // 한글/비한글 경계에서 복합어 분리
-            // ex) "SS매트리스" → "ss" + "매트리스", "3인용소파" → "3인용" + "소파"
+            // ex) "SS매트리스" → "ss" + "매트리스", "3인용소파" → "3" + "인용소파"
             String[] parts = trimmed.split("(?<=[가-힣])(?=[^가-힣])|(?<=[^가-힣])(?=[가-힣])");
             if (parts.length > 1) {
                 for (String part : parts) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
@@ -1,0 +1,55 @@
+package or.sopt.houme.domain.furniture.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class CurationProductTokenizer {
+
+    public String buildTokens(String productName, String brand, List<String> furnitureTypeNames, List<String> customKeywords) {
+        Set<String> tokens = new LinkedHashSet<>();
+
+        addWordTokens(tokens, productName);
+        addWordTokens(tokens, brand);
+
+        for (String name : furnitureTypeNames) {
+            if (name != null && !name.isBlank()) {
+                tokens.add(name.trim());
+            }
+        }
+
+        for (String kw : customKeywords) {
+            if (kw != null && !kw.isBlank()) {
+                tokens.add(kw.trim());
+            }
+        }
+
+        return String.join(" ", tokens);
+    }
+
+    private void addWordTokens(Set<String> tokens, String text) {
+        if (text == null || text.isBlank()) return;
+
+        String[] words = text.split("[\\s\\-_/()\\[\\],.]+");
+        for (String word : words) {
+            String trimmed = word.trim();
+            if (trimmed.isEmpty()) continue;
+            tokens.add(trimmed);
+
+            // 한글/비한글 경계에서 복합어 분리
+            // ex) "SS매트리스" → "SS" + "매트리스", "3인용소파" → "3인용" + "소파"
+            String[] parts = trimmed.split("(?<=[가-힣])(?=[^가-힣])|(?<=[^가-힣])(?=[가-힣])");
+            if (parts.length > 1) {
+                for (String part : parts) {
+                    String p = part.trim();
+                    if (!p.isEmpty()) {
+                        tokens.add(p);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
@@ -15,14 +15,14 @@ public class CurationProductTokenizer {
         addWordTokens(tokens, productName);
         addWordTokens(tokens, brand);
 
-        for (String name : furnitureTypeNames) {
+        for (String name : furnitureTypeNames == null ? List.<String>of() : furnitureTypeNames) {
             if (name != null && !name.isBlank()) {
                 tokens.add(name.trim().toLowerCase());
                 addWordTokens(tokens, name);
             }
         }
 
-        for (String kw : customKeywords) {
+        for (String kw : customKeywords == null ? List.<String>of() : customKeywords) {
             if (kw != null && !kw.isBlank()) {
                 tokens.add(kw.trim().toLowerCase());
                 addWordTokens(tokens, kw);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizer.java
@@ -17,13 +17,15 @@ public class CurationProductTokenizer {
 
         for (String name : furnitureTypeNames) {
             if (name != null && !name.isBlank()) {
-                tokens.add(name.trim());
+                tokens.add(name.trim().toLowerCase());
+                addWordTokens(tokens, name);
             }
         }
 
         for (String kw : customKeywords) {
             if (kw != null && !kw.isBlank()) {
-                tokens.add(kw.trim());
+                tokens.add(kw.trim().toLowerCase());
+                addWordTokens(tokens, kw);
             }
         }
 
@@ -35,12 +37,12 @@ public class CurationProductTokenizer {
 
         String[] words = text.split("[\\s\\-_/()\\[\\],.]+");
         for (String word : words) {
-            String trimmed = word.trim();
+            String trimmed = word.trim().toLowerCase();
             if (trimmed.isEmpty()) continue;
             tokens.add(trimmed);
 
             // 한글/비한글 경계에서 복합어 분리
-            // ex) "SS매트리스" → "SS" + "매트리스", "3인용소파" → "3인용" + "소파"
+            // ex) "SS매트리스" → "ss" + "매트리스", "3인용소파" → "3인용" + "소파"
             String[] parts = trimmed.split("(?<=[가-힣])(?=[^가-힣])|(?<=[^가-힣])(?=[가-힣])");
             if (parts.length > 1) {
                 for (String part : parts) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductService.java
@@ -7,6 +7,8 @@ import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.dto.CurationRawProductSaveResult;
+import or.sopt.houme.domain.furniture.service.event.CurationRawProductTokenRefreshEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 public class CurationRawProductService {
 
     private final CurationRawProductRepository curationRawProductRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<NaverFurnitureProductDto> getCandidatesByFurnitureTag(FurnitureTag furnitureTag) {
@@ -133,7 +136,9 @@ public class CurationRawProductService {
         }
 
         if (!toSave.isEmpty()) {
-            curationRawProductRepository.saveAll(toSave);
+            List<CurationRawProduct> saved = curationRawProductRepository.saveAll(toSave);
+            List<Long> savedIds = saved.stream().map(CurationRawProduct::getId).toList();
+            eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(savedIds));
         }
 
         return new CurationRawProductSaveResult(inserted, updated, skipped);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -19,8 +19,10 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductColorReposito
 import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
+import or.sopt.houme.domain.furniture.service.event.CurationRawProductTokenRefreshEvent;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -47,6 +49,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
     private final CurationRawProductColorRepository curationRawProductColorRepository;
     private final CurationRawProductFurnitureTagRepository curationRawProductFurnitureTagRepository;
     private final FurnitureTagRepository furnitureTagRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -119,6 +122,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
         try {
             CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
+            eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
             throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
@@ -156,6 +160,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
                     request.isExposed()
             );
             CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
+            eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
             throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationProductTokenEventListener.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationProductTokenEventListener.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.domain.furniture.service.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.domain.furniture.service.CurationProductTokenService;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CurationProductTokenEventListener {
+
+    private final CurationProductTokenService curationProductTokenService;
+
+    @EventListener
+    @Async("tokenRefreshExecutor")
+    public void handleTokenRefresh(CurationRawProductTokenRefreshEvent event) {
+        try {
+            curationProductTokenService.refreshTokensForProducts(event.productIds());
+        } catch (Exception e) {
+            log.error("search_tokens 갱신 실패 (productIds={}): {}", event.productIds(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationProductTokenEventListener.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationProductTokenEventListener.java
@@ -3,9 +3,10 @@ package or.sopt.houme.domain.furniture.service.event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.furniture.service.CurationProductTokenService;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -14,7 +15,7 @@ public class CurationProductTokenEventListener {
 
     private final CurationProductTokenService curationProductTokenService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async("tokenRefreshExecutor")
     public void handleTokenRefresh(CurationRawProductTokenRefreshEvent event) {
         try {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationRawProductTokenRefreshEvent.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/event/CurationRawProductTokenRefreshEvent.java
@@ -1,0 +1,5 @@
+package or.sopt.houme.domain.furniture.service.event;
+
+import java.util.List;
+
+public record CurationRawProductTokenRefreshEvent(List<Long> productIds) {}

--- a/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
+++ b/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package or.sopt.houme.global.api;
 
 import io.sentry.Sentry;
 import or.sopt.houme.global.api.handler.ImageFallbackException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -115,6 +116,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodValidationException(HandlerMethodValidationException e) {
+        ErrorCode errorCode = ErrorCode.NOT_VALID_EXCEPTION;
+
+        Sentry.captureException(e);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.fail(errorCode.getCode(), errorCode.getMsg()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
         ErrorCode errorCode = ErrorCode.NOT_VALID_EXCEPTION;
 
         Sentry.captureException(e);

--- a/src/main/java/or/sopt/houme/global/config/AsyncConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/AsyncConfig.java
@@ -50,6 +50,17 @@ public class AsyncConfig {
         this.virtualConcurrencyLimit = virtualConcurrencyLimit;
     }
 
+    @Bean(name = "tokenRefreshExecutor")
+    public Executor tokenRefreshExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("TokenRefresh-");
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "imageGenerationExecutor")
     public Executor imageGenerationExecutor(){
         if ("virtual".equalsIgnoreCase(executorMode)) {

--- a/src/main/java/or/sopt/houme/global/config/AsyncConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,7 +20,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@EnableAsync    // 비동기 기능 활성화
+@Slf4j
+@EnableAsync
 @Configuration
 public class AsyncConfig {
 
@@ -57,6 +59,9 @@ public class AsyncConfig {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("TokenRefresh-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.setRejectedExecutionHandler((r, e) -> log.warn("TokenRefresh 큐 포화 — 토큰 갱신 작업 유실 (active={}, queue={})", e.getActiveCount(), e.getQueue().size()));
         executor.initialize();
         return executor;
     }

--- a/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/SecurityConfig.java
@@ -111,6 +111,7 @@ public class SecurityConfig {
                 .requestMatchers(WhiteListConfig.exploreWhiteList().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.monitoringWhiteList().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.adminWhiteList().toArray(new String[0])).permitAll()
+                .requestMatchers(WhiteListConfig.curationWhiteList().toArray(new String[0])).permitAll()
                 .anyRequest().authenticated());
 
 

--- a/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
@@ -75,6 +75,14 @@ public class WhiteListConfig {
         );
     }
 
+    // 상품 탭 관련 인가 설정
+    public static final List<String> curationWhiteList() {
+        return List.of(
+                "/api/v1/curations/products",
+                "/api/v1/curations/products/**"
+        );
+    }
+
     public static final List<String> adminWhiteList() {
         return List.of(
                 "/api/v1/admin/register",

--- a/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/WhiteListConfig.java
@@ -79,7 +79,9 @@ public class WhiteListConfig {
     public static final List<String> curationWhiteList() {
         return List.of(
                 "/api/v1/curations/products",
-                "/api/v1/curations/products/**"
+                "/api/v1/curations/products/**",
+                "/api/v2/curations/products",
+                "/api/v2/curations/products/**"
         );
     }
 

--- a/src/main/java/or/sopt/houme/global/jwt/JWTFilter.java
+++ b/src/main/java/or/sopt/houme/global/jwt/JWTFilter.java
@@ -15,14 +15,18 @@ import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.config.JWTConfig;
+import or.sopt.houme.global.config.WhiteListConfig;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
 
 
 /**
@@ -34,12 +38,29 @@ import java.io.IOException;
  * */
 @RequiredArgsConstructor
 @Component
-public class JWTFilter extends OncePerRequestFilter{
+public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
     private final JWTConfig jwtConfig;
     private final BlacklistTokenRepository blacklistTokenRepository;
     private final CustomUserDetailsService customUserDetailsService;
+
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private static final List<String> ALL_WHITELIST = Stream.of(
+            WhiteListConfig.swaggerWhitelist(),
+            WhiteListConfig.oauthWhitelist(),
+            WhiteListConfig.serverWhitelist(),
+            WhiteListConfig.makeHouseWhitelist(),
+            WhiteListConfig.userWhiteList(),
+            WhiteListConfig.exploreWhiteList(),
+            WhiteListConfig.monitoringWhiteList(),
+            WhiteListConfig.adminWhiteList(),
+            WhiteListConfig.curationWhiteList()
+    ).flatMap(List::stream).toList();
+
+    private boolean isWhitelisted(String uri) {
+        return ALL_WHITELIST.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -89,21 +110,30 @@ public class JWTFilter extends OncePerRequestFilter{
             // 블랙리스트 검사
             String jti = jwtUtil.getJti(accessToken);
             if (blacklistTokenRepository.exists(jti)) {
+                if (isWhitelisted(request.getRequestURI())) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 setErrorResponse(response, ErrorCode.ACCESS_TOKEN_BLACKLISTED);
                 return;
             }
 
-
             String category = jwtUtil.getCategory(accessToken);
             if (!"access".equals(category)) {
+                if (isWhitelisted(request.getRequestURI())) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 setErrorResponse(response, ErrorCode.ACCESS_INVALID_TYPE);
-
                 return;
             }
 
         } catch (ExpiredJwtException e) {
+            if (isWhitelisted(request.getRequestURI())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
             setErrorResponse(response, ErrorCode.ACCESS_TOKEN_EXPIRED);
-
             return;
         }
 

--- a/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
@@ -7,10 +7,13 @@ import or.sopt.houme.global.jwt.JWTFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import or.sopt.houme.global.api.GlobalExceptionHandler;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @DisplayName("상품 큐레이션 v2 컨트롤러 테스트")
+@Import(ValidationAutoConfiguration.class)
 @WebMvcTest(controllers = CurationProductV2Controller.class, excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
                 JWTFilter.class

--- a/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
@@ -1,0 +1,93 @@
+package or.sopt.houme.domain.furniture.presentation.controller;
+
+import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductListResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductMetaResponse;
+import or.sopt.houme.domain.furniture.service.CurationProductService;
+import or.sopt.houme.global.jwt.JWTFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@DisplayName("상품 큐레이션 v2 컨트롤러 테스트")
+@WebMvcTest(controllers = CurationProductV2Controller.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                JWTFilter.class
+        })
+})
+class CurationProductV2ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CurationProductService curationProductService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /api/v2/curations/products - 키워드 없이 호출 시 200 응답과 명세서 규격을 준수한다")
+    void getProducts_withoutKeyword() throws Exception {
+        // given
+        CurationProductListResponse mockResponse = new CurationProductListResponse(
+                List.of(),
+                new CurationProductMetaResponse(null, false, List.of())
+        );
+        given(curationProductService.getProductsV2(any(), any(), any(), any(), any(), any()))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/curations/products"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"))
+                .andExpect(jsonPath("$.data.products").isArray())
+                .andExpect(jsonPath("$.data.meta.hasNext").value(false))
+                .andExpect(jsonPath("$.data.meta.appliedFilters").isArray());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /api/v2/curations/products - 키워드 검색 시 서비스에 keyword 파라미터가 전달된다")
+    void getProducts_withKeyword() throws Exception {
+        // given
+        CurationProductListResponse mockResponse = new CurationProductListResponse(
+                List.of(),
+                new CurationProductMetaResponse(null, false, List.of())
+        );
+        given(curationProductService.getProductsV2(eq("매트리스"), any(), any(), any(), any(), any()))
+                .willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/curations/products").param("keyword", "매트리스"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /api/v2/curations/products - size가 100을 초과하면 400을 반환한다")
+    void getProducts_invalidSizeReturns400() throws Exception {
+        mockMvc.perform(get("/api/v2/curations/products").param("size", "101"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -124,6 +124,48 @@ class CurationProductServiceImplTest {
     }
 
     @Test
+    @DisplayName("getProductsV2()는 v2 레포지토리 메서드를 호출하여 토큰 기반 검색 결과를 반환한다")
+    void getProductsV2() {
+        // given
+        String keyword = "매트리스";
+        Integer size = 20;
+
+        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
+        given(furnitureRepository.findAll()).willReturn(List.of());
+
+        CurationRawProduct product = CurationRawProduct.builder()
+                .id(99L)
+                .productId(3003L)
+                .productName("SS매트리스 침대")
+                .discountPrice(200000L)
+                .isExposed(true)
+                .furnitureTagMappings(new HashSet<>())
+                .build();
+        product.updateSearchTokens("SS매트리스 침대 SS 매트리스");
+
+        Slice<CurationRawProduct> slice = new SliceImpl<>(
+                List.of(product),
+                PageRequest.of(0, size),
+                false
+        );
+
+        given(curationRawProductRepository.findAllByCurationFiltersV2(
+                eq(keyword), any(), any(), any(), any(), any()
+        )).willReturn(slice);
+
+        // when
+        CurationProductListResponse response = curationProductService.getProductsV2(
+                keyword, null, null, null, null, size
+        );
+
+        // then
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().get(0).name()).isEqualTo("SS매트리스 침대");
+        assertThat(response.meta().hasNext()).isFalse();
+    }
+
+    @Test
     @DisplayName("getProductDetail()은 다중 매핑 시 우선순위가 가장 높은 카테고리명을 반환한다")
     void getProductDetail_withMultipleTags() {
         // given

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -130,10 +130,6 @@ class CurationProductServiceImplTest {
         String keyword = "매트리스";
         Integer size = 20;
 
-        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
-        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
-        given(furnitureRepository.findAll()).willReturn(List.of());
-
         CurationRawProduct product = CurationRawProduct.builder()
                 .id(99L)
                 .productId(3003L)

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
@@ -99,6 +99,6 @@ class CurationProductTokenServiceTest {
     void refreshTokensForProducts_doesNothingForEmptyList() {
         curationProductTokenService.refreshTokensForProducts(List.of());
 
-        verify(curationRawProductRepository, org.mockito.Mockito.never()).findAllById(anyList());
+        verify(curationRawProductRepository, org.mockito.Mockito.never()).findAllByIdWithFurnitureTags(anyList());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
@@ -1,0 +1,104 @@
+package or.sopt.houme.domain.furniture.service;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationProductSearchKeyword;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.repository.CurationProductSearchKeywordRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CurationProductTokenService 단위 테스트")
+class CurationProductTokenServiceTest {
+
+    @InjectMocks
+    private CurationProductTokenService curationProductTokenService;
+
+    @Mock
+    private CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    private CurationProductSearchKeywordRepository searchKeywordRepository;
+
+    @Mock
+    private CurationProductTokenizer tokenizer;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("refreshTokensForProducts()는 각 상품의 search_tokens를 갱신하고 저장한다")
+    void refreshTokensForProducts_updatesAndSaves() {
+        // given
+        CurationRawProduct product = CurationRawProduct.builder()
+                .id(1L)
+                .productId(100L)
+                .productName("퀸 침대 프레임")
+                .brand("이케아")
+                .isExposed(true)
+                .furnitureTagMappings(new HashSet<>())
+                .build();
+
+        given(curationRawProductRepository.findAllById(List.of(1L))).willReturn(List.of(product));
+        given(searchKeywordRepository.findAllByCurationRawProductIdIn(anyList())).willReturn(List.of());
+        given(tokenizer.buildTokens(any(), any(), anyList(), anyList())).willReturn("퀸 침대 프레임 이케아");
+
+        // when
+        curationProductTokenService.refreshTokensForProducts(List.of(1L));
+
+        // then
+        assertThat(product.getSearchTokens()).isEqualTo("퀸 침대 프레임 이케아");
+        verify(curationRawProductRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("refreshTokensForProducts()는 커스텀 키워드를 포함하여 토크나이저를 호출한다")
+    void refreshTokensForProducts_passesCustomKeywordsToTokenizer() {
+        // given
+        CurationRawProduct product = CurationRawProduct.builder()
+                .id(1L)
+                .productId(100L)
+                .productName("침대")
+                .isExposed(true)
+                .furnitureTagMappings(new HashSet<>())
+                .build();
+
+        CurationProductSearchKeyword keyword = CurationProductSearchKeyword.of(product, "1인용침대");
+
+        given(curationRawProductRepository.findAllById(List.of(1L))).willReturn(List.of(product));
+        given(searchKeywordRepository.findAllByCurationRawProductIdIn(anyList())).willReturn(List.of(keyword));
+        given(tokenizer.buildTokens(any(), any(), anyList(), anyList())).willReturn("침대 1인용침대");
+
+        ArgumentCaptor<List<String>> customKeywordsCaptor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        curationProductTokenService.refreshTokensForProducts(List.of(1L));
+
+        // then
+        verify(tokenizer).buildTokens(any(), any(), anyList(), customKeywordsCaptor.capture());
+        assertThat(customKeywordsCaptor.getValue()).contains("1인용침대");
+    }
+
+    @Test
+    @DisplayName("refreshTokensForProducts()는 빈 리스트 입력 시 아무것도 처리하지 않는다")
+    void refreshTokensForProducts_doesNothingForEmptyList() {
+        curationProductTokenService.refreshTokensForProducts(List.of());
+
+        verify(curationRawProductRepository, org.mockito.Mockito.never()).findAllById(anyList());
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenServiceTest.java
@@ -54,7 +54,7 @@ class CurationProductTokenServiceTest {
                 .furnitureTagMappings(new HashSet<>())
                 .build();
 
-        given(curationRawProductRepository.findAllById(List.of(1L))).willReturn(List.of(product));
+        given(curationRawProductRepository.findAllByIdWithFurnitureTags(List.of(1L))).willReturn(List.of(product));
         given(searchKeywordRepository.findAllByCurationRawProductIdIn(anyList())).willReturn(List.of());
         given(tokenizer.buildTokens(any(), any(), anyList(), anyList())).willReturn("퀸 침대 프레임 이케아");
 
@@ -80,7 +80,7 @@ class CurationProductTokenServiceTest {
 
         CurationProductSearchKeyword keyword = CurationProductSearchKeyword.of(product, "1인용침대");
 
-        given(curationRawProductRepository.findAllById(List.of(1L))).willReturn(List.of(product));
+        given(curationRawProductRepository.findAllByIdWithFurnitureTags(List.of(1L))).willReturn(List.of(product));
         given(searchKeywordRepository.findAllByCurationRawProductIdIn(anyList())).willReturn(List.of(keyword));
         given(tokenizer.buildTokens(any(), any(), anyList(), anyList())).willReturn("침대 1인용침대");
 

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
@@ -1,0 +1,96 @@
+package or.sopt.houme.domain.furniture.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CurationProductTokenizer 단위 테스트")
+class CurationProductTokenizerTest {
+
+    private CurationProductTokenizer tokenizer;
+
+    @BeforeEach
+    void setUp() {
+        tokenizer = new CurationProductTokenizer();
+    }
+
+    @Test
+    @DisplayName("상품명의 공백으로 분리된 단어들이 각각 토큰으로 포함된다")
+    void buildTokens_includesSpaceSplitWords() {
+        String result = tokenizer.buildTokens("원목 퀸 침대", null, List.of(), List.of());
+
+        assertThat(result).contains("원목");
+        assertThat(result).contains("퀸");
+        assertThat(result).contains("침대");
+    }
+
+    @Test
+    @DisplayName("한글/영문 경계의 복합어가 분리된 토큰으로 추가된다")
+    void buildTokens_splitsKoreanEnglishBoundary() {
+        // "SS매트리스" → "SS" + "매트리스" 모두 포함
+        String result = tokenizer.buildTokens("SS매트리스", null, List.of(), List.of());
+
+        assertThat(result).contains("SS매트리스");
+        assertThat(result).contains("SS");
+        assertThat(result).contains("매트리스");
+    }
+
+    @Test
+    @DisplayName("숫자/한글 경계의 복합어가 분리된 토큰으로 추가된다")
+    void buildTokens_splitsNumberKoreanBoundary() {
+        // "3인용소파" → "3인용" + "소파" 모두 포함
+        String result = tokenizer.buildTokens("3인용소파", null, List.of(), List.of());
+
+        assertThat(result).contains("3인용소파");
+        assertThat(result).contains("소파");
+    }
+
+    @Test
+    @DisplayName("브랜드명이 토큰에 포함된다")
+    void buildTokens_includesBrand() {
+        String result = tokenizer.buildTokens("침대 프레임", "이케아", List.of(), List.of());
+
+        assertThat(result).contains("이케아");
+    }
+
+    @Test
+    @DisplayName("가구 유형명이 토큰에 포함된다")
+    void buildTokens_includesFurnitureTypeNames() {
+        String result = tokenizer.buildTokens("제품명", null, List.of("침대/프레임", "소파"), List.of());
+
+        assertThat(result).contains("침대/프레임");
+        assertThat(result).contains("소파");
+    }
+
+    @Test
+    @DisplayName("커스텀 키워드가 토큰에 포함된다")
+    void buildTokens_includesCustomKeywords() {
+        String result = tokenizer.buildTokens("제품명", null, List.of(), List.of("1인소파", "좌식의자"));
+
+        assertThat(result).contains("1인소파");
+        assertThat(result).contains("좌식의자");
+    }
+
+    @Test
+    @DisplayName("null 또는 빈 값은 토큰에 포함되지 않는다")
+    void buildTokens_ignoresNullAndBlank() {
+        String result = tokenizer.buildTokens(null, "  ", List.of(null, ""), List.of());
+
+        assertThat(result).isBlank();
+    }
+
+    @Test
+    @DisplayName("중복 토큰은 한 번만 포함된다")
+    void buildTokens_deduplicatesTokens() {
+        String result = tokenizer.buildTokens("침대 침대", null, List.of("침대"), List.of("침대"));
+
+        long count = List.of(result.split(" ")).stream()
+                .filter("침대"::equals)
+                .count();
+        assertThat(count).isEqualTo(1);
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +79,7 @@ class CurationProductTokenizerTest {
     @Test
     @DisplayName("null 또는 빈 값은 토큰에 포함되지 않는다")
     void buildTokens_ignoresNullAndBlank() {
-        String result = tokenizer.buildTokens(null, "  ", List.of(null, ""), List.of());
+        String result = tokenizer.buildTokens(null, "  ", Arrays.asList(null, ""), List.of());
 
         assertThat(result).isBlank();
     }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
@@ -35,8 +35,8 @@ class CurationProductTokenizerTest {
         // "SS매트리스" → "SS" + "매트리스" 모두 포함
         String result = tokenizer.buildTokens("SS매트리스", null, List.of(), List.of());
 
-        assertThat(result).contains("SS매트리스");
-        assertThat(result).contains("SS");
+        assertThat(result).contains("ss매트리스");
+        assertThat(result).contains("ss");
         assertThat(result).contains("매트리스");
     }
 

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductTokenizerTest.java
@@ -32,22 +32,25 @@ class CurationProductTokenizerTest {
     @Test
     @DisplayName("한글/영문 경계의 복합어가 분리된 토큰으로 추가된다")
     void buildTokens_splitsKoreanEnglishBoundary() {
-        // "SS매트리스" → "SS" + "매트리스" 모두 포함
+        // "SS매트리스" → "ss매트리스" + "ss" + "매트리스" 모두 토큰으로 포함
         String result = tokenizer.buildTokens("SS매트리스", null, List.of(), List.of());
+        List<String> tokens = List.of(result.split(" "));
 
-        assertThat(result).contains("ss매트리스");
-        assertThat(result).contains("ss");
-        assertThat(result).contains("매트리스");
+        assertThat(tokens).contains("ss매트리스");
+        assertThat(tokens).contains("ss");
+        assertThat(tokens).contains("매트리스");
     }
 
     @Test
-    @DisplayName("숫자/한글 경계의 복합어가 분리된 토큰으로 추가된다")
+    @DisplayName("숫자/한글 경계의 복합어는 경계에서 분리된다")
     void buildTokens_splitsNumberKoreanBoundary() {
-        // "3인용소파" → "3인용" + "소파" 모두 포함
+        // "3인용소파" → 한글/비한글 경계: "3" + "인용소파" 로 분리됨
         String result = tokenizer.buildTokens("3인용소파", null, List.of(), List.of());
+        List<String> tokens = List.of(result.split(" "));
 
-        assertThat(result).contains("3인용소파");
-        assertThat(result).contains("소파");
+        assertThat(tokens).contains("3인용소파");
+        assertThat(tokens).contains("3");
+        assertThat(tokens).contains("인용소파");
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -29,6 +29,7 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagR
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
+import org.springframework.context.ApplicationEventPublisher;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
 
@@ -62,6 +63,9 @@ class AdminCurationRawProductServiceImplTest {
 
     @Mock
     private FurnitureTagRepository furnitureTagRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private AdminCurationRawProductServiceImpl adminCurationRawProductService;


### PR DESCRIPTION
## 📣 Related Issue

- close #491

## 📝 Summary

- `CurationRawProduct`에 `search_tokens` (TEXT) 컬럼 추가
- `CurationProductSearchKeyword` 엔티티 생성 — 어드민 설정 커스텀 키워드 매핑
- `CurationProductTokenizer` 구현 — 상품명/브랜드/가구유형명/커스텀 키워드 토큰화, 한글·영문·숫자 경계 복합어 분리 (ex. `SS매트리스` → `SS` + `매트리스`)
- Spring Event 기반 비동기 토큰 갱신 (`@EventListener` + `@Async`) — 상품 저장/수정 시 응답 속도 영향 없음
- `ApplicationRunner` 기반 기존 상품 `search_tokens` 백필 + `pg_trgm` GIN 인덱스 초기화
- `CurationRawProductRepositoryCustom`에 v2 검색 메서드 추가 (`search_tokens LIKE '%keyword%'`)
- `/api/v2/curations/products` 컨트롤러/서비스 구현 — v1과 동일한 응답 포맷, 엔드포인트만 변경
- `GlobalExceptionHandler`에 `ConstraintViolationException` 핸들러 추가 (누락 버그 수정)
- 단위 테스트 추가: `CurationProductTokenizerTest`, `CurationProductTokenServiceTest`, `CurationProductV2ControllerTest`, `CurationProductServiceImplTest`

## 🙏 Question & PR point

- v2는 v1과 동일한 필터/페이징 파라미터를 유지하며, 검색 로직만 `search_tokens` 기반으로 교체되었습니다.
- `search_tokens`는 nullable 컬럼으로 추가 후 서버 시작 시 백필이 자동 실행됩니다. prod 배포 시 첫 기동에 백필이 수행되므로, 상품 수에 따라 시작 시간이 다소 길어질 수 있습니다.
- `pg_trgm` 확장은 superuser 권한이 필요합니다. RDS의 경우 master 계정으로 `CREATE EXTENSION IF NOT EXISTS pg_trgm;` 을 수동 실행해야 합니다.
- v2 개선 효과 검증: `소파` 검색 시 v1에서 누락되던 `id: 470` (상품명에 소파 없음, 가구 유형 태그로만 매핑)이 v2에서 추가 노출됨을 Swagger로 확인했습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 토큰 기반 검색(v2) API 추가(키워드, 타입/가격/색상 필터, 커서 페이징), 토큰 생성/갱신 서비스·토크나이저·이벤트 기반 백그라운드 처리 및 시작 시 일괄 백필러 추가
  * 커스텀 검색 키워드 저장 및 검색 토큰 필드 추가

* **Tests**
  * v2 컨트롤러·서비스·토크나이저·토큰 서비스 관련 단위/통합 테스트 추가

* **Chores**
  * .gitignore 업데이트

* **Stability**
  * 입력 검증 강화(size 제한 100), 전역 예외 처리 확장 및 인증 화이트리스트·안전한 널 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->