### PR TITLE
[CHORE] 이미지 생성 API 응답 통일 및 목록형 결과에서 imageUrl 제거

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/BannerGenerateImageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/BannerGenerateImageResponse.java
@@ -1,9 +1,11 @@
 package or.sopt.houme.domain.generateImage.presentation.dto.response;
 
 public record BannerGenerateImageResponse(
-        Long imageId
+        Long imageId,
+        String imageUrl,
+        boolean isMirror
 ) {
-    public static BannerGenerateImageResponse of(Long imageId) {
-        return new BannerGenerateImageResponse(imageId);
+    public static BannerGenerateImageResponse of(Long imageId, String imageUrl, boolean isMirror) {
+        return new BannerGenerateImageResponse(imageId, imageUrl, isMirror);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/GenerateImageV4Response.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/GenerateImageV4Response.java
@@ -2,9 +2,10 @@ package or.sopt.houme.domain.generateImage.presentation.dto.response;
 
 public record GenerateImageV4Response(
         Long imageId,
-        String imageUrl
+        String imageUrl,
+        boolean isMirror
 ) {
-    public static GenerateImageV4Response of(Long imageId, String imageUrl) {
-        return new GenerateImageV4Response(imageId, imageUrl);
+    public static GenerateImageV4Response of(Long imageId, String imageUrl, boolean isMirror) {
+        return new GenerateImageV4Response(imageId, imageUrl, isMirror);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/OtherStyleGenerateImageResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/response/OtherStyleGenerateImageResponse.java
@@ -1,9 +1,11 @@
 package or.sopt.houme.domain.generateImage.presentation.dto.response;
 
 public record OtherStyleGenerateImageResponse(
-        Long imageId
+        Long imageId,
+        String imageUrl,
+        boolean isMirror
 ) {
-    public static OtherStyleGenerateImageResponse of(Long imageId) {
-        return new OtherStyleGenerateImageResponse(imageId);
+    public static OtherStyleGenerateImageResponse of(Long imageId, String imageUrl, boolean isMirror) {
+        return new OtherStyleGenerateImageResponse(imageId, imageUrl, isMirror);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -146,7 +146,7 @@ public class GenerateImageTransactionService {
 
         creditService.commitCreditDeletion(lockedCredit);
         userService.updateHasGeneratedImage(user);
-        return BannerGenerateImageResponse.of(generateImage.getId());
+        return BannerGenerateImageResponse.of(generateImage.getId(), generateImage.getUrl(), isMirror);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -179,7 +179,7 @@ public class GenerateImageTransactionService {
 
         creditService.commitCreditDeletion(lockedCredit);
         userService.updateHasGeneratedImage(user);
-        return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl());
+        return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl(), isMirror);
     }
 
     private FloorPlan getFloorPlanOrThrow(House house) {

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -472,7 +472,7 @@ public class GenerateImageFacade {
                     imageUploadResponseDTO
             );
             log.info("스타일 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());
-            return OtherStyleGenerateImageResponse.of(response.imageId());
+            return OtherStyleGenerateImageResponse.of(response.imageId(), response.imageUrl(), response.isMirror());
         } catch (ValidException validException) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
                 creditService.rollbackCreditPending(lockedCredit);

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/controller/GenerateImageResultController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/controller/GenerateImageResultController.java
@@ -24,8 +24,8 @@ public class GenerateImageResultController {
 
     private final GenerateImageResultService generateImageResultService;
 
-    @Operation(summary = "이미지 & 선택한 아이템 조회 API",
-            description = "generation_type이 LIST인 생성 이미지에 대해 결과 이미지와 연결된 상품 목록을 조회합니다.")
+    @Operation(summary = "[목록형 결과] 선택한 아이템 조회 API",
+            description = "generation_type이 LIST인 생성 이미지에 대해 연결된 상품 목록을 조회합니다.")
     @GetMapping("/list-result/{imageId}/items")
     public ResponseEntity<ApiResponse<GenerateImageResultResponse>> getListResultItems(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -36,7 +36,7 @@ public class GenerateImageResultController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "방금 담은 스타일과 비슷한 상품 조회 API",
+    @Operation(summary = "[목록형 결과] 방금 담은 스타일과 비슷한 상품 조회 API",
             description = "generation_type이 LIST인 생성 이미지의 선택 상품을 기반으로 유사 상품을 최대 4개 조회합니다.")
     @GetMapping("/list-result/{imageId}/similar-items")
     public ResponseEntity<ApiResponse<SimilarItemsResponse>> getSimilarItems(
@@ -48,7 +48,7 @@ public class GenerateImageResultController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "00님이 고른 아이템이 포함된 이미지 조회 API",
+    @Operation(summary = "[목록형 결과] 00님이 고른 아이템이 포함된 이미지 조회 API",
             description = "요청 이미지의 선택 상품과 동일 상품이 포함된 다른 생성 이미지를 최신순으로 최대 10개 조회합니다.")
     @GetMapping("/list-result/{imageId}/related-images")
     public ResponseEntity<ApiResponse<RelatedImagesResponse>> getRelatedImages(

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GenerateImageResultResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GenerateImageResultResponse.java
@@ -4,17 +4,13 @@ import java.util.List;
 
 public record GenerateImageResultResponse(
         Long imageId,
-        String imageUrl,
-        boolean isMirror,
         List<GenerateImageResultProductResponse> products
 ) {
 
     public static GenerateImageResultResponse of(
             Long imageId,
-            String imageUrl,
-            boolean isMirror,
             List<GenerateImageResultProductResponse> products
     ) {
-        return new GenerateImageResultResponse(imageId, imageUrl, isMirror, products);
+        return new GenerateImageResultResponse(imageId, products);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -69,7 +69,6 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
         GenerateImage generateImage = generateImageService.findGenerateImage(imageId);
         validateListResultAccessible(generateImage);
 
-        boolean isMirror = resolveIsMirror(generateImage);
         List<CurationRawProduct> selectedProducts = resolveSelectedRawProducts(generateImage);
         Map<Long, List<ProductColorResponse>> colorsByRawProductId = buildColorsByRawProductId(selectedProducts);
         Set<Long> likedRawProductIds = resolveLikedRawProductIds(user, selectedProducts);
@@ -84,8 +83,6 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
 
         return GenerateImageResultResponse.of(
                 generateImage.getId(),
-                generateImage.getUrl(),
-                isMirror,
                 products
         );
     }

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
@@ -85,6 +85,8 @@ class GenerateImageTransactionServiceTest {
         );
 
         assertThat(response.imageId()).isEqualTo(101L);
+        assertThat(response.imageUrl()).isEqualTo("https://cdn.example.com/file.jpg");
+        assertThat(response.isMirror()).isTrue();
         verify(houseService).createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
         verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.LIST);
         verify(creditService).commitCreditDeletion(lockedCredit);

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -428,11 +428,13 @@ class GenerateImageFacadeTest {
                 eq(false),
                 any(),
                 eq(imageUploadResponseDTO)
-        )).thenReturn(BannerGenerateImageResponse.of(999L));
+        )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
 
         BannerGenerateImageResponse response = generateImageFacade.generateBannerImageByGemini(user, request);
 
         assertThat(response.imageId()).isEqualTo(999L);
+        assertThat(response.imageUrl()).isEqualTo("https://generated-image");
+        assertThat(response.isMirror()).isFalse();
         verify(generateImageTransactionService).saveBannerImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
@@ -536,12 +538,13 @@ class GenerateImageFacadeTest {
                 eq(Activity.REMOTE_WORK),
                 eq(List.of(7L, 8L)),
                 eq(List.of(1L, 2L))
-        )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image"));
+        )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
 
         GenerateImageV4Response response = generateImageFacade.generateImageV4ByGemini(user, request);
 
         assertThat(response.imageId()).isEqualTo(999L);
         assertThat(response.imageUrl()).isEqualTo("https://generated-image");
+        assertThat(response.isMirror()).isTrue();
         verify(geminiImageService).createImageWithReferences(
                 any(),
                 argThat(urls -> urls.size() == 3

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -167,8 +167,6 @@ class GenerateImageResultServiceImplTest {
         GenerateImageResultResponse response = generateImageResultService.getListResultItems(user, 1L);
 
         assertThat(response.imageId()).isEqualTo(1L);
-        assertThat(response.imageUrl()).isEqualTo("https://generated-image");
-        assertThat(response.isMirror()).isFalse();
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().getFirst().id()).isEqualTo(101L);
         assertThat(response.products().getFirst().name()).isEqualTo("테스트 상품");


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #508 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이미지 생성 v4, 배너 기반 이미지 생성, 다른 스타일 기반 이미지 생성 3개 API의 응답을 아래와 같이 통일합니다.
- "[목록형 결과] 이미지 & 선택한 아이템 조회"를 "[목록형 결과] 선택한 아이템 조회"로 수정하여 이미지url 응답을 제거합니다.
```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "imageId": 1,
	  "imageUrl": "https://google.com",
	  "isMirror": true
  }
}
```

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이미지 생성 응답에 이미지 URL 및 미러 정보 포함

* **문서화**
  * 목록형 결과 엔드포인트 설명 개선

* **테스트**
  * 응답 데이터 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->