### PR TITLE
[CHORE] 이미지 생성 v4 응답시 이미지 url 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImage
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.OtherStyleGenerateImageResponse;
@@ -111,11 +112,11 @@ public class GenerateImageController {
     @Operation(summary = "V4 이미지 생성 API",
             description = "도면/뷰, 무드보드, 주요활동, 가구를 기반으로 Gemini 모델로 이미지 1장을 생성합니다.")
     @PostMapping("/v4/generated-images/generate")
-    public ResponseEntity<ApiResponse<BannerGenerateImageResponse>> generateImageV4ByGemini(
+    public ResponseEntity<ApiResponse<GenerateImageV4Response>> generateImageV4ByGemini(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid GenerateImageV4Request request
     ) {
-        BannerGenerateImageResponse response =
+        GenerateImageV4Response response =
                 generateImageFacade.generateImageV4ByGemini(userDetails.getUser(), request);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/GenerateImageV4Response.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/GenerateImageV4Response.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.generateImage.presentation.dto.response;
+
+public record GenerateImageV4Response(
+        Long imageId,
+        String imageUrl
+) {
+    public static GenerateImageV4Response of(Long imageId, String imageUrl) {
+        return new GenerateImageV4Response(imageId, imageUrl);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -6,6 +6,7 @@ import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
@@ -149,7 +150,7 @@ public class GenerateImageTransactionService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public BannerGenerateImageResponse saveV4ImageAndConfirmCredit(
+    public GenerateImageV4Response saveV4ImageAndConfirmCredit(
             User user,
             Credit lockedCredit,
             Long floorPlanId,
@@ -178,7 +179,7 @@ public class GenerateImageTransactionService {
 
         creditService.commitCreditDeletion(lockedCredit);
         userService.updateHasGeneratedImage(user);
-        return BannerGenerateImageResponse.of(generateImage.getId());
+        return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl());
     }
 
     private FloorPlan getFloorPlanOrThrow(House house) {

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -27,6 +27,7 @@ import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImage
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.OtherStyleGenerateImageResponse;
@@ -495,7 +496,7 @@ public class GenerateImageFacade {
         }
     }
 
-    public BannerGenerateImageResponse generateImageV4ByGemini(User user, GenerateImageV4Request request) {
+    public GenerateImageV4Response generateImageV4ByGemini(User user, GenerateImageV4Request request) {
         Credit lockedCredit = null;
 
         try {

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -21,6 +21,7 @@ import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerat
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
@@ -535,11 +536,12 @@ class GenerateImageFacadeTest {
                 eq(Activity.REMOTE_WORK),
                 eq(List.of(7L, 8L)),
                 eq(List.of(1L, 2L))
-        )).thenReturn(BannerGenerateImageResponse.of(999L));
+        )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image"));
 
-        BannerGenerateImageResponse response = generateImageFacade.generateImageV4ByGemini(user, request);
+        GenerateImageV4Response response = generateImageFacade.generateImageV4ByGemini(user, request);
 
         assertThat(response.imageId()).isEqualTo(999L);
+        assertThat(response.imageUrl()).isEqualTo("https://generated-image");
         verify(geminiImageService).createImageWithReferences(
                 any(),
                 argThat(urls -> urls.size() == 3


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #503

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이미지 생성 v4 응답시 이미지 url을 추가했습니다.
- 다른 목록형 이미지 결과와 달리 추천형은 이전의 큐레이션 API를 재사용하기 때문에, 추가적인 image Url 응답이 필요했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 개선**
  * 이미지 생성 v4 엔드포인트의 응답이 개선되었습니다. 이제 이미지 ID와 생성된 이미지 URL을 함께 반환합니다.

* **테스트**
  * 관련 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->