### PR TITLE
[CHORE] 랜딩 전체조회시 BannerId 함께 응답

### DIFF
--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
@@ -8,8 +8,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,7 +38,12 @@ import java.util.stream.Collectors;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "banners")
+@Table(
+        name = "banners",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_banners_banner_id", columnNames = "banner_id")
+        }
+)
 @Comment("스타일 배너 본체 정보")
 public class Banner extends BaseEntity {
 
@@ -73,6 +81,11 @@ public class Banner extends BaseEntity {
     @Comment("스타일 답변 칩 목록 JSON")
     private String styleAnswerChipsJson;
 
+    @ManyToOne
+    @JoinColumn(name = "banner_id")
+    @Comment("LANDING이 참조하는 BANNER")
+    private Banner linkedBanner;
+
     @OneToMany(mappedBy = "banner", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<BannerCurationRawProduct> bannerRawProducts = new ArrayList<>();
@@ -84,7 +97,8 @@ public class Banner extends BaseEntity {
             String styleDescription,
             String styleQuestion,
             String stylePrompt,
-            String styleAnswerChipsJson
+            String styleAnswerChipsJson,
+            Banner linkedBanner
     ) {
         return Banner.builder()
                 .bannerType(bannerType)
@@ -94,6 +108,7 @@ public class Banner extends BaseEntity {
                 .styleQuestion(styleQuestion)
                 .stylePrompt(stylePrompt)
                 .styleAnswerChipsJson(styleAnswerChipsJson)
+                .linkedBanner(linkedBanner)
                 .build();
     }
 
@@ -104,7 +119,8 @@ public class Banner extends BaseEntity {
             String styleDescription,
             String styleQuestion,
             String stylePrompt,
-            String styleAnswerChipsJson
+            String styleAnswerChipsJson,
+            Banner linkedBanner
     ) {
         this.bannerType = bannerType;
         this.bannerImageUrl = bannerImageUrl;
@@ -113,6 +129,7 @@ public class Banner extends BaseEntity {
         this.styleQuestion = styleQuestion;
         this.stylePrompt = stylePrompt;
         this.styleAnswerChipsJson = styleAnswerChipsJson;
+        this.linkedBanner = linkedBanner;
     }
 
     public void replaceRawProducts(List<BannerCurationRawProduct> mappings) {

--- a/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
+++ b/src/main/java/or/sopt/houme/domain/banner/model/entity/Banner.java
@@ -1,18 +1,6 @@
 package or.sopt.houme.domain.banner.model.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,7 +29,7 @@ import java.util.stream.Collectors;
 @Table(
         name = "banners",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_banners_banner_id", columnNames = "banner_id")
+                @UniqueConstraint(name = "uk_banners_banner_id", columnNames = "linked_banner_id")
         }
 )
 @Comment("스타일 배너 본체 정보")
@@ -81,8 +69,8 @@ public class Banner extends BaseEntity {
     @Comment("스타일 답변 칩 목록 JSON")
     private String styleAnswerChipsJson;
 
-    @ManyToOne
-    @JoinColumn(name = "banner_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "linked_banner_id")
     @Comment("LANDING이 참조하는 BANNER")
     private Banner linkedBanner;
 

--- a/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/LandingResponse.java
+++ b/src/main/java/or/sopt/houme/domain/banner/presentation/dto/response/LandingResponse.java
@@ -4,6 +4,7 @@ import or.sopt.houme.domain.banner.model.entity.Banner;
 
 public record LandingResponse(
         Long id,
+        Long bannerId,
         String name,
         String imageUrl
 ) {
@@ -11,6 +12,7 @@ public record LandingResponse(
     public static LandingResponse from(Banner banner) {
         return new LandingResponse(
                 banner.getId(),
+                banner.getLinkedBanner() != null ? banner.getLinkedBanner().getId() : null,
                 banner.getBannerTitle(),
                 banner.getBannerImageUrl()
         );

--- a/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface BannerRepositoryCustom {
     List<Banner> findAllWithRawProducts(BannerType bannerType, boolean includeLegacyBanner);
 
     List<Banner> findAllByIdInWithRawProducts(List<Long> bannerIds);
+
+    List<Banner> findAllLandingsWithLinkedBanner();
 }

--- a/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/banner/repository/BannerRepositoryImpl.java
@@ -86,6 +86,19 @@ public class BannerRepositoryImpl implements BannerRepositoryCustom {
         return List.copyOf(distinctById.values());
     }
 
+    @Override
+    public List<Banner> findAllLandingsWithLinkedBanner() {
+        QBanner banner = QBanner.banner;
+        QBanner linkedBanner = new QBanner("linkedBanner");
+
+        return queryFactory
+                .selectFrom(banner)
+                .leftJoin(banner.linkedBanner, linkedBanner).fetchJoin()
+                .where(banner.bannerType.eq(BannerType.LANDING))
+                .orderBy(banner.id.asc())
+                .fetch();
+    }
+
     private BooleanBuilder bannerTypeCondition(QBanner banner, BannerType bannerType, boolean includeLegacyBanner) {
         BooleanBuilder condition = new BooleanBuilder();
         condition.or(banner.bannerType.eq(bannerType));

--- a/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/banner/service/BannerServiceImpl.java
@@ -59,8 +59,7 @@ public class BannerServiceImpl implements BannerService {
     @Override
     public LandingListResponse getLandings() {
         return LandingListResponse.of(
-                bannerRepository.findAllWithRawProducts(BannerType.LANDING, false).stream()
-                        .sorted((left, right) -> Long.compare(left.getId(), right.getId()))
+                bannerRepository.findAllLandingsWithLinkedBanner().stream()
                         .map(LandingResponse::from)
                         .toList()
         );

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImpl.java
@@ -52,7 +52,8 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 adminBannerSupport.normalizeRequired(request.styleDescription()),
                 adminBannerSupport.normalizeRequired(request.styleQuestion()),
                 adminBannerSupport.normalizeRequired(request.stylePrompt()),
-                adminBannerSupport.toStyleAnswerChipsJson(styleAnswerChips)
+                adminBannerSupport.toStyleAnswerChipsJson(styleAnswerChips),
+                null
         );
         banner.replaceRawProducts(adminBannerSupport.buildMappings(banner, request.mappedRawProductIds(), requiredRawProducts));
         Banner savedBanner = bannerRepository.saveAndFlush(banner);
@@ -99,7 +100,8 @@ public class AdminBannerServiceImpl implements AdminBannerService {
                 request.styleDescription() != null ? adminBannerSupport.normalizeRequired(request.styleDescription()) : banner.getStyleDescription(),
                 request.styleQuestion() != null ? adminBannerSupport.normalizeRequired(request.styleQuestion()) : banner.getStyleQuestion(),
                 request.stylePrompt() != null ? adminBannerSupport.normalizeRequired(request.stylePrompt()) : banner.getStylePrompt(),
-                adminBannerSupport.toStyleAnswerChipsJson(targetChips)
+                adminBannerSupport.toStyleAnswerChipsJson(targetChips),
+                null
         );
         banner.replaceRawProducts(adminBannerSupport.buildMappings(banner, targetMappedRawProductIds, requiredRawProducts));
 

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminLandingServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminLandingServiceImpl.java
@@ -42,6 +42,7 @@ public class AdminLandingServiceImpl implements AdminLandingService {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         Banner savedLanding = bannerRepository.saveAndFlush(landing);
@@ -73,6 +74,7 @@ public class AdminLandingServiceImpl implements AdminLandingService {
                 BannerType.LANDING,
                 request.bannerImageUrl() != null ? adminBannerSupport.normalizeRequired(request.bannerImageUrl()) : landing.getBannerImageUrl(),
                 request.bannerTitle() != null ? adminBannerSupport.normalizeRequired(request.bannerTitle()) : landing.getBannerTitle(),
+                null,
                 null,
                 null,
                 null,

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
@@ -47,6 +47,7 @@ public class AdminStyleServiceImpl implements AdminStyleService {
                 adminBannerSupport.normalizeRequired(request.styleDescription()),
                 null,
                 adminBannerSupport.normalizeRequired(request.stylePrompt()),
+                null,
                 null
         );
         style.replaceRawProducts(adminBannerSupport.buildMappings(style, request.mappedRawProductIds(), requiredRawProducts));
@@ -92,6 +93,7 @@ public class AdminStyleServiceImpl implements AdminStyleService {
                 request.styleDescription() != null ? adminBannerSupport.normalizeRequired(request.styleDescription()) : style.getStyleDescription(),
                 null,
                 request.stylePrompt() != null ? adminBannerSupport.normalizeRequired(request.stylePrompt()) : style.getStylePrompt(),
+                null,
                 null
         );
         style.replaceRawProducts(adminBannerSupport.buildMappings(style, targetMappedRawProductIds, requiredRawProducts));

--- a/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
@@ -62,7 +62,7 @@ class BannerServiceImplTest {
                 null
         );
 
-        when(bannerRepository.findAllWithRawProducts(BannerType.LANDING, false)).thenReturn(List.of(landing));
+        when(bannerRepository.findAllLandingsWithLinkedBanner()).thenReturn(List.of(landing));
 
         LandingListResponse response = bannerService.getLandings();
 

--- a/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/banner/service/BannerServiceImplTest.java
@@ -58,6 +58,7 @@ class BannerServiceImplTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 
@@ -66,6 +67,7 @@ class BannerServiceImplTest {
         LandingListResponse response = bannerService.getLandings();
 
         assertThat(response.landings()).hasSize(1);
+        assertThat(response.landings().getFirst().bannerId()).isNull();
         assertThat(response.landings().getFirst().name()).isEqualTo("랜딩 제목");
         assertThat(response.landings().getFirst().imageUrl()).isEqualTo("https://landing-image");
     }

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminBannerServiceImplTest.java
@@ -133,7 +133,8 @@ class AdminBannerServiceImplTest {
                 "설명",
                 "질문",
                 "prompt",
-                "[]"
+                "[]",
+                null
         );
         ReflectionTestUtils.setField(banner, "id", 10L);
         ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));
@@ -185,7 +186,8 @@ class AdminBannerServiceImplTest {
                 "기존 설명",
                 "기존 질문",
                 "기존 프롬프트",
-                "[]"
+                "[]",
+                null
         );
         ReflectionTestUtils.setField(banner, "id", 11L);
         ReflectionTestUtils.setField(banner, "createdAt", LocalDateTime.of(2026, 3, 13, 12, 0));

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminLandingServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminLandingServiceImplTest.java
@@ -41,7 +41,7 @@ class AdminLandingServiceImplTest {
     @Test
     @DisplayName("create()는 랜딩을 생성한다")
     void create_success() {
-        Banner landing = Banner.create(BannerType.LANDING, "https://landing-image", "랜딩 제목", null, null, null, null);
+        Banner landing = Banner.create(BannerType.LANDING, "https://landing-image", "랜딩 제목", null, null, null, null, null);
         ReflectionTestUtils.setField(landing, "id", 30L);
         ReflectionTestUtils.setField(landing, "createdAt", LocalDateTime.of(2026, 3, 27, 12, 0));
         ReflectionTestUtils.setField(landing, "updatedAt", LocalDateTime.of(2026, 3, 27, 12, 5));
@@ -61,7 +61,7 @@ class AdminLandingServiceImplTest {
     @Test
     @DisplayName("update()는 랜딩을 수정한다")
     void update_success() {
-        Banner landing = Banner.create(BannerType.LANDING, "https://old-image", "기존 랜딩", null, null, null, null);
+        Banner landing = Banner.create(BannerType.LANDING, "https://old-image", "기존 랜딩", null, null, null, null, null);
         ReflectionTestUtils.setField(landing, "id", 31L);
         ReflectionTestUtils.setField(landing, "createdAt", LocalDateTime.of(2026, 3, 27, 12, 0));
         ReflectionTestUtils.setField(landing, "updatedAt", LocalDateTime.of(2026, 3, 27, 12, 5));
@@ -80,7 +80,7 @@ class AdminLandingServiceImplTest {
     @Test
     @DisplayName("getAll()은 랜딩 목록을 반환한다")
     void getAll_success() {
-        Banner landing = Banner.create(BannerType.LANDING, "https://landing-image", "랜딩 제목", null, null, null, null);
+        Banner landing = Banner.create(BannerType.LANDING, "https://landing-image", "랜딩 제목", null, null, null, null, null);
         ReflectionTestUtils.setField(landing, "id", 32L);
         ReflectionTestUtils.setField(landing, "createdAt", LocalDateTime.of(2026, 3, 27, 12, 0));
         ReflectionTestUtils.setField(landing, "updatedAt", LocalDateTime.of(2026, 3, 27, 12, 5));

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImplTest.java
@@ -56,6 +56,7 @@ class AdminStyleServiceImplTest {
                 "스타일 설명",
                 null,
                 "prompt",
+                null,
                 null
         );
         ReflectionTestUtils.setField(style, "id", 20L);
@@ -96,6 +97,7 @@ class AdminStyleServiceImplTest {
                 "기존 설명",
                 null,
                 "old prompt",
+                null,
                 null
         );
         ReflectionTestUtils.setField(style, "id", 21L);
@@ -162,7 +164,8 @@ class AdminStyleServiceImplTest {
                 "설명",
                 "질문",
                 "prompt",
-                "[]"
+                "[]",
+                null
         );
 
         when(bannerRepository.findByIdWithRawProducts(99L, BannerType.STYLE, false)).thenReturn(Optional.of(banner));
@@ -181,6 +184,7 @@ class AdminStyleServiceImplTest {
                 "설명",
                 null,
                 "prompt",
+                null,
                 null
         );
         ReflectionTestUtils.setField(style, "id", 30L);
@@ -194,7 +198,8 @@ class AdminStyleServiceImplTest {
                 "배너 설명",
                 "질문",
                 "prompt",
-                "[]"
+                "[]",
+                null
         );
         ReflectionTestUtils.setField(banner, "id", 31L);
 
@@ -217,7 +222,8 @@ class AdminStyleServiceImplTest {
                 "설명",
                 "질문",
                 "prompt",
-                "[]"
+                "[]",
+                null
         );
 
         when(bannerRepository.findByIdWithRawProducts(55L, BannerType.STYLE, false)).thenReturn(Optional.of(banner));


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #497 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 랜딩에서 탐색 탭으로 이동할 때, 사용자가 랜딩에서 선택한 이미지에 해당하는 배너가 배너 슬라이드의 첫 번째로 보이도록 하는 것이 기존 기획 의도였습니다.
이를 위해 배너 슬라이드 전체조회 API는 bannerId를 시작점으로 받도록 되어 있었지만, 실제로는 랜딩 전체조회 응답의 id를 그대로 넘기면 배너를 찾지 못하는 문제가 발생했습니다.

- 원인은 랜딩/배너 구조 변경입니다.
3주 전 논의에 따라 banners 테이블에서 banner_type으로 LANDING과 BANNER를 분리 관리하게 되면서, 기존처럼 하나의 레코드 ID를 공유하지 않고 landingId와 bannerId가 서로 다른 값이 되었습니다.
그 결과 랜딩 ID를 배너 조회 시작 ID로 사용하던 흐름이 깨졌습니다.

- 해결 방식은 랜딩-배너 1:1 명시 매핑입니다.
LANDING 레코드가 연결된 BANNER를 참조할 수 있도록 linkedBannerId(self-reference)를 추가했고, 랜딩 전체조회 응답에 해당 매핑의 bannerId를 함께 내려주도록 수정했습니다.
이제 클라이언트는 랜딩 목록에서 받은 bannerId를 배너 슬라이드 API에 전달하면, 의도한 배너를 첫 번째로 정확히 노출할 수 있습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
@gdbs1107 
- 해당 PR에서 랜딩과 배너의 1:1 매핑 추가 & 전체 조회 응답값 수정으로 프론트의 API 사용 흐름을 수정한 작업입니다.
- 다만 어드민에서 랜딩 생성 & 수정 시 bannerId를 지정하여 생성 & 수정할 수 있도록 해야할 것 같습니다!
- 후속 작업으로 어드민 API 수정해주시면 감사하겠습니다!!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 배너가 다른 배너를 참조하여 연결할 수 있는 기능이 추가되었습니다.
  * API 응답에 연결된 배너의 ID 정보가 포함됩니다(연결없으면 null).
  * 랜딩 배너 목록의 정렬이 내부 정렬 대신 저장소(서버) 기준으로 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->