### PR TITLE
[FEATURE] 선택한 상품으로 이미지 생성 API

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/controller/GenerateImageController.java
@@ -8,6 +8,7 @@ import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerat
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.ProductGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
@@ -142,6 +143,18 @@ public class GenerateImageController {
     ) {
         OtherStyleGenerateImageResponse response =
                 generateImageFacade.generateOtherStyleImageByGemini(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "선택한 상품 기반 이미지 생성 API",
+            description = "도면/뷰와 선택한 상품 이미지(최대 6개)를 기반으로 Gemini 모델로 이미지 1장을 생성합니다.")
+    @PostMapping("/v1/generated-images/generate/products")
+    public ResponseEntity<ApiResponse<GenerateImageV4Response>> generateImageByProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid ProductGenerateImageRequest request
+    ) {
+        GenerateImageV4Response response =
+                generateImageFacade.generateImageByProducts(userDetails.getUser(), request);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/ProductGenerateImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/ProductGenerateImageRequest.java
@@ -15,6 +15,6 @@ public record ProductGenerateImageRequest(
         Boolean isMirror,
         @NotNull(message = "productIds는 필수입니다.")
         @Size(min = 1, max = 6, message = "상품은 최소 1개에서 최대 6개까지 입력 가능합니다.")
-        List<Long> productIds
+        List<@NotNull(message = "productIds의 각 요소는 null일 수 없습니다.") Long> productIds
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/ProductGenerateImageRequest.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/presentation/dto/request/ProductGenerateImageRequest.java
@@ -1,0 +1,20 @@
+package or.sopt.houme.domain.generateImage.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ProductGenerateImageRequest(
+        @NotNull(message = "floorPlanId는 필수입니다.")
+        Long floorPlanId,
+        @NotBlank(message = "floorPlanView는 필수입니다.")
+        String floorPlanView,
+        @NotNull(message = "isMirror는 필수입니다.")
+        Boolean isMirror,
+        @NotNull(message = "productIds는 필수입니다.")
+        @Size(min = 1, max = 6, message = "상품은 최소 1개에서 최대 6개까지 입력 가능합니다.")
+        List<Long> productIds
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -182,6 +182,28 @@ public class GenerateImageTransactionService {
         return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl(), isMirror);
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GenerateImageV4Response saveProductImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Long floorPlanId,
+            boolean isMirror,
+            String finalPrompt,
+            ImageUploadResponseDTO imageResponse
+    ) {
+        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror);
+
+        GenerateImage generateImage = generateImageService.createGenerateImage(
+                imageResponse,
+                house,
+                GenerateImageType.LIST
+        );
+
+        creditService.commitCreditDeletion(lockedCredit);
+        userService.updateHasGeneratedImage(user);
+        return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl(), isMirror);
+    }
+
     private FloorPlan getFloorPlanOrThrow(House house) {
         return houseFloorPlanRepository.findHouseFloorPlanByHouseId(house.getId())
                 .map(HouseFloorPlan::getFloorPlan)

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -26,6 +26,7 @@ import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerat
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.OtherStyleGenerateImageRequest;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.ProductGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoListResponse;
@@ -582,6 +583,70 @@ public class GenerateImageFacade {
         }
     }
 
+    public GenerateImageV4Response generateImageByProducts(User user, ProductGenerateImageRequest request) {
+        Credit lockedCredit = null;
+
+        try {
+            lockedCredit = creditService.tryLockAndGetCredit(user);
+
+            FloorPlan floorPlan = floorPlanRepository.findById(request.floorPlanId())
+                    .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
+
+            List<Long> productIds = request.productIds().stream()
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .toList();
+            if (productIds.isEmpty()) {
+                throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_REQUEST);
+            }
+
+            List<CurationRawProduct> selectedProducts = curationRawProductRepository.findAllById(productIds);
+            if (selectedProducts.size() != productIds.size()) {
+                throw new FurnitureException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT);
+            }
+
+            String floorPlanImageUrl = resolveFloorPlanImageUrlStrict(floorPlan, request.floorPlanView());
+            List<String> referenceImageUrls = buildProductReferenceImageUrls(floorPlanImageUrl, selectedProducts);
+            String prompt = buildProductBasedPrompt(floorPlan, selectedProducts);
+
+            ImageUploadResponseDTO imageUploadResponseDTO =
+                    geminiImageService.createImageWithReferences(prompt, referenceImageUrls);
+
+            if (imageUploadResponseDTO.getImageLink().equals(S3Constant.FALL_BACK_IMAGE)) {
+                throw new ImageFallbackException(ErrorCode.GENERATED_IMAGE_EXCEPTION, null);
+            }
+
+            return generateImageTransactionService.saveProductImageAndConfirmCredit(
+                    user,
+                    lockedCredit,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    prompt,
+                    imageUploadResponseDTO
+            );
+        } catch (ValidException validException) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw validException;
+        } catch (GeneralException e) {
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error("선택 상품 기반 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
+            if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
+                creditService.rollbackCreditPending(lockedCredit);
+            }
+            throw new GenerateImageException(ErrorCode.GENERATED_IMAGE_EXCEPTION);
+        } finally {
+            if (lockedCredit != null) {
+                creditService.releaseLock(user);
+            }
+        }
+    }
+
     private ImageInfoListResponse generateImageBy2eaInternal(User user, GenerateImageRequest generateImageRequest, boolean useGemini) {
 
         // finally 블록에서 사용하기 위해 선언
@@ -954,6 +1019,37 @@ public class GenerateImageFacade {
                 .map(FurnitureTag::getFurniturePrompt)
                 .filter(prompt -> prompt != null && !prompt.isBlank())
                 .forEach(parts::add);
+        return String.join("\n\n", parts);
+    }
+
+    private List<String> buildProductReferenceImageUrls(
+            String floorPlanImageUrl,
+            List<CurationRawProduct> selectedProducts
+    ) {
+        LinkedHashSet<String> urls = new LinkedHashSet<>();
+        if (floorPlanImageUrl != null && !floorPlanImageUrl.isBlank()) {
+            urls.add(floorPlanImageUrl);
+        }
+        selectedProducts.stream()
+                .map(CurationRawProduct::getProductImageUrl)
+                .filter(url -> url != null && !url.isBlank())
+                .forEach(urls::add);
+        return List.copyOf(urls);
+    }
+
+    private String buildProductBasedPrompt(FloorPlan floorPlan, List<CurationRawProduct> selectedProducts) {
+        List<String> parts = new ArrayList<>();
+        if (floorPlan.getFloorPlanPrompt() != null && !floorPlan.getFloorPlanPrompt().isBlank()) {
+            parts.add(floorPlan.getFloorPlanPrompt());
+        }
+        parts.add("주어진 도면 구조와 원근을 유지하고, 참고 상품들을 실제 실내 배치처럼 자연스럽게 배치해주세요.");
+        parts.add("동선과 크기 비율을 지키고, 가구 간 간섭 없이 현실적인 인테리어 결과를 생성해주세요.");
+
+        selectedProducts.stream()
+                .map(product -> product.getProductName())
+                .filter(name -> name != null && !name.isBlank())
+                .forEach(name -> parts.add("반영 상품: " + name));
+
         return String.join("\n\n", parts);
     }
 

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -10,6 +10,7 @@ import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
@@ -20,6 +21,7 @@ import or.sopt.houme.domain.generateImage.infrastructure.gemini.service.GeminiIm
 import or.sopt.houme.domain.generateImage.presentation.dto.request.BannerGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageV4Request;
+import or.sopt.houme.domain.generateImage.presentation.dto.request.ProductGenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
@@ -644,6 +646,63 @@ class GenerateImageFacadeTest {
                 any(),
                 any(),
                 any()
+        );
+    }
+
+    @Test
+    @DisplayName("선택 상품 기반 이미지 생성은 도면+상품 이미지로 생성 후 저장한다")
+    void generateImageByProducts_callsGeminiAndSaves() {
+        User user = User.builder().id(1L).name("test_user").build();
+        Credit lockedCredit = Credit.builder().id(10L).status(CreditStatus.PENDING).user(user).build();
+        ProductGenerateImageRequest request = new ProductGenerateImageRequest(
+                11L,
+                "창가 뷰",
+                true,
+                List.of(1L, 2L, 3L)
+        );
+
+        FloorPlan floorPlan = FloorPlan.builder()
+                .id(11L)
+                .floorPlanPrompt("도면 프롬프트")
+                .imagesJson("[]")
+                .build();
+
+        CurationRawProduct p1 = CurationRawProduct.builder().id(1L).productName("소파").productImageUrl("https://p1").build();
+        CurationRawProduct p2 = CurationRawProduct.builder().id(2L).productName("책상").productImageUrl("https://p2").build();
+        CurationRawProduct p3 = CurationRawProduct.builder().id(3L).productName("조명").productImageUrl("https://p3").build();
+
+        ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
+                "generated.webp",
+                "generated-original.webp",
+                "https://generated-image",
+                "image/webp"
+        );
+
+        when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
+        when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
+        when(curationRawProductRepository.findAllById(List.of(1L, 2L, 3L))).thenReturn(List.of(p1, p2, p3));
+        when(floorPlanImageJsonCodec.read("[]"))
+                .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
+        when(geminiImageService.createImageWithReferences(any(), any())).thenReturn(imageUploadResponseDTO);
+        when(generateImageTransactionService.saveProductImageAndConfirmCredit(
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO)
+        )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
+
+        GenerateImageV4Response response = generateImageFacade.generateImageByProducts(user, request);
+
+        assertThat(response.imageId()).isEqualTo(999L);
+        assertThat(response.imageUrl()).isEqualTo("https://generated-image");
+        assertThat(response.isMirror()).isTrue();
+        verify(geminiImageService).createImageWithReferences(
+                any(),
+                argThat(urls -> urls.size() == 4
+                        && urls.get(0).equals("https://floorplan-view")
+                        && urls.contains("https://p1")
+                        && urls.contains("https://p2")
+                        && urls.contains("https://p3"))
+        );
+        verify(generateImageTransactionService).saveProductImageAndConfirmCredit(
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO)
         );
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #515

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 상품탭에서 선택한 상품들로 이미지를 생성합니다.
- 요청 바디는 아래와 같습니다.
```json
{
  "floorPlanId": 1,
  "floorPlanView": "창가 뷰",
  "isMirror": true,
  "productIds": [1,2,3] // 최대 6개
}
```

- 응답 바디는 아래와 같습니다.
```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "imageId": 1,
	  "imageUrl": "https://google.com",
	  "isMirror": true
  }
}
```

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 원하는 대로 상품과 도면이 잘 합쳐지긴 하는데, 위치 배치가 조금 어설프네요.
- 프롬프팅으로 해결하면 좋을 것 같습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/5e66e189-90bd-4dd7-bd7d-0ccedac662ac" />
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/e3c06b99-e646-4929-82e3-d44345f77ccb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 선택한 제품을 기반으로 이미지를 생성할 수 있는 기능이 추가되었습니다.
  * 바닥재 평면도와 최대 6개의 제품을 선택하여 맞춤형 이미지를 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->