### PR TITLE
[CHORE] 추천형 결과를 위한 가구 카테고리 조회시 요청값 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
@@ -91,6 +91,18 @@ public class FurnitureController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    @Operation(summary = "생성된 이미지에서 가구 카테고리 조회 API V2",
+            description = "객체 인식 요청값 없이, 이미지 생성 시 사용자가 선택했던 가구 기준으로 카테고리를 제공합니다.")
+    @GetMapping("/v2/generated-images/{imageId}/curations/categories")
+    public ResponseEntity<ApiResponse<FurnitureCategoriesResponse>> getFurnitureCategoriesV2(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long imageId
+    ) {
+        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyleV2(userDetails.getUser(), imageId);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
     @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
             description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다.")
     @GetMapping("/v1/generated-images/{imageId}/curations/products/{categoryId}")

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepository.java
@@ -4,38 +4,18 @@ import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface FurnitureTagRepository extends JpaRepository<FurnitureTag, Long> {
+public interface FurnitureTagRepository extends JpaRepository<FurnitureTag, Long>, FurnitureTagRepositoryCustom {
 
     Optional<FurnitureTag> findByFurnitureAndTag(Furniture furniture, Tag tag);
 
     List<FurnitureTag> findByFurniture(Furniture furniture);
 
-    @Query("""
-            select furnitureTag
-            from FurnitureTag furnitureTag
-            join fetch furnitureTag.furniture furniture
-            where furnitureTag.tag.id = :tagId
-              and furniture in :furnitures
-            """)
-    List<FurnitureTag> findAllByTagIdAndFurnitureIn(Long tagId, List<Furniture> furnitures);
-
     List<FurnitureTag> findAllByFurnitureIdInAndTagId(List<Long> furnitureIds, Long tagId);
 
-    @Query("""
-            select furnitureTag
-            from FurnitureTag furnitureTag
-            join fetch furnitureTag.furniture furniture
-            join fetch furniture.furnitureType furnitureType
-            join fetch furnitureTag.tag tag
-            where furnitureType.id = :furnitureTypeId
-            order by furniture.furnitureNameKr asc, furnitureTag.priority asc, furnitureTag.id asc
-            """)
-    List<FurnitureTag> findAllByFurnitureTypeIdWithFurnitureAndTag(Long furnitureTypeId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepository.java
@@ -17,6 +17,13 @@ public interface FurnitureTagRepository extends JpaRepository<FurnitureTag, Long
 
     List<FurnitureTag> findByFurniture(Furniture furniture);
 
+    @Query("""
+            select furnitureTag
+            from FurnitureTag furnitureTag
+            join fetch furnitureTag.furniture furniture
+            where furnitureTag.tag.id = :tagId
+              and furniture in :furnitures
+            """)
     List<FurnitureTag> findAllByTagIdAndFurnitureIn(Long tagId, List<Furniture> furnitures);
 
     List<FurnitureTag> findAllByFurnitureIdInAndTagId(List<Long> furnitureIds, Long tagId);

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryCustom.java
@@ -1,0 +1,13 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+
+import java.util.List;
+
+public interface FurnitureTagRepositoryCustom {
+
+    List<FurnitureTag> findAllByTagIdAndFurnitureIn(Long tagId, List<Furniture> furnitures);
+
+    List<FurnitureTag> findAllByFurnitureTypeIdWithFurnitureAndTag(Long furnitureTypeId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryImpl.java
@@ -1,0 +1,55 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.QFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.QFurnitureType;
+import or.sopt.houme.domain.house.model.taste.entity.QTag;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FurnitureTagRepositoryImpl implements FurnitureTagRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<FurnitureTag> findAllByTagIdAndFurnitureIn(Long tagId, List<Furniture> furnitures) {
+        QFurnitureTag furnitureTag = QFurnitureTag.furnitureTag;
+
+        return queryFactory
+                .selectFrom(furnitureTag)
+                .join(furnitureTag.furniture).fetchJoin()
+                .where(
+                        furnitureTag.tag.id.eq(tagId),
+                        furnitureTag.furniture.in(furnitures)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<FurnitureTag> findAllByFurnitureTypeIdWithFurnitureAndTag(Long furnitureTypeId) {
+        QFurnitureTag furnitureTag = QFurnitureTag.furnitureTag;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType furnitureType = QFurnitureType.furnitureType;
+        QTag tag = QTag.tag;
+
+        return queryFactory
+                .selectFrom(furnitureTag)
+                .join(furnitureTag.furniture, furniture).fetchJoin()
+                .join(furniture.furnitureType, furnitureType).fetchJoin()
+                .join(furnitureTag.tag, tag).fetchJoin()
+                .where(furnitureType.id.eq(furnitureTypeId))
+                .orderBy(
+                        furniture.furnitureNameKr.asc(),
+                        furnitureTag.priority.asc(),
+                        furnitureTag.id.asc()
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureService.java
@@ -22,6 +22,7 @@ public interface FurnitureService {
     List<FurnitureCategoryGroup> getDashboardCategories();
 
     FurnitureCategoriesResponse getFurnitureCategoriesByStyle(User user, Long imageId, List<String> detectedObjects);
+    FurnitureCategoriesResponse getFurnitureCategoriesByStyleV2(User user, Long imageId);
 
     // 가구 중 침대 ID 조회
     Optional<Long> findBedId(List<Long> furnitureIds);

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -150,17 +150,21 @@ public class FurnitureServiceImpl implements FurnitureService {
 
         // 5. 교집합으로 산출된 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회
         List<FurnitureTag> matchedTags = furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), intersectedFurnitures);
+        return buildCategoryResponse(matchedTags);
+    }
 
-        // 6. priority 기준 오름차순 정렬 → 응답 DTO 변환
-        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> categoryResponses = matchedTags.stream()
-                .sorted(Comparator.comparingInt(FurnitureTag::getPriority))
-                .map(ft -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
-                        ft.getFurniture().getId(),
-                        ft.getFurniture().getFurnitureNameKr()
-                ))
-                .toList();
+    @Override
+    public FurnitureCategoriesResponse getFurnitureCategoriesByStyleV2(User user, Long imageId) {
 
-        return FurnitureCategoriesResponse.of(categoryResponses);
+        // 1. userId와 imageId로 해당하는 스타일 태그 조회
+        Tag tag = findTag(user, imageId);
+
+        // 2. userId와 imageId로 이미지 생성시 선택했던 가구들을 조회
+        List<Furniture> selectedFurnitures = findSelectedFurnitures(user, imageId);
+
+        // 3. 선택 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회
+        List<FurnitureTag> matchedTags = furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), selectedFurnitures);
+        return buildCategoryResponse(matchedTags);
     }
 
     @Override
@@ -238,5 +242,17 @@ public class FurnitureServiceImpl implements FurnitureService {
                 .filter(f -> f.getFurnitureNameEng() != null
                         && keywords.contains(f.getFurnitureNameEng().toLowerCase()))
                 .toList();
+    }
+
+    private FurnitureCategoriesResponse buildCategoryResponse(List<FurnitureTag> matchedTags) {
+        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> categoryResponses = matchedTags.stream()
+                .sorted(Comparator.comparingInt(FurnitureTag::getPriority))
+                .map(ft -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
+                        ft.getFurniture().getId(),
+                        ft.getFurniture().getFurnitureNameKr()
+                ))
+                .toList();
+
+        return FurnitureCategoriesResponse.of(categoryResponses);
     }
 }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -372,6 +372,37 @@ class FurnitureServiceImplTest {
                 () -> furnitureService.getFurnitureCategoriesByStyle(user, imageId, List.of("Bed")));
     }
 
+    @Test
+    @DisplayName("V2 카테고리 조회는 detectedObjects 없이 선택 가구 기준으로 정렬 응답한다")
+    void getFurnitureCategoriesByStyleV2_fromSelectedFurnitures_sorted() {
+        Long imageId = 10L;
+
+        Tag tag = Tag.builder().id(100L).build();
+        House house = House.builder().id(200L).build();
+
+        Furniture bed = Furniture.builder().id(1L).furnitureNameKr("침대").build();
+        Furniture chair = Furniture.builder().id(2L).furnitureNameKr("의자").build();
+        Furniture tv = Furniture.builder().id(3L).furnitureNameKr("TV").build();
+        Furniture dining = Furniture.builder().id(4L).furnitureNameKr("식탁").build();
+
+        FurnitureTag ftBed = FurnitureTag.builder().id(11L).tag(tag).furniture(bed).priority(4).build();
+        FurnitureTag ftChair = FurnitureTag.builder().id(12L).tag(tag).furniture(chair).priority(3).build();
+        FurnitureTag ftTv = FurnitureTag.builder().id(14L).tag(tag).furniture(tv).priority(2).build();
+        FurnitureTag ftDining = FurnitureTag.builder().id(13L).tag(tag).furniture(dining).priority(1).build();
+
+        when(tagRepository.findTagByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(tag));
+        when(houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(house));
+        when(furnitureRepository.findAllByHouseId(house.getId())).thenReturn(List.of(bed, chair, tv, dining));
+        when(furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), List.of(bed, chair, tv, dining)))
+                .thenReturn(List.of(ftBed, ftChair, ftTv, ftDining));
+
+        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyleV2(user, imageId);
+
+        assertThat(response.categories())
+                .extracting(FurnitureCategoriesResponse.FurnitureCategoryResponse::categoryName)
+                .containsExactly("식탁", "TV", "의자", "침대");
+    }
+
     private Furniture createFurniture(Long id, String eng, String kr, FurnitureType type) {
         return Furniture.builder()
                 .id(id)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #517 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 추천형 결과 카테고리 조회 API를 v2로 추가하고, detectedObjects 없이 동작하도록 분리했습니다.
- v2는 객체 인식값이 아닌 “사용자가 이미지 생성 시 선택한 가구” 기준으로 카테고리를 반환합니다.
- 카테고리 조회 쿼리에 fetch join을 적용해 Furniture 접근 시 N+1 가능성을 줄였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 가구 카테고리 조회를 위한 새로운 V2 API 엔드포인트 추가 (`GET /api/v2/generated-images/{imageId}/curations/categories`). 기존 입력 파라미터 요구사항이 제거되어 더욱 간편한 조회가 가능합니다.

* **테스트**
  * V2 카테고리 조회 기능에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->