### PR TITLE
[CHORE] 회원가입 시, 반환되는 토큰 개수 5개로 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -49,7 +49,7 @@ import java.util.stream.IntStream;
 @Slf4j
 public class OAuthService {
 
-    private static final int SIGN_UP_CREDIT_COUNT = 1;
+    private static final int SIGN_UP_CREDIT_COUNT = 5;
     private static final String USER_NICKNAME_TAG_UNIQUE_CONSTRAINT = "uk_user_nickname_nickname_tag";
 
     private final KaKaoOAuthClient kaKaoOAuthClient;

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -71,7 +71,7 @@ import java.util.stream.IntStream;
 @Transactional
 public class UserServiceImpl implements UserService {
 
-    private static final int SIGN_UP_CREDIT_COUNT = 1;
+    private static final int SIGN_UP_CREDIT_COUNT = 5;
     private static final String USER_NICKNAME_TAG_UNIQUE_CONSTRAINT = "uk_user_nickname_nickname_tag";
 
     private final UserRepository userRepository;

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -562,7 +562,7 @@ class UserServiceImplTest {
         assertEquals(LocalDate.of(2000, 5, 15), dbUser.getBirthday());
 
         verify(creditRepository, times(1))
-                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 1));
+                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 5));
     }
 
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #505 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

토큰 개수를 5개로 조정했습니다.
구현하다보니, 하드코딩된 사항은 원래도 변동폭이 크지 않은 상수이니 괜찮지만 상수가 두군데에서 사용되고 있네요.

일단 급하니 이렇게 적용하고 추후에 이슈파서 이거 일원화 진행하도록 하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 신규 가입 시 기본 지급되는 크레딧 수를 1개에서 5개로 늘려, 사용자가 가입 직후 더 많은 서비스를 이용할 수 있습니다.
* **테스트**
  * 관련 단위 테스트를 갱신하여 새 크레딧 수(5개)를 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->