### PR TITLE
[CHORE] 최근 사용 도면 데이터 응답 dto 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanItemResponse.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanItemResponse.java
@@ -10,6 +10,10 @@ public record RecentFloorPlanItemResponse(
         String view
 ) {
 
+    public static RecentFloorPlanItemResponse empty() {
+        return new RecentFloorPlanItemResponse(null, null, null, null, null);
+    }
+
     public static RecentFloorPlanItemResponse of(FloorPlan floorPlan, String imageUrl, String view) {
         return new RecentFloorPlanItemResponse(
                 floorPlan.getId(),

--- a/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanResponse.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanResponse.java
@@ -2,7 +2,7 @@ package or.sopt.houme.domain.house.presentation.floorPlan.dto.response;
 
 public record RecentFloorPlanResponse(
         Boolean hasRecentImage,
-        Object floorPlan
+        RecentFloorPlanItemResponse floorPlan
 ) {
 
     public static RecentFloorPlanResponse withRecent(RecentFloorPlanItemResponse floorPlan) {
@@ -10,6 +10,6 @@ public record RecentFloorPlanResponse(
     }
 
     public static RecentFloorPlanResponse noRecent() {
-        return new RecentFloorPlanResponse(Boolean.FALSE, Boolean.FALSE);
+        return new RecentFloorPlanResponse(Boolean.FALSE, RecentFloorPlanItemResponse.empty());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
@@ -4,6 +4,7 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.FloorPlanListResponse;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHouseTemplateDetailResponse;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHouseTemplateListResponse;
+import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.RecentFloorPlanResponse;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
 import or.sopt.houme.domain.house.repository.floorPlan.FloorPlanRepository;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
@@ -52,6 +53,20 @@ class FloorPlanServiceImplTest {
 
     @Mock
     FloorPlanEquilibriumJsonCodec floorPlanEquilibriumJsonCodec;
+
+    @Test
+    @DisplayName("최근 생성 이력이 없으면 floorPlan은 null 필드 객체로 반환한다")
+    void getRecentFloorPlan_returnsEmptyObjectWhenNoRecentImage() {
+        RecentFloorPlanResponse response = floorPlanService.getRecentFloorPlan(null);
+
+        assertThat(response.hasRecentImage()).isFalse();
+        assertThat(response.floorPlan()).isNotNull();
+        assertThat(response.floorPlan().id()).isNull();
+        assertThat(response.floorPlan().name()).isNull();
+        assertThat(response.floorPlan().imageUrl()).isNull();
+        assertThat(response.floorPlan().equilibrium()).isNull();
+        assertThat(response.floorPlan().view()).isNull();
+    }
 
     @Test
     @DisplayName("사용자가 입력한 값들을 토대로 도면 템플릿을 필터링해서 내려줄 수 있다.")


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #499 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 스웨거의 sheme에서 응답 dto의 floorPlan의 인터페이스가 정의되어있지 않아, 프론트에서 개발할때 불편한 부분이 있었습니다.
- 최근 사용 도면 데이터 조회 API의 응답은 최근 사용한 도면 데이터가 있을때와 없을때 두가지로 나뉩니다.
- 기존에는 생성 이력이 없는 경우, 응답 객체의 floorPlan을 생성하지 않고 false 값으로 응답했다면,
- 수정 이후에는 아래와 같이 응답 객체의 인터페이스는 유지하고 null값으로 채워 응답합니다.

<img width="413" height="750" alt="image" src="https://github.com/user-attachments/assets/aa691acf-21e7-406e-8526-c6c8a7ed59cb" />


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 최근 층계 평면도 응답 데이터 구조의 타입 안정성 개선 및 빈 응답 처리 메커니즘 강화

* **Tests**
  * 최근 층계 평면도 조회 시 null 입력에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->