### PR TITLE
[FEATURE] 이미지url 조회 API

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/controller/GenerateImageResultController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/controller/GenerateImageResultController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
+import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GeneratedImageMetaResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImagesResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.SimilarItemsResponse;
 import or.sopt.houme.domain.generateImageResult.service.GenerateImageResultService;
@@ -33,6 +34,18 @@ public class GenerateImageResultController {
     ) {
         GenerateImageResultResponse response =
                 generateImageResultService.getListResultItems(userDetails.getUser(), imageId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "이미지 URL/좌우반전 여부 조회 API",
+            description = "imageId로 생성 이미지 URL과 좌우반전 여부를 단일 조회합니다.")
+    @GetMapping("/{imageId}/meta")
+    public ResponseEntity<ApiResponse<GeneratedImageMetaResponse>> getGeneratedImageMeta(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long imageId
+    ) {
+        GeneratedImageMetaResponse response =
+                generateImageResultService.getGeneratedImageMeta(userDetails.getUser(), imageId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GeneratedImageMetaResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GeneratedImageMetaResponse.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.domain.generateImageResult.presentation.dto.response;
+
+public record GeneratedImageMetaResponse(
+        Long imageId,
+        String imageUrl,
+        boolean isMirror
+) {
+
+    public static GeneratedImageMetaResponse of(Long imageId, String imageUrl, boolean isMirror) {
+        return new GeneratedImageMetaResponse(imageId, imageUrl, isMirror);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultService.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.generateImageResult.service;
 
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
+import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GeneratedImageMetaResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImagesResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.SimilarItemsResponse;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -8,6 +9,8 @@ import or.sopt.houme.domain.user.model.entity.User;
 public interface GenerateImageResultService {
 
     GenerateImageResultResponse getListResultItems(User user, Long imageId);
+
+    GeneratedImageMetaResponse getGeneratedImageMeta(User user, Long imageId);
 
     SimilarItemsResponse getSimilarItems(User user, Long imageId);
 

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -22,6 +22,7 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultProductResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
+import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GeneratedImageMetaResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImageResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImagesResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.SimilarItemResponse;
@@ -84,6 +85,22 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
         return GenerateImageResultResponse.of(
                 generateImage.getId(),
                 products
+        );
+    }
+
+    @Override
+    public GeneratedImageMetaResponse getGeneratedImageMeta(User user, Long imageId) {
+        if (user == null) {
+            throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_RESULT_REQUEST);
+        }
+
+        GenerateImage generateImage = generateImageService.findGenerateImage(imageId);
+        boolean isMirror = resolveIsMirror(generateImage);
+
+        return GeneratedImageMetaResponse.of(
+                generateImage.getId(),
+                generateImage.getUrl(),
+                isMirror
         );
     }
 

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -28,6 +28,7 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
+import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GeneratedImageMetaResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.RelatedImagesResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.SimilarItemsResponse;
 import or.sopt.houme.domain.house.model.entity.House;
@@ -81,6 +82,27 @@ class GenerateImageResultServiceImplTest {
 
     @Mock
     private HouseService houseService;
+
+    @Test
+    @DisplayName("이미지 메타 조회 시 imageUrl과 isMirror를 반환한다")
+    void getGeneratedImageMeta_returnsImageUrlAndIsMirror() {
+        House house = House.builder().id(100L).build();
+        GenerateImage image = GenerateImage.builder()
+                .id(1L)
+                .url("https://generated-image")
+                .house(house)
+                .build();
+        User user = User.builder().id(1L).build();
+
+        when(generateImageService.findGenerateImage(1L)).thenReturn(image);
+        when(houseService.getIsMirrorByHouseId(100L)).thenReturn(true);
+
+        GeneratedImageMetaResponse response = generateImageResultService.getGeneratedImageMeta(user, 1L);
+
+        assertThat(response.imageId()).isEqualTo(1L);
+        assertThat(response.imageUrl()).isEqualTo("https://generated-image");
+        assertThat(response.isMirror()).isTrue();
+    }
 
     @Test
     @DisplayName("LIST 타입이 아닌 이미지 조회 요청이면 예외가 발생한다")


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #511

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이미지 URL과 좌우반전 여부를 조회하는 API 입니다.
- 이미지 URL을 이미지 생성시에만 응답하고 있는데,
  - 마이페이지에서 접근하는 경우에도 이미지 URL이 필요
  - 다른 추천형 & 목록형 결과 조회 API와 겹치는 부분이 존재하고 의미적으로 따로 구분하는 것이 유연한 설계인 것 같아 API를 분리하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 생성된 이미지의 메타데이터(URL 및 좌우 반전 상태)를 조회하는 새로운 API 엔드포인트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->