### PR TITLE
[FIX] 색상 필터 목록에 전체 항목 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -354,6 +354,7 @@ public class CurationProductServiceImpl implements CurationProductService {
     private List<ColorFilterResponse> getColorFilters() {
         java.util.Map<String, String> standardFilters = ColorHexMapper.getStandardColorFilters();
         java.util.List<ColorFilterResponse> responses = new java.util.ArrayList<>();
+        responses.add(new ColorFilterResponse(0L, "전체", null));
 
         long id = 1L;
         for (java.util.Map.Entry<String, String> entry : standardFilters.entrySet()) {


### PR DESCRIPTION
## 📣 Related Issue

- close #495

## 📝 Summary

- 상품 필터 조회 API 색상 목록에 `전체` 항목(id: 0) 누락 수정
- 가구 유형, 가격대 필터와 동일하게 `전체` 항목을 첫 번째로 반환하도록 추가

## 🙏 Question & PR point

- 없음

## 📬 Postman
<img width="590" height="514" alt="image" src="https://github.com/user-attachments/assets/2c38f15b-6a10-484b-ade3-605f1eb2bf79" />

<!-- postman 스크린샷을 첨부해주세요 -->