### PR TITLE
[FEATURE] 회원정보 조회 및 수정 API 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
@@ -81,6 +81,14 @@ public class User extends BaseEntity {
         this.gender = gender;
     }
 
+    public void updateMyPageProfile(String nickname, String nicknameTag, LocalDate birthday, Gender gender) {
+        this.nickname = nickname;
+        this.nicknameTag = nicknameTag;
+        this.name = nickname;
+        this.birthday = birthday;
+        this.gender = gender;
+    }
+
     public String getDisplayName() {
         if (nickname != null && !nickname.isBlank()) {
             return nickname;

--- a/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/User.java
@@ -82,11 +82,17 @@ public class User extends BaseEntity {
     }
 
     public void updateMyPageProfile(String nickname, String nicknameTag, LocalDate birthday, Gender gender) {
-        this.nickname = nickname;
-        this.nicknameTag = nicknameTag;
-        this.name = nickname;
-        this.birthday = birthday;
-        this.gender = gender;
+        if (nickname != null) {
+            this.nickname = nickname;
+            this.nicknameTag = nicknameTag;
+            this.name = nickname;
+        }
+        if (birthday != null) {
+            this.birthday = birthday;
+        }
+        if (gender != null) {
+            this.gender = gender;
+        }
     }
 
     public String getDisplayName() {

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
@@ -11,7 +11,7 @@ import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
 import or.sopt.houme.domain.user.presentation.controller.dto.SocialSignUpV2Request;
 import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileRequest;
-import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.MyPageProfileResponse;
 import or.sopt.houme.domain.user.service.NicknameService;
 import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.domain.user.service.UserService;
@@ -81,16 +81,26 @@ public class UserV2Controller {
         return ResponseEntity.ok(ApiResponse.ok(nicknameService.rotateNickname()));
     }
 
+    @GetMapping(value = "/mypage/user")
+    @Operation(summary = "마이페이지 프로필 조회 API")
+    public ResponseEntity<ApiResponse<MyPageProfileResponse>> getMyPageProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MyPageProfileResponse response = userService.getMyPageProfile(userDetails.getUser());
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
     @PatchMapping(value = "/mypage/user")
     @Operation(summary = "마이페이지 프로필 수정 API")
-    public ResponseEntity<ApiResponse<UpdateMyPageProfileResponse>> updateMyPageProfile(
+    public ResponseEntity<ApiResponse<MyPageProfileResponse>> updateMyPageProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UpdateMyPageProfileRequest request
     ) {
         Gender gender = request.gender() == null ? null : parseGender(request.gender());
         LocalDate birthday = request.birthday() == null ? null : parseBirthday(request.birthday());
 
-        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+        MyPageProfileResponse response = userService.updateMyPageProfile(
                 userDetails.getUser(),
                 request.nickname(),
                 gender,

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
@@ -87,8 +87,8 @@ public class UserV2Controller {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UpdateMyPageProfileRequest request
     ) {
-        Gender gender = parseGender(request.gender());
-        LocalDate birthday = parseBirthday(request.birthday());
+        Gender gender = request.gender() == null ? null : parseGender(request.gender());
+        LocalDate birthday = request.birthday() == null ? null : parseBirthday(request.birthday());
 
         UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
                 userDetails.getUser(),

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/UserV2Controller.java
@@ -10,6 +10,8 @@ import or.sopt.houme.domain.user.presentation.controller.dto.CreateUserV2Request
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
 import or.sopt.houme.domain.user.presentation.controller.dto.SocialSignUpV2Request;
+import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileRequest;
+import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
 import or.sopt.houme.domain.user.service.NicknameService;
 import or.sopt.houme.domain.user.service.OAuthService;
 import or.sopt.houme.domain.user.service.UserService;
@@ -77,6 +79,25 @@ public class UserV2Controller {
     @Operation(summary = "닉네임 랜덤 생성 API")
     public ResponseEntity<ApiResponse<String>> rotateNickname() {
         return ResponseEntity.ok(ApiResponse.ok(nicknameService.rotateNickname()));
+    }
+
+    @PatchMapping(value = "/mypage/user")
+    @Operation(summary = "마이페이지 프로필 수정 API")
+    public ResponseEntity<ApiResponse<UpdateMyPageProfileResponse>> updateMyPageProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UpdateMyPageProfileRequest request
+    ) {
+        Gender gender = parseGender(request.gender());
+        LocalDate birthday = parseBirthday(request.birthday());
+
+        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+                userDetails.getUser(),
+                request.nickname(),
+                gender,
+                birthday
+        );
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @GetMapping(value = "/mypage/images")

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageProfileResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageProfileResponse.java
@@ -5,14 +5,14 @@ import or.sopt.houme.domain.user.model.entity.User;
 
 import java.time.LocalDate;
 
-public record UpdateMyPageProfileResponse(
+public record MyPageProfileResponse(
         Long userId,
         String nickname,
         LocalDate birthday,
         Gender gender
 ) {
-    public static UpdateMyPageProfileResponse from(User user) {
-        return new UpdateMyPageProfileResponse(
+    public static MyPageProfileResponse from(User user) {
+        return new MyPageProfileResponse(
                 user.getId(),
                 user.getNickname(),
                 user.getBirthday(),

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileRequest.java
@@ -1,0 +1,25 @@
+package or.sopt.houme.domain.user.presentation.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import or.sopt.houme.domain.user.presentation.valid.ValidBirthday;
+
+public record UpdateMyPageProfileRequest(
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "특수문자는 입력할 수 없어요.")
+        @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+        String nickname,
+
+        @NotBlank(message = "성별은 필수 입력값입니다.")
+        @Pattern(
+                regexp = "MALE|FEMALE|NONBINARY",
+                message = "성별은 MALE, FEMALE, NONBINARY 중 하나여야 해요."
+        )
+        String gender,
+
+        @NotBlank(message = "생년월일은 필수 입력값입니다.")
+        @ValidBirthday
+        String birthday
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileRequest.java
@@ -1,24 +1,20 @@
 package or.sopt.houme.domain.user.presentation.controller.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import or.sopt.houme.domain.user.presentation.valid.ValidBirthday;
 
 public record UpdateMyPageProfileRequest(
-        @NotBlank(message = "닉네임은 필수 입력값입니다.")
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "특수문자는 입력할 수 없어요.")
         @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
         String nickname,
 
-        @NotBlank(message = "성별은 필수 입력값입니다.")
         @Pattern(
                 regexp = "MALE|FEMALE|NONBINARY",
                 message = "성별은 MALE, FEMALE, NONBINARY 중 하나여야 해요."
         )
         String gender,
 
-        @NotBlank(message = "생년월일은 필수 입력값입니다.")
         @ValidBirthday
         String birthday
 ) {

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/UpdateMyPageProfileResponse.java
@@ -1,0 +1,22 @@
+package or.sopt.houme.domain.user.presentation.controller.dto;
+
+import or.sopt.houme.domain.user.model.entity.Gender;
+import or.sopt.houme.domain.user.model.entity.User;
+
+import java.time.LocalDate;
+
+public record UpdateMyPageProfileResponse(
+        Long userId,
+        String nickname,
+        LocalDate birthday,
+        Gender gender
+) {
+    public static UpdateMyPageProfileResponse from(User user) {
+        return new UpdateMyPageProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getBirthday(),
+                user.getGender()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/valid/BirthdayValidator.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/valid/BirthdayValidator.java
@@ -10,7 +10,8 @@ public class BirthdayValidator implements ConstraintValidator<ValidBirthday, Str
 
     @Override
     public boolean isValid(String birthdayStr, ConstraintValidatorContext context) {
-        if (birthdayStr == null || birthdayStr.isBlank()) return false;
+        if (birthdayStr == null) return true;
+        if (birthdayStr.isBlank()) return false;
 
         LocalDate birthday;
         try {

--- a/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
@@ -76,6 +76,21 @@ public class UserNicknameTagTransactionService {
         return user.getDisplayName();
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public User updateMyPageProfile(
+            Long userId,
+            String nickname,
+            String nicknameTag,
+            Gender gender,
+            LocalDate birthday
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateMyPageProfile(nickname, nicknameTag, birthday, gender);
+        return userRepository.saveAndFlush(user);
+    }
+
     private void createSignUpCredits(User user) {
         try {
             List<Credit> newCredits = IntStream.range(0, SIGN_UP_CREDIT_COUNT)

--- a/src/main/java/or/sopt/houme/domain/user/service/UserService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserService.java
@@ -3,7 +3,7 @@ package or.sopt.houme.domain.user.service;
 import or.sopt.houme.domain.user.presentation.controller.dto.ImageHistoriesResultPageResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageInfoResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
-import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.MyPageProfileResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.model.entity.Gender;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -21,13 +21,15 @@ public interface UserService {
      */
     MyPageGeneratedImageV2Response getUserGeneratedImageHistoryListV2(User user);
 
+    MyPageProfileResponse getMyPageProfile(User user);
+
     ImageHistoriesResultPageResponse getImageHistoryResultPage(User user, Long houseId);
 
     String updateUser(User user, String name, Gender gender, LocalDate birthday);
 
     String updateUserV2(User user, String nickname, Gender gender, LocalDate birthday);
 
-    UpdateMyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday);
+    MyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday);
 
     // 사용자 이미지 생성 여부 저장
     @Transactional

--- a/src/main/java/or/sopt/houme/domain/user/service/UserService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.user.service;
 import or.sopt.houme.domain.user.presentation.controller.dto.ImageHistoriesResultPageResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageInfoResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
+import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.model.entity.Gender;
 import or.sopt.houme.domain.user.model.entity.User;
@@ -25,6 +26,8 @@ public interface UserService {
     String updateUser(User user, String name, Gender gender, LocalDate birthday);
 
     String updateUserV2(User user, String nickname, Gender gender, LocalDate birthday);
+
+    UpdateMyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday);
 
     // 사용자 이미지 생성 여부 저장
     @Transactional

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -39,7 +39,7 @@ import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.presentation.controller.dto.ImageHistoriesResultPageResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageInfoResponse;
-import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.MyPageProfileResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryDTO;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.repository.UserRepository;
@@ -101,6 +101,13 @@ public class UserServiceImpl implements UserService {
         String name = findUser.getDisplayName();
         Long creditCount = userRepository.countByMemberIdAndStatus(findUser.getId());
         return MyPageInfoResponse.of(findUser.getId(), name, creditCount);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MyPageProfileResponse getMyPageProfile(User user) {
+        User findUser = findUser(user);
+        return MyPageProfileResponse.from(findUser);
     }
 
     @Override
@@ -313,7 +320,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public UpdateMyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday) {
+    public MyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday) {
         Long userId = user.getId();
         findUser(user);
 
@@ -325,7 +332,7 @@ public class UserServiceImpl implements UserService {
                     gender,
                     birthday
             );
-            return UpdateMyPageProfileResponse.from(updatedUser);
+            return MyPageProfileResponse.from(updatedUser);
         }
 
         return executeWithNicknameTagRetry(nickname, nicknameTag -> {
@@ -336,7 +343,7 @@ public class UserServiceImpl implements UserService {
                     gender,
                     birthday
             );
-            return UpdateMyPageProfileResponse.from(updatedUser);
+            return MyPageProfileResponse.from(updatedUser);
         });
     }
 

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -39,6 +39,7 @@ import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.presentation.controller.dto.ImageHistoriesResultPageResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageGeneratedImageV2Response;
 import or.sopt.houme.domain.user.presentation.controller.dto.MyPageInfoResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryDTO;
 import or.sopt.houme.domain.user.presentation.controller.dto.UserImageHistoryListResponse;
 import or.sopt.houme.domain.user.repository.UserRepository;
@@ -308,6 +309,33 @@ public class UserServiceImpl implements UserService {
                         gender,
                         birthday
                 );
+            } catch (DataIntegrityViolationException exception) {
+                if (!isNicknameTagConstraintViolation(exception)) {
+                    throw exception;
+                }
+            }
+        }
+
+        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public UpdateMyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday) {
+        Long userId = user.getId();
+        findUser(user);
+
+        for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
+            String nicknameTag = nicknameService.generateNicknameTag(nickname);
+            try {
+                User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
+                        userId,
+                        nickname,
+                        nicknameTag,
+                        gender,
+                        birthday
+                );
+                return UpdateMyPageProfileResponse.from(updatedUser);
             } catch (DataIntegrityViolationException exception) {
                 if (!isNicknameTagConstraintViolation(exception)) {
                     throw exception;

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -299,24 +300,15 @@ public class UserServiceImpl implements UserService {
         Long userId = user.getId();
         findUser(user);
 
-        for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
-            String nicknameTag = nicknameService.generateNicknameTag(nickname);
-            try {
-                return userNicknameTagTransactionService.completeUserSignUpV2(
+        return executeWithNicknameTagRetry(nickname, nicknameTag ->
+                userNicknameTagTransactionService.completeUserSignUpV2(
                         userId,
                         nickname,
                         nicknameTag,
                         gender,
                         birthday
-                );
-            } catch (DataIntegrityViolationException exception) {
-                if (!isNicknameTagConstraintViolation(exception)) {
-                    throw exception;
-                }
-            }
-        }
-
-        throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
+                )
+        );
     }
 
     @Override
@@ -325,17 +317,34 @@ public class UserServiceImpl implements UserService {
         Long userId = user.getId();
         findUser(user);
 
+        if (nickname == null) {
+            User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
+                    userId,
+                    null,
+                    null,
+                    gender,
+                    birthday
+            );
+            return UpdateMyPageProfileResponse.from(updatedUser);
+        }
+
+        return executeWithNicknameTagRetry(nickname, nicknameTag -> {
+            User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
+                    userId,
+                    nickname,
+                    nicknameTag,
+                    gender,
+                    birthday
+            );
+            return UpdateMyPageProfileResponse.from(updatedUser);
+        });
+    }
+
+    private <T> T executeWithNicknameTagRetry(String nickname, Function<String, T> nicknameTagCommand) {
         for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
             String nicknameTag = nicknameService.generateNicknameTag(nickname);
             try {
-                User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
-                        userId,
-                        nickname,
-                        nicknameTag,
-                        gender,
-                        birthday
-                );
-                return UpdateMyPageProfileResponse.from(updatedUser);
+                return nicknameTagCommand.apply(nicknameTag);
             } catch (DataIntegrityViolationException exception) {
                 if (!isNicknameTagConstraintViolation(exception)) {
                     throw exception;

--- a/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
@@ -6,6 +6,7 @@ import or.sopt.houme.domain.user.model.entity.Role;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetailsService;
+import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.service.NicknameService;
 import or.sopt.houme.domain.user.service.OAuthService;
@@ -147,5 +148,52 @@ class UserV2ControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").value("응답 성공"))
                 .andExpect(jsonPath("$.data").value("느긋한펭귄"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v2/mypage/user 요청 시 마이페이지 프로필을 수정한다")
+    void updateMyPageProfile_success() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        UsernamePasswordAuthenticationToken requestAuthentication =
+                new UsernamePasswordAuthenticationToken(
+                        new CustomUserDetails(user),
+                        null,
+                        List.of(() -> "ROLE_USER")
+                );
+
+        given(userService.updateMyPageProfile(
+                any(),
+                any(String.class),
+                any(Gender.class),
+                any(LocalDate.class)
+        )).willReturn(new UpdateMyPageProfileResponse(
+                1L,
+                "잠자는꾸민성1470",
+                LocalDate.of(2001, 1, 1),
+                Gender.FEMALE
+        ));
+
+        mockMvc.perform(patch("/api/v2/mypage/user")
+                        .with(authentication(requestAuthentication))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "잠자는꾸민성1470",
+                                  "gender": "FEMALE",
+                                  "birthday": "2001-01-01"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"))
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.nickname").value("잠자는꾸민성1470"))
+                .andExpect(jsonPath("$.data.birthday").value("2001-01-01"))
+                .andExpect(jsonPath("$.data.gender").value("FEMALE"));
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
@@ -6,7 +6,7 @@ import or.sopt.houme.domain.user.model.entity.Role;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetailsService;
-import or.sopt.houme.domain.user.presentation.controller.dto.UpdateMyPageProfileResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.MyPageProfileResponse;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.service.NicknameService;
 import or.sopt.houme.domain.user.service.OAuthService;
@@ -151,6 +151,41 @@ class UserV2ControllerTest {
     }
 
     @Test
+    @DisplayName("GET /api/v2/mypage/user 요청 시 마이페이지 프로필을 조회한다")
+    void getMyPageProfile_success() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        UsernamePasswordAuthenticationToken requestAuthentication =
+                new UsernamePasswordAuthenticationToken(
+                        new CustomUserDetails(user),
+                        null,
+                        List.of(() -> "ROLE_USER")
+                );
+
+        given(userService.getMyPageProfile(any()))
+                .willReturn(new MyPageProfileResponse(
+                        1L,
+                        "잠자는꾸민성1470",
+                        LocalDate.of(2001, 1, 1),
+                        Gender.FEMALE
+                ));
+
+        mockMvc.perform(get("/api/v2/mypage/user")
+                        .with(authentication(requestAuthentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"))
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.nickname").value("잠자는꾸민성1470"))
+                .andExpect(jsonPath("$.data.birthday").value("2001-01-01"))
+                .andExpect(jsonPath("$.data.gender").value("FEMALE"));
+    }
+
+    @Test
     @DisplayName("PATCH /api/v2/mypage/user 요청 시 마이페이지 프로필을 수정한다")
     void updateMyPageProfile_success() throws Exception {
         User user = User.builder()
@@ -171,7 +206,7 @@ class UserV2ControllerTest {
                 any(String.class),
                 any(Gender.class),
                 any(LocalDate.class)
-        )).willReturn(new UpdateMyPageProfileResponse(
+        )).willReturn(new MyPageProfileResponse(
                 1L,
                 "잠자는꾸민성1470",
                 LocalDate.of(2001, 1, 1),
@@ -218,7 +253,7 @@ class UserV2ControllerTest {
                 any(String.class),
                 any(),
                 any()
-        )).willReturn(new UpdateMyPageProfileResponse(
+        )).willReturn(new MyPageProfileResponse(
                 1L,
                 "새닉네임",
                 LocalDate.of(2001, 1, 1),

--- a/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserV2ControllerTest.java
@@ -196,4 +196,46 @@ class UserV2ControllerTest {
                 .andExpect(jsonPath("$.data.birthday").value("2001-01-01"))
                 .andExpect(jsonPath("$.data.gender").value("FEMALE"));
     }
+
+    @Test
+    @DisplayName("PATCH /api/v2/mypage/user 요청은 전달된 필드만 수정할 수 있다")
+    void updateMyPageProfile_partialSuccess() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        UsernamePasswordAuthenticationToken requestAuthentication =
+                new UsernamePasswordAuthenticationToken(
+                        new CustomUserDetails(user),
+                        null,
+                        List.of(() -> "ROLE_USER")
+                );
+
+        given(userService.updateMyPageProfile(
+                any(),
+                any(String.class),
+                any(),
+                any()
+        )).willReturn(new UpdateMyPageProfileResponse(
+                1L,
+                "새닉네임",
+                LocalDate.of(2001, 1, 1),
+                Gender.FEMALE
+        ));
+
+        mockMvc.perform(patch("/api/v2/mypage/user")
+                        .with(authentication(requestAuthentication))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "새닉네임"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"))
+                .andExpect(jsonPath("$.data.nickname").value("새닉네임"));
+    }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -669,6 +669,27 @@ class UserServiceImplTest {
     }
 
     @Test
+    @DisplayName("마이페이지 프로필 조회는 사용자 프로필 수정 화면 정보를 반환한다")
+    void getMyPageProfile_success() {
+        User inputUser = User.builder().id(1L).build();
+        User dbUser = User.builder()
+                .id(1L)
+                .nickname("잠자는꾸민성1470")
+                .birthday(LocalDate.of(2001, 1, 1))
+                .gender(Gender.FEMALE)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(dbUser));
+
+        MyPageProfileResponse response = userService.getMyPageProfile(inputUser);
+
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("잠자는꾸민성1470");
+        assertThat(response.birthday()).isEqualTo(LocalDate.of(2001, 1, 1));
+        assertThat(response.gender()).isEqualTo(Gender.FEMALE);
+    }
+
+    @Test
     @DisplayName("마이페이지 프로필 수정은 닉네임 태그를 생성하고 사용자 정보를 업데이트한다")
     void updateMyPageProfile_success() {
         User inputUser = User.builder().id(1L).build();
@@ -694,7 +715,7 @@ class UserServiceImplTest {
             return updatedUser;
         });
 
-        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+        MyPageProfileResponse response = userService.updateMyPageProfile(
                 inputUser,
                 "새닉네임",
                 Gender.FEMALE,
@@ -734,7 +755,7 @@ class UserServiceImplTest {
             return updatedUser;
         });
 
-        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+        MyPageProfileResponse response = userService.updateMyPageProfile(
                 inputUser,
                 "새닉네임",
                 Gender.FEMALE,
@@ -770,7 +791,7 @@ class UserServiceImplTest {
             return updatedUser;
         });
 
-        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+        MyPageProfileResponse response = userService.updateMyPageProfile(
                 inputUser,
                 null,
                 Gender.FEMALE,

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -668,4 +668,81 @@ class UserServiceImplTest {
         then(nicknameService).should(times(2)).generateNicknameTag("새닉네임");
     }
 
+    @Test
+    @DisplayName("마이페이지 프로필 수정은 닉네임 태그를 생성하고 사용자 정보를 업데이트한다")
+    void updateMyPageProfile_success() {
+        User inputUser = User.builder().id(1L).build();
+        User updatedUser = User.builder()
+                .id(1L)
+                .name("기존닉네임")
+                .nickname("기존닉네임")
+                .nicknameTag("#0001")
+                .birthday(LocalDate.of(1999, 1, 1))
+                .gender(Gender.MALE)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(updatedUser));
+        given(nicknameService.generateNicknameTag("새닉네임")).willReturn("#1234");
+        given(userNicknameTagTransactionService.updateMyPageProfile(
+                1L,
+                "새닉네임",
+                "#1234",
+                Gender.FEMALE,
+                LocalDate.of(2001, 1, 1)
+        )).willAnswer(invocation -> {
+            updatedUser.updateMyPageProfile("새닉네임", "#1234", LocalDate.of(2001, 1, 1), Gender.FEMALE);
+            return updatedUser;
+        });
+
+        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+                inputUser,
+                "새닉네임",
+                Gender.FEMALE,
+                LocalDate.of(2001, 1, 1)
+        );
+
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("새닉네임");
+        assertThat(response.birthday()).isEqualTo(LocalDate.of(2001, 1, 1));
+        assertThat(response.gender()).isEqualTo(Gender.FEMALE);
+    }
+
+    @Test
+    @DisplayName("마이페이지 프로필 수정은 닉네임 태그 유니크 충돌이 나면 재시도한다")
+    void updateMyPageProfile_retryOnNicknameTagConstraintViolation() {
+        User inputUser = User.builder().id(1L).build();
+        User updatedUser = User.builder().id(1L).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(updatedUser));
+        given(nicknameService.generateNicknameTag("새닉네임"))
+                .willReturn("#1234", "#5678");
+        given(userNicknameTagTransactionService.updateMyPageProfile(
+                1L,
+                "새닉네임",
+                "#1234",
+                Gender.FEMALE,
+                LocalDate.of(2001, 1, 1)
+        )).willThrow(new DataIntegrityViolationException("uk_user_nickname_nickname_tag"));
+        given(userNicknameTagTransactionService.updateMyPageProfile(
+                1L,
+                "새닉네임",
+                "#5678",
+                Gender.FEMALE,
+                LocalDate.of(2001, 1, 1)
+        )).willAnswer(invocation -> {
+            updatedUser.updateMyPageProfile("새닉네임", "#5678", LocalDate.of(2001, 1, 1), Gender.FEMALE);
+            return updatedUser;
+        });
+
+        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+                inputUser,
+                "새닉네임",
+                Gender.FEMALE,
+                LocalDate.of(2001, 1, 1)
+        );
+
+        assertThat(response.nickname()).isEqualTo("새닉네임");
+        then(nicknameService).should(times(2)).generateNicknameTag("새닉네임");
+    }
+
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -745,4 +745,41 @@ class UserServiceImplTest {
         then(nicknameService).should(times(2)).generateNicknameTag("새닉네임");
     }
 
+    @Test
+    @DisplayName("마이페이지 프로필 수정은 닉네임이 없으면 닉네임 태그를 생성하지 않는다")
+    void updateMyPageProfile_withoutNickname_doesNotGenerateNicknameTag() {
+        User inputUser = User.builder().id(1L).build();
+        User updatedUser = User.builder()
+                .id(1L)
+                .name("기존닉네임")
+                .nickname("기존닉네임")
+                .nicknameTag("#0001")
+                .birthday(LocalDate.of(1999, 1, 1))
+                .gender(Gender.MALE)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(updatedUser));
+        given(userNicknameTagTransactionService.updateMyPageProfile(
+                1L,
+                null,
+                null,
+                Gender.FEMALE,
+                null
+        )).willAnswer(invocation -> {
+            updatedUser.updateMyPageProfile(null, null, null, Gender.FEMALE);
+            return updatedUser;
+        });
+
+        UpdateMyPageProfileResponse response = userService.updateMyPageProfile(
+                inputUser,
+                null,
+                Gender.FEMALE,
+                null
+        );
+
+        assertThat(response.nickname()).isEqualTo("기존닉네임");
+        assertThat(response.gender()).isEqualTo(Gender.FEMALE);
+        then(nicknameService).shouldHaveNoInteractions();
+    }
+
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #513
- close #514 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 회원정보 업데이트, 조회 API를 구현했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

```java

    @Override
    @Transactional(propagation = Propagation.NOT_SUPPORTED)
    public MyPageProfileResponse updateMyPageProfile(User user, String nickname, Gender gender, LocalDate birthday) {
        Long userId = user.getId();
        findUser(user);

        if (nickname == null) {
            User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
                    userId,
                    null,
                    null,
                    gender,
                    birthday
            );
            return MyPageProfileResponse.from(updatedUser);
        }

        return executeWithNicknameTagRetry(nickname, nicknameTag -> {
            User updatedUser = userNicknameTagTransactionService.updateMyPageProfile(
                    userId,
                    nickname,
                    nicknameTag,
                    gender,
                    birthday
            );
            return MyPageProfileResponse.from(updatedUser);
        });
    }

    private <T> T executeWithNicknameTagRetry(String nickname, Function<String, T> nicknameTagCommand) {
        for (int attempt = 0; attempt < NicknameService.NICKNAME_TAG_RETRY_COUNT; attempt++) {
            String nicknameTag = nicknameService.generateNicknameTag(nickname);
            try {
                return nicknameTagCommand.apply(nicknameTag);
```

왜 여기서 트랜잭션을 끊어버릴까 하실 수 있는데요.
이전에 트랜잭션 전파 작업에서 설명드렸듯이, 하나의 트랜잭션에서 retry로직이 실행되면 원본 트랜잭션은 실패로 판단하기 때문에 retry가 성공해도 데이터를 반영하지 않습니다.

그래서 별도의 트랜잭션을 REQUIRED_NEW로 선언하기 위해서 트랜잭션을 분리한 것이에요.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * MyPage 프로필 조회 및 수정 기능 추가 - 사용자가 프로필 정보(닉네임, 생년월일, 성별)를 조회하고 업데이트할 수 있습니다.
  * 프로필 업데이트 시 선택 항목 지원 - 변경하려는 항목만 부분 수정 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->