### PR TITLE
[CHORE] 추천형 결과 화면 상품의 응답 스펙 조정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/FurnitureController.java
@@ -2,12 +2,12 @@ package or.sopt.houme.domain.furniture.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityFurnitureMappingsResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ActivityWithFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.DashboardCategoriesResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureAndActivityResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureCategoriesResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
 import or.sopt.houme.domain.furniture.service.facade.FurnitureFacade;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
@@ -104,10 +104,10 @@ public class FurnitureController {
     }
 
     @Operation(summary = "가구 카테고리를 클릭하여 가구 제품 조회 API",
-            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 네이버 쇼핑 API를 통한 가구 제품들을 검색합니다.")
+            description = "생성된 이미지의 큐레이션 탭에서 가구 카테고리를 클릭하여 curation_raw_product 기반으로 가구 제품들을 조회합니다.")
     @GetMapping("/v1/generated-images/{imageId}/curations/products/{categoryId}")
-    public ResponseEntity<ApiResponse<FurnitureProductsInfoResponse>> getFurnitureProductInfoFromNaverApi(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @PathVariable Long categoryId) {
-        FurnitureProductsInfoResponse response = furnitureFacade.getFurnitureProductInfoFromNaverApi(userDetails.getUser(), imageId, categoryId);
+    public ResponseEntity<ApiResponse<FurnitureProductsInfoResponseV2>> getFurnitureProductInfoFromNaverApi(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long imageId, @PathVariable Long categoryId) {
+        FurnitureProductsInfoResponseV2 response = furnitureFacade.getFurnitureProductInfoFromNaverApi(userDetails.getUser(), imageId, categoryId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureProductsInfoResponseV2.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/FurnitureProductsInfoResponseV2.java
@@ -1,0 +1,38 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import java.util.List;
+
+public record FurnitureProductsInfoResponseV2(
+        String userName,
+        List<ProductWrapper> products
+) {
+    public static FurnitureProductsInfoResponseV2 of(String userName, List<ProductWrapper> products) {
+        return new FurnitureProductsInfoResponseV2(userName, products);
+    }
+
+    public record ProductWrapper(
+            ProductInfo product
+    ) {
+        public static ProductWrapper of(ProductInfo product) {
+            return new ProductWrapper(product);
+        }
+    }
+
+    public record ProductInfo(
+            Long id,
+            Long productId,
+            String categoryName,
+            String source,
+            String brand,
+            String name,
+            String imageUrl,
+            Long originalPrice,
+            Integer discountRate,
+            Long finalPrice,
+            String mallName,
+            String linkUrl,
+            List<ProductColorResponse> colors,
+            boolean isLiked
+    ) {
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureService.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.furniture.service;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
 
 import java.util.List;
 
@@ -14,5 +15,12 @@ public interface CurationFurnitureService {
             FurnitureTag furnitureTag,
             List<FurnitureProductsInfoResponse.FurnitureProductInfo> infos,
             CurationSource source
+    );
+
+    FurnitureProductsInfoResponseV2 buildProductsInfoResponse(
+            Long userId,
+            String userName,
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos
     );
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationFurnitureServiceImpl.java
@@ -8,7 +8,10 @@ import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.Jjym;
 import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.CurationFurnitureRepository;
@@ -23,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -125,12 +129,164 @@ public class CurationFurnitureServiceImpl implements CurationFurnitureService {
         return getCurationProducts(furnitureTag, source);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public FurnitureProductsInfoResponseV2 buildProductsInfoResponse(
+            Long userId,
+            String userName,
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos
+    ) {
+        String categoryName = furnitureTag.getFurniture() != null ? furnitureTag.getFurniture().getFurnitureNameKr() : null;
+        Map<Long, CurationRawProduct> rawProductByProductId = findLatestRawProductByProductId(furnitureTag, rawInfos);
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = findColorMapByRawProductId(rawProductByProductId);
+        Set<Long> likedRecommendIds = findLikedRecommendIds(userId, rawInfos);
+
+        List<FurnitureProductsInfoResponseV2.ProductWrapper> products = rawInfos.stream()
+                .map(info -> {
+                    CurationRawProduct rawProduct = rawProductByProductId.get(info.furnitureProductId());
+                    Long rawProductId = rawProduct != null ? rawProduct.getId() : null;
+
+                    FurnitureProductsInfoResponseV2.ProductInfo product = new FurnitureProductsInfoResponseV2.ProductInfo(
+                            rawProductId,
+                            info.furnitureProductId(),
+                            categoryName,
+                            rawProduct != null ? rawProduct.getSource() : CurationSource.RAW.name().toLowerCase(),
+                            rawProduct != null ? rawProduct.getBrand() : info.brandName(),
+                            rawProduct != null ? rawProduct.getProductName() : info.furnitureProductName(),
+                            rawProduct != null ? rawProduct.getProductImageUrl() : info.furnitureProductImageUrl(),
+                            rawProduct != null ? rawProduct.getListPrice() : info.listPrice(),
+                            rawProduct != null ? rawProduct.getDiscountRate() : info.discountRate(),
+                            rawProduct != null ? rawProduct.getDiscountPrice() : info.discountPrice(),
+                            rawProduct != null ? rawProduct.getProductMallName() : info.furnitureProductMallName(),
+                            rawProduct != null ? rawProduct.getProductSiteUrl() : info.furnitureProductSiteUrl(),
+                            rawProductId != null ? colorsByRawProductId.getOrDefault(rawProductId, List.of()) : List.of(),
+                            likedRecommendIds.contains(info.id())
+                    );
+                    return FurnitureProductsInfoResponseV2.ProductWrapper.of(product);
+                })
+                .toList();
+
+        return FurnitureProductsInfoResponseV2.of(userName, products);
+    }
+
     private Map<Long, Long> buildJjymCountMap(List<CurationFurniture> curations) {
         List<Long> recommendFurnitureIds = curations.stream()
                 .map(curation -> curation.getRecommendFurniture().getId())
                 .distinct()
                 .toList();
         return jjymRepository.countByRecommendFurnitureIds(recommendFurnitureIds);
+    }
+
+    private Set<Long> findLikedRecommendIds(Long userId, List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos) {
+        List<Long> recommendFurnitureIds = rawInfos.stream()
+                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::id)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (recommendFurnitureIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(userId, recommendFurnitureIds).stream()
+                .map(Jjym::getRecommendFurniture)
+                .filter(Objects::nonNull)
+                .map(RecommendFurniture::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private Map<Long, CurationRawProduct> findLatestRawProductByProductId(
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos
+    ) {
+        List<Long> productIds = rawInfos.stream()
+                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::furnitureProductId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (productIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return curationRawProductRepository.findAllByFurnitureTagAndProductIdIn(furnitureTag, productIds).stream()
+                .collect(Collectors.toMap(
+                        CurationRawProduct::getProductId,
+                        rawProduct -> rawProduct,
+                        this::selectLatestRawProductForResponse,
+                        java.util.LinkedHashMap::new
+                ));
+    }
+
+    private Map<Long, List<ProductColorResponse>> findColorMapByRawProductId(Map<Long, CurationRawProduct> rawProductByProductId) {
+        if (rawProductByProductId.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> rawProductIds = rawProductByProductId.values().stream()
+                .map(CurationRawProduct::getId)
+                .toList();
+
+        Map<Long, Set<String>> colorNamesByRawProductId = new java.util.LinkedHashMap<>();
+        List<CurationRawProductColor> colorEntities = curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds);
+        for (CurationRawProductColor colorEntity : colorEntities) {
+            Long rawProductId = colorEntity.getCurationRawProduct().getId();
+            if (rawProductId == null) {
+                continue;
+            }
+            String colorName = resolveColorName(colorEntity);
+            if (colorName == null) {
+                continue;
+            }
+            colorNamesByRawProductId.computeIfAbsent(rawProductId, key -> new java.util.LinkedHashSet<>())
+                    .add(colorName);
+        }
+
+        Map<Long, List<ProductColorResponse>> result = new java.util.LinkedHashMap<>();
+        for (Map.Entry<Long, Set<String>> entry : colorNamesByRawProductId.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().stream()
+                    .map(ProductColorResponse::fromName)
+                    .toList());
+        }
+        return result;
+    }
+
+    private CurationRawProduct selectLatestRawProductForResponse(CurationRawProduct current, CurationRawProduct candidate) {
+        LocalDateTime currentFetchedAt = current.getFetchedAt();
+        LocalDateTime candidateFetchedAt = candidate.getFetchedAt();
+
+        if (currentFetchedAt == null && candidateFetchedAt == null) {
+            if (candidate.getId() != null && current.getId() != null && candidate.getId() > current.getId()) {
+                return candidate;
+            }
+            return current;
+        }
+        if (currentFetchedAt == null) {
+            return candidate;
+        }
+        if (candidateFetchedAt == null) {
+            return current;
+        }
+        if (candidateFetchedAt.isAfter(currentFetchedAt)) {
+            return candidate;
+        }
+        if (candidateFetchedAt.isEqual(currentFetchedAt)
+                && candidate.getId() != null
+                && current.getId() != null
+                && candidate.getId() > current.getId()) {
+            return candidate;
+        }
+        return current;
+    }
+
+    private String resolveColorName(CurationRawProductColor colorEntity) {
+        if (colorEntity.getClientColorName() != null && !colorEntity.getClientColorName().isBlank()) {
+            return colorEntity.getClientColorName();
+        }
+        if (colorEntity.getRawColorName() != null && !colorEntity.getRawColorName().isBlank()) {
+            return colorEntity.getRawColorName();
+        }
+        return null;
     }
 
     private Map<Long, RawProductMeta> buildRawMetaByProductId(

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacade.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacade.java
@@ -2,10 +2,11 @@ package or.sopt.houme.domain.furniture.service.facade;
 
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
 import or.sopt.houme.domain.user.model.entity.User;
 
 public interface FurnitureFacade {
-    FurnitureProductsInfoResponse getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId);
+    FurnitureProductsInfoResponseV2 getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId);
 
     FurnitureProductsInfoResponseForPlan getFurnitureProductInfoFromNaverApiForPlan(User user, Long tagId, Long furnitureId, String searchKeyword, int pHash);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.Jjym;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
@@ -29,6 +30,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -124,6 +126,7 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         String categoryName = furnitureTag.getFurniture() != null ? furnitureTag.getFurniture().getFurnitureNameKr() : null;
         Map<Long, CurationRawProduct> rawProductByProductId = findLatestRawProductByProductId(furnitureTag, rawInfos);
         Map<Long, List<ProductColorResponse>> colorsByRawProductId = findColorMapByRawProductId(rawProductByProductId);
+        Set<Long> likedRecommendIds = findLikedRecommendIds(user.getId(), rawInfos);
 
         List<FurnitureProductsInfoResponseV2.ProductWrapper> products = rawInfos.stream()
                 .map(info -> {
@@ -144,13 +147,31 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
                             rawProduct != null ? rawProduct.getProductMallName() : info.furnitureProductMallName(),
                             rawProduct != null ? rawProduct.getProductSiteUrl() : info.furnitureProductSiteUrl(),
                             rawProductId != null ? colorsByRawProductId.getOrDefault(rawProductId, List.of()) : List.of(),
-                            info.id() != null && jjymRepository.existsByUserIdAndRecommendFurnitureId(user.getId(), info.id())
+                            likedRecommendIds.contains(info.id())
                     );
                     return FurnitureProductsInfoResponseV2.ProductWrapper.of(product);
                 })
                 .toList();
 
         return FurnitureProductsInfoResponseV2.of(user.getName(), products);
+    }
+
+    private Set<Long> findLikedRecommendIds(Long userId, List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos) {
+        List<Long> recommendFurnitureIds = rawInfos.stream()
+                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::id)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (recommendFurnitureIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(userId, recommendFurnitureIds).stream()
+                .map(Jjym::getRecommendFurniture)
+                .filter(Objects::nonNull)
+                .map(recommendFurniture -> recommendFurniture.getId())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     private Map<Long, CurationRawProduct> findLatestRawProductByProductId(

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -5,8 +5,15 @@ import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
 import or.sopt.houme.domain.furniture.service.CurationRawProductService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
@@ -19,7 +26,11 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import or.sopt.houme.global.config.NaverProperties;
 
@@ -36,10 +47,13 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
     private final FurnitureService furnitureService;
     private final CurationFurnitureService curationFurnitureService;
     private final CurationRawProductService curationRawProductService;
+    private final CurationRawProductRepository curationRawProductRepository;
+    private final CurationRawProductColorRepository curationRawProductColorRepository;
+    private final JjymRepository jjymRepository;
     private final NaverProperties naverProperties;
 
     @Override
-    public FurnitureProductsInfoResponse getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId) {
+    public FurnitureProductsInfoResponseV2 getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId) {
 
 
         LocalDateTime now = LocalDateTime.now();
@@ -106,8 +120,131 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         }
 
         log.info("큐레이션 종료:{}",formatted);
-        // 네이버 큐레이션 비활성화로 RAW 결과만 반환합니다.
-        return FurnitureProductsInfoResponse.of(user.getName(), rawInfos);
+
+        String categoryName = furnitureTag.getFurniture() != null ? furnitureTag.getFurniture().getFurnitureNameKr() : null;
+        Map<Long, CurationRawProduct> rawProductByProductId = findLatestRawProductByProductId(furnitureTag, rawInfos);
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = findColorMapByRawProductId(rawProductByProductId);
+
+        List<FurnitureProductsInfoResponseV2.ProductWrapper> products = rawInfos.stream()
+                .map(info -> {
+                    CurationRawProduct rawProduct = rawProductByProductId.get(info.furnitureProductId());
+                    Long rawProductId = rawProduct != null ? rawProduct.getId() : null;
+
+                    FurnitureProductsInfoResponseV2.ProductInfo product = new FurnitureProductsInfoResponseV2.ProductInfo(
+                            rawProductId,
+                            info.furnitureProductId(),
+                            categoryName,
+                            rawProduct != null ? rawProduct.getSource() : CurationSource.RAW.name().toLowerCase(),
+                            rawProduct != null ? rawProduct.getBrand() : info.brandName(),
+                            rawProduct != null ? rawProduct.getProductName() : info.furnitureProductName(),
+                            rawProduct != null ? rawProduct.getProductImageUrl() : info.furnitureProductImageUrl(),
+                            rawProduct != null ? rawProduct.getListPrice() : info.listPrice(),
+                            rawProduct != null ? rawProduct.getDiscountRate() : info.discountRate(),
+                            rawProduct != null ? rawProduct.getDiscountPrice() : info.discountPrice(),
+                            rawProduct != null ? rawProduct.getProductMallName() : info.furnitureProductMallName(),
+                            rawProduct != null ? rawProduct.getProductSiteUrl() : info.furnitureProductSiteUrl(),
+                            rawProductId != null ? colorsByRawProductId.getOrDefault(rawProductId, List.of()) : List.of(),
+                            info.id() != null && jjymRepository.existsByUserIdAndRecommendFurnitureId(user.getId(), info.id())
+                    );
+                    return FurnitureProductsInfoResponseV2.ProductWrapper.of(product);
+                })
+                .toList();
+
+        return FurnitureProductsInfoResponseV2.of(user.getName(), products);
+    }
+
+    private Map<Long, CurationRawProduct> findLatestRawProductByProductId(
+            FurnitureTag furnitureTag,
+            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos
+    ) {
+        List<Long> productIds = rawInfos.stream()
+                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::furnitureProductId)
+                .filter(productId -> productId != null)
+                .distinct()
+                .toList();
+        if (productIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return curationRawProductRepository.findAllByFurnitureTagAndProductIdIn(furnitureTag, productIds).stream()
+                .collect(Collectors.toMap(
+                        CurationRawProduct::getProductId,
+                        rawProduct -> rawProduct,
+                        this::selectLatestRawProduct,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private Map<Long, List<ProductColorResponse>> findColorMapByRawProductId(Map<Long, CurationRawProduct> rawProductByProductId) {
+        if (rawProductByProductId.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> rawProductIds = rawProductByProductId.values().stream()
+                .map(CurationRawProduct::getId)
+                .toList();
+
+        Map<Long, Set<String>> colorNamesByRawProductId = new LinkedHashMap<>();
+        List<CurationRawProductColor> colorEntities = curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds);
+        for (CurationRawProductColor colorEntity : colorEntities) {
+            Long rawProductId = colorEntity.getCurationRawProduct().getId();
+            if (rawProductId == null) {
+                continue;
+            }
+
+            String colorName = resolveColorName(colorEntity);
+            if (colorName == null) {
+                continue;
+            }
+            colorNamesByRawProductId.computeIfAbsent(rawProductId, key -> new java.util.LinkedHashSet<>())
+                    .add(colorName);
+        }
+
+        Map<Long, List<ProductColorResponse>> result = new LinkedHashMap<>();
+        for (Map.Entry<Long, Set<String>> entry : colorNamesByRawProductId.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().stream()
+                    .map(ProductColorResponse::fromName)
+                    .toList());
+        }
+        return result;
+    }
+
+    private CurationRawProduct selectLatestRawProduct(CurationRawProduct current, CurationRawProduct candidate) {
+        LocalDateTime currentFetchedAt = current.getFetchedAt();
+        LocalDateTime candidateFetchedAt = candidate.getFetchedAt();
+
+        if (currentFetchedAt == null && candidateFetchedAt == null) {
+            if (candidate.getId() != null && current.getId() != null && candidate.getId() > current.getId()) {
+                return candidate;
+            }
+            return current;
+        }
+        if (currentFetchedAt == null) {
+            return candidate;
+        }
+        if (candidateFetchedAt == null) {
+            return current;
+        }
+        if (candidateFetchedAt.isAfter(currentFetchedAt)) {
+            return candidate;
+        }
+        if (candidateFetchedAt.isEqual(currentFetchedAt)
+                && candidate.getId() != null
+                && current.getId() != null
+                && candidate.getId() > current.getId()) {
+            return candidate;
+        }
+        return current;
+    }
+
+    private String resolveColorName(CurationRawProductColor colorEntity) {
+        if (colorEntity.getClientColorName() != null && !colorEntity.getClientColorName().isBlank()) {
+            return colorEntity.getClientColorName();
+        }
+        if (colorEntity.getRawColorName() != null && !colorEntity.getRawColorName().isBlank()) {
+            return colorEntity.getRawColorName();
+        }
+        return null;
     }
 
     // 기획의사결정용

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -5,16 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.FurnitureProductsInfoResponse;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.forPlan.FurnitureProductsInfoResponseForPlan;
 import or.sopt.houme.domain.furniture.infrastructure.dto.external.naverShop.NaverFurnitureProductDto;
-import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
-import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
-import or.sopt.houme.domain.furniture.model.entity.Jjym;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
-import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
-import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
-import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
-import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
 import or.sopt.houme.domain.furniture.service.CurationRawProductService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
@@ -27,12 +20,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import or.sopt.houme.global.config.NaverProperties;
 
@@ -49,9 +37,6 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
     private final FurnitureService furnitureService;
     private final CurationFurnitureService curationFurnitureService;
     private final CurationRawProductService curationRawProductService;
-    private final CurationRawProductRepository curationRawProductRepository;
-    private final CurationRawProductColorRepository curationRawProductColorRepository;
-    private final JjymRepository jjymRepository;
     private final NaverProperties naverProperties;
 
     @Override
@@ -122,150 +107,12 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
         }
 
         log.info("큐레이션 종료:{}",formatted);
-
-        String categoryName = furnitureTag.getFurniture() != null ? furnitureTag.getFurniture().getFurnitureNameKr() : null;
-        Map<Long, CurationRawProduct> rawProductByProductId = findLatestRawProductByProductId(furnitureTag, rawInfos);
-        Map<Long, List<ProductColorResponse>> colorsByRawProductId = findColorMapByRawProductId(rawProductByProductId);
-        Set<Long> likedRecommendIds = findLikedRecommendIds(user.getId(), rawInfos);
-
-        List<FurnitureProductsInfoResponseV2.ProductWrapper> products = rawInfos.stream()
-                .map(info -> {
-                    CurationRawProduct rawProduct = rawProductByProductId.get(info.furnitureProductId());
-                    Long rawProductId = rawProduct != null ? rawProduct.getId() : null;
-
-                    FurnitureProductsInfoResponseV2.ProductInfo product = new FurnitureProductsInfoResponseV2.ProductInfo(
-                            rawProductId,
-                            info.furnitureProductId(),
-                            categoryName,
-                            rawProduct != null ? rawProduct.getSource() : CurationSource.RAW.name().toLowerCase(),
-                            rawProduct != null ? rawProduct.getBrand() : info.brandName(),
-                            rawProduct != null ? rawProduct.getProductName() : info.furnitureProductName(),
-                            rawProduct != null ? rawProduct.getProductImageUrl() : info.furnitureProductImageUrl(),
-                            rawProduct != null ? rawProduct.getListPrice() : info.listPrice(),
-                            rawProduct != null ? rawProduct.getDiscountRate() : info.discountRate(),
-                            rawProduct != null ? rawProduct.getDiscountPrice() : info.discountPrice(),
-                            rawProduct != null ? rawProduct.getProductMallName() : info.furnitureProductMallName(),
-                            rawProduct != null ? rawProduct.getProductSiteUrl() : info.furnitureProductSiteUrl(),
-                            rawProductId != null ? colorsByRawProductId.getOrDefault(rawProductId, List.of()) : List.of(),
-                            likedRecommendIds.contains(info.id())
-                    );
-                    return FurnitureProductsInfoResponseV2.ProductWrapper.of(product);
-                })
-                .toList();
-
-        return FurnitureProductsInfoResponseV2.of(user.getName(), products);
-    }
-
-    private Set<Long> findLikedRecommendIds(Long userId, List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos) {
-        List<Long> recommendFurnitureIds = rawInfos.stream()
-                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::id)
-                .filter(Objects::nonNull)
-                .distinct()
-                .toList();
-        if (recommendFurnitureIds.isEmpty()) {
-            return Set.of();
-        }
-
-        return jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(userId, recommendFurnitureIds).stream()
-                .map(Jjym::getRecommendFurniture)
-                .filter(Objects::nonNull)
-                .map(recommendFurniture -> recommendFurniture.getId())
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-    }
-
-    private Map<Long, CurationRawProduct> findLatestRawProductByProductId(
-            FurnitureTag furnitureTag,
-            List<FurnitureProductsInfoResponse.FurnitureProductInfo> rawInfos
-    ) {
-        List<Long> productIds = rawInfos.stream()
-                .map(FurnitureProductsInfoResponse.FurnitureProductInfo::furnitureProductId)
-                .filter(productId -> productId != null)
-                .distinct()
-                .toList();
-        if (productIds.isEmpty()) {
-            return Map.of();
-        }
-
-        return curationRawProductRepository.findAllByFurnitureTagAndProductIdIn(furnitureTag, productIds).stream()
-                .collect(Collectors.toMap(
-                        CurationRawProduct::getProductId,
-                        rawProduct -> rawProduct,
-                        this::selectLatestRawProduct,
-                        LinkedHashMap::new
-                ));
-    }
-
-    private Map<Long, List<ProductColorResponse>> findColorMapByRawProductId(Map<Long, CurationRawProduct> rawProductByProductId) {
-        if (rawProductByProductId.isEmpty()) {
-            return Map.of();
-        }
-
-        List<Long> rawProductIds = rawProductByProductId.values().stream()
-                .map(CurationRawProduct::getId)
-                .toList();
-
-        Map<Long, Set<String>> colorNamesByRawProductId = new LinkedHashMap<>();
-        List<CurationRawProductColor> colorEntities = curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds);
-        for (CurationRawProductColor colorEntity : colorEntities) {
-            Long rawProductId = colorEntity.getCurationRawProduct().getId();
-            if (rawProductId == null) {
-                continue;
-            }
-
-            String colorName = resolveColorName(colorEntity);
-            if (colorName == null) {
-                continue;
-            }
-            colorNamesByRawProductId.computeIfAbsent(rawProductId, key -> new java.util.LinkedHashSet<>())
-                    .add(colorName);
-        }
-
-        Map<Long, List<ProductColorResponse>> result = new LinkedHashMap<>();
-        for (Map.Entry<Long, Set<String>> entry : colorNamesByRawProductId.entrySet()) {
-            result.put(entry.getKey(), entry.getValue().stream()
-                    .map(ProductColorResponse::fromName)
-                    .toList());
-        }
-        return result;
-    }
-
-    private CurationRawProduct selectLatestRawProduct(CurationRawProduct current, CurationRawProduct candidate) {
-        LocalDateTime currentFetchedAt = current.getFetchedAt();
-        LocalDateTime candidateFetchedAt = candidate.getFetchedAt();
-
-        if (currentFetchedAt == null && candidateFetchedAt == null) {
-            if (candidate.getId() != null && current.getId() != null && candidate.getId() > current.getId()) {
-                return candidate;
-            }
-            return current;
-        }
-        if (currentFetchedAt == null) {
-            return candidate;
-        }
-        if (candidateFetchedAt == null) {
-            return current;
-        }
-        if (candidateFetchedAt.isAfter(currentFetchedAt)) {
-            return candidate;
-        }
-        if (candidateFetchedAt.isEqual(currentFetchedAt)
-                && candidate.getId() != null
-                && current.getId() != null
-                && candidate.getId() > current.getId()) {
-            return candidate;
-        }
-        return current;
-    }
-
-    private String resolveColorName(CurationRawProductColor colorEntity) {
-        if (colorEntity.getClientColorName() != null && !colorEntity.getClientColorName().isBlank()) {
-            return colorEntity.getClientColorName();
-        }
-        if (colorEntity.getRawColorName() != null && !colorEntity.getRawColorName().isBlank()) {
-            return colorEntity.getRawColorName();
-        }
-        return null;
+        return curationFurnitureService.buildProductsInfoResponse(
+                user.getId(),
+                user.getName(),
+                furnitureTag,
+                rawInfos
+        );
     }
 
     // 기획의사결정용


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #521

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- v1 응답 DTO 변경
  - v2로 분리하려 했으나, 로직은 그대로이고 응답 필드만 바뀌는 형태이기에 v1을 유지하고 dto만 수정했습니다.
- swagger 설명에 naver api 문구를 지우고, raw_product 문구로 수정했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 가구 상품 정보 조회 API의 응답 포맷을 새 버전으로 변경하여 더 풍부한 상품 정보를 제공합니다.
  * 상품별 색상 목록, 원가/최종가/할인율, 쇼핑몰명 및 링크, 좋아요 상태 등을 응답에 포함했습니다.
  * 큐레이션 결과를 최신 원시상품 기준으로 선택·집계해 정확도를 높였습니다.
  * 관련 엔드포인트가 새 응답 형식을 반환하도록 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/522)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->