### PR TITLE
[CHORE] 대시보드 가구 전체조회시 priroty값 삭제

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureCategoryGroup.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureCategoryGroup.java
@@ -1,6 +1,5 @@
 package or.sopt.houme.domain.furniture.presentation.dto.response;
 
-import or.sopt.houme.domain.furniture.presentation.dto.FurnitureItem;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
 
 import java.util.List;
@@ -10,10 +9,10 @@ public record FurnitureCategoryGroup(
         Long categoryId, // FurnitureType의 id
         String nameKr,  // 카테고리 한글명
         String nameEng, // 카테고리 영어명
-        List<FurnitureItem> furnitures
+        List<FurnitureCategoryItem> furnitures
 ) {
 
-    public static FurnitureCategoryGroup from(FurnitureType furnitureType, List<FurnitureItem> furnitures) {
+    public static FurnitureCategoryGroup from(FurnitureType furnitureType, List<FurnitureCategoryItem> furnitures) {
         return new FurnitureCategoryGroup(
                 furnitureType.getId(),
                 furnitureType.getNameKr(),

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureCategoryItem.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureCategoryItem.java
@@ -1,0 +1,17 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.presentation.dto.FurnitureItem;
+
+public record FurnitureCategoryItem(
+        Long id,
+        String code,
+        String label
+) {
+    public static FurnitureCategoryItem from(FurnitureItem item) {
+        return new FurnitureCategoryItem(
+                item.id(),
+                item.code(),
+                item.label()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -6,6 +6,7 @@ import or.sopt.houme.domain.furniture.infrastructure.client.NaverShopApiClient;
 import or.sopt.houme.domain.furniture.presentation.dto.ActivityItem;
 import or.sopt.houme.domain.furniture.presentation.dto.FurnitureItem;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoryItem;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoryGroup;
@@ -104,7 +105,11 @@ public class FurnitureServiceImpl implements FurnitureService {
                 )
                 .map(furnitureType -> {
                     // 없으면 빈 리스트
-                    List<FurnitureItem> items = furnitureByCategory.getOrDefault(furnitureType.getId(), Collections.emptyList());
+                    List<FurnitureCategoryItem> items = furnitureByCategory
+                            .getOrDefault(furnitureType.getId(), Collections.emptyList())
+                            .stream()
+                            .map(FurnitureCategoryItem::from)
+                            .toList();
                     return FurnitureCategoryGroup.from(furnitureType, items);
                 })
                 .toList();


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #501 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 대시보드 가구 전체조회시 priroty값 삭제

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 응답값 깔끔하게 주기 위한 간단한 PR입니다..!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **개선 사항**
  * 가구 카테고리 조회 API의 응답 데이터 구조를 최적화하여 불필요한 필드를 제거하고 더 간결한 정보(ID, 코드, 레이블)만 반환하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->