### PR TITLE
[CHORE] 상품탭 필터 조회 조건 반환시 식별자 분리

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -360,34 +360,34 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         return List.of(
                 new FurnitureTypeFilterResponse(0L, "전체", "ALL"),
-                findType(types, "BED", "침대/프레임"),
-                findFurniture(furnitures, "OFFICE_DESK", "업무용 책상"),
-                findFurniture(furnitures, "DINING_TABLE", "식탁"),
-                findFurniture(furnitures, "SITTING_TABLE", "좌식 테이블"),
-                findFurniture(furnitures, "CLOSET", "옷장"),
-                findType(types, "STORAGE", "수납/장식장"),
-                findType(types, "SOFA", "소파"),
+                findType(types, "BED", "침대/프레임", -10L),
+                findFurniture(furnitures, "OFFICE_DESK", "업무용 책상", -11L),
+                findFurniture(furnitures, "DINING_TABLE", "식탁", -12L),
+                findFurniture(furnitures, "SITTING_TABLE", "좌식 테이블", -13L),
+                findFurniture(furnitures, "CLOSET", "옷장", -14L),
+                findType(types, "STORAGE", "수납/장식장", -15L),
+                findType(types, "SOFA", "소파", -16L),
                 new FurnitureTypeFilterResponse(-1L, "의자/스툴", "CHAIR"),
                 new FurnitureTypeFilterResponse(-2L, "화장대/협탁", "DRESSER"),
                 new FurnitureTypeFilterResponse(-3L, "조명", "LIGHTING"),
-                findType(types, "ETC", "기타")
+                findType(types, "ETC", "기타", -17L)
         );
     }
 
-    private FurnitureTypeFilterResponse findType(List<FurnitureType> types, String nameEng, String labelKr) {
+    private FurnitureTypeFilterResponse findType(List<FurnitureType> types, String nameEng, String labelKr, Long fallbackId) {
         return types.stream()
                 .filter(t -> t.getNameEng() != null && t.getNameEng().trim().equalsIgnoreCase(nameEng))
                 .findFirst()
                 .map(t -> new FurnitureTypeFilterResponse(t.getId(), labelKr, t.getNameEng().trim()))
-                .orElse(new FurnitureTypeFilterResponse(-1L, labelKr, nameEng));
+                .orElse(new FurnitureTypeFilterResponse(fallbackId, labelKr, nameEng));
     }
 
-    private FurnitureTypeFilterResponse findFurniture(List<Furniture> furnitures, String nameEng, String labelKr) {
+    private FurnitureTypeFilterResponse findFurniture(List<Furniture> furnitures, String nameEng, String labelKr, Long fallbackId) {
         return furnitures.stream()
                 .filter(f -> f.getFurnitureNameEng() != null && f.getFurnitureNameEng().trim().equalsIgnoreCase(nameEng))
                 .findFirst()
                 .map(f -> new FurnitureTypeFilterResponse(f.getId(), labelKr, f.getFurnitureNameEng().trim()))
-                .orElse(new FurnitureTypeFilterResponse(-1L, labelKr, nameEng));
+                .orElse(new FurnitureTypeFilterResponse(fallbackId, labelKr, nameEng));
     }
 
 


### PR DESCRIPTION
## 📣 Related Issue

- close #510

## 📝 Summary

- `findType` / `findFurniture` 메서드에 `fallbackId` 파라미터를 추가하여, DB에서 조회되지 않을 경우 항목별 고유한 음수 ID를 반환하도록 수정
- 기존에는 DB 미존재 시 모두 `-1L`로 fallback되어, CLOSET / STORAGE / ETC / CHAIR가 동일한 id(`-1`)를 가지는 중복 문제가 있었음
- 항목별 fallback ID 분리:
  - BED → `-10L`, OFFICE_DESK → `-11L`, DINING_TABLE → `-12L`, SITTING_TABLE → `-13L`
  - CLOSET → `-14L`, STORAGE → `-15L`, SOFA → `-16L`, ETC → `-17L`
  - 기존 하드코딩 유지: CHAIR(`-1L`), DRESSER(`-2L`), LIGHTING(`-3L`)

## 🙏 Question & PR point

- `preprocessTypeIds` 로직은 기존과 동일하게 음수 ID → 빈 결과 유도 방식이라 추가 수정 없이 호환됩니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 가구 필터 조회 로직을 개선하여 카테고리별 기본값 처리의 유연성을 증대했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->