### PR TITLE
[FEATURE] 가구 색상 관리 기능 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductColor.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductColor.java
@@ -56,4 +56,16 @@ public class CurationRawProductColor {
     @Column(name = "client_color_name")
     @Comment("클라이언트 반환용 색상명")
     private String clientColorName;
+
+    public static CurationRawProductColor of(
+            CurationRawProduct curationRawProduct,
+            String rawColorName,
+            String clientColorName
+    ) {
+        return CurationRawProductColor.builder()
+                .curationRawProduct(curationRawProduct)
+                .rawColorName(rawColorName)
+                .clientColorName(clientColorName)
+                .build();
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductColorRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductColorRequest.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.domain.furniture.presentation.dto.request;
+
+public record AdminCurationRawProductColorRequest(
+        String rawColorName,
+        String clientColorName
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AdminCurationRawProductCreateRequest(
         @NotBlank(message = "source는 필수 입력값입니다.")
@@ -50,6 +51,7 @@ public record AdminCurationRawProductCreateRequest(
         @PositiveOrZero(message = "freeShippingCondition는 0 이상이어야 합니다.")
         Long freeShippingCondition,
         Boolean isExposed,
-        LocalDateTime fetchedAt
+        LocalDateTime fetchedAt,
+        List<AdminCurationRawProductColorRequest> colors
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AdminCurationRawProductUpdateRequest(
         @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$", message = "source 형식이 올바르지 않습니다.")
@@ -32,6 +33,7 @@ public record AdminCurationRawProductUpdateRequest(
         @PositiveOrZero(message = "freeShippingCondition는 0 이상이어야 합니다.")
         Long freeShippingCondition,
         Boolean isExposed,
-        LocalDateTime fetchedAt
+        LocalDateTime fetchedAt,
+        List<AdminCurationRawProductColorRequest> colors
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -7,6 +7,7 @@ import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTa
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductColorRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductExposureUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
@@ -122,6 +123,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
 
         try {
             CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
+            saveColors(saved, request.colors());
             eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
@@ -160,6 +162,9 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
                     request.isExposed()
             );
             CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
+            if (request.colors() != null) {
+                replaceColors(saved, request.colors());
+            }
             eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
@@ -280,6 +285,49 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
     private CurationRawProduct getRawProductOrThrow(Long curationRawProductId) {
         return curationRawProductRepository.findById(curationRawProductId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT));
+    }
+
+    private void replaceColors(CurationRawProduct rawProduct, List<AdminCurationRawProductColorRequest> colorRequests) {
+        curationRawProductColorRepository.deleteAllByCurationRawProduct(rawProduct);
+        curationRawProductColorRepository.flush();
+        saveColors(rawProduct, colorRequests);
+    }
+
+    private void saveColors(CurationRawProduct rawProduct, List<AdminCurationRawProductColorRequest> colorRequests) {
+        List<CurationRawProductColor> colors = buildColors(rawProduct, colorRequests);
+        if (!colors.isEmpty()) {
+            curationRawProductColorRepository.saveAll(colors);
+        }
+    }
+
+    private List<CurationRawProductColor> buildColors(
+            CurationRawProduct rawProduct,
+            List<AdminCurationRawProductColorRequest> colorRequests
+    ) {
+        if (colorRequests == null || colorRequests.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, CurationRawProductColor> colorsByKey = new LinkedHashMap<>();
+        for (AdminCurationRawProductColorRequest request : colorRequests) {
+            if (request == null) {
+                continue;
+            }
+
+            String rawColorName = normalizeNullable(request.rawColorName());
+            String clientColorName = normalizeNullable(request.clientColorName());
+            if (rawColorName == null && clientColorName == null) {
+                throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+            }
+
+            // raw_color_name에 unique 제약이 있어 같은 원본 색상은 하나만 저장한다.
+            String uniqueKey = rawColorName != null ? rawColorName : "client:" + clientColorName;
+            colorsByKey.putIfAbsent(
+                    uniqueKey,
+                    CurationRawProductColor.of(rawProduct, rawColorName, clientColorName)
+            );
+        }
+        return new ArrayList<>(colorsByKey.values());
     }
 
     private FurnitureTag getFurnitureTagOrThrow(Long furnitureTagId) {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1240,6 +1240,11 @@
                             <input type="text" class="form-control" id="rawCreateBrand">
                         </div>
                         <div class="raw-form-field">
+                            <label for="rawCreateColors">Colors</label>
+                            <input type="text" class="form-control" id="rawCreateColors" placeholder="예: 우드, 화이트, 블랙">
+                            <small class="text-muted">쉼표 또는 줄바꿈으로 여러 색상을 입력합니다.</small>
+                        </div>
+                        <div class="raw-form-field">
                             <label for="rawCreateIsExposed">Exposure Status</label>
                             <select class="form-select" id="rawCreateIsExposed">
                                 <option value="true" selected>노출</option>
@@ -1395,6 +1400,15 @@
                                 <div class="raw-form-field">
                                     <label for="rawUpdateBrand">Brand</label>
                                     <input type="text" class="form-control" id="rawUpdateBrand">
+                                </div>
+                                <div class="raw-form-field">
+                                    <label for="rawUpdateColors">Colors</label>
+                                    <input type="text" class="form-control" id="rawUpdateColors" placeholder="예: 우드, 화이트, 블랙">
+                                    <div class="form-check mt-2">
+                                        <input class="form-check-input" type="checkbox" id="rawUpdateColorsEnabled">
+                                        <label class="form-check-label small" for="rawUpdateColorsEnabled">색상 수정 반영</label>
+                                    </div>
+                                    <small class="text-muted">체크 후 비워서 저장하면 색상이 전체 삭제됩니다.</small>
                                 </div>
                                 <div class="raw-form-field">
                                     <label for="rawUpdateIsExposed">Exposure Status</label>
@@ -4954,6 +4968,8 @@
         document.getElementById('rawUpdateFreeShippingCondition').value = product.freeShippingCondition ?? '';
         document.getElementById('rawUpdateIsExposed').value = product.isExposed == null ? '' : String(product.isExposed);
         document.getElementById('rawUpdateFetchedAt').value = formatDateTimeLocalValue(product.fetchedAt);
+        document.getElementById('rawUpdateColors').value = formatRawProductColorsForInput(product.colors);
+        document.getElementById('rawUpdateColorsEnabled').checked = true;
     }
 
     function populateRawProductFurnitureTagForm(product) {
@@ -5500,7 +5516,8 @@
             baseShippingFee: parseNumberValue(document.getElementById('rawCreateBaseShippingFee').value),
             freeShippingCondition: parseNumberValue(getOptionalInputValue('rawCreateFreeShippingCondition')),
             isExposed: parseBooleanValue(document.getElementById('rawCreateIsExposed').value),
-            fetchedAt: parseStringValue(getOptionalInputValue('rawCreateFetchedAt'))
+            fetchedAt: parseStringValue(getOptionalInputValue('rawCreateFetchedAt')),
+            colors: parseRawProductColorRequests(document.getElementById('rawCreateColors').value)
         };
     }
 
@@ -5521,6 +5538,7 @@
         const freeShippingCondition = parseNumberValue(document.getElementById('rawUpdateFreeShippingCondition').value);
         const isExposed = parseBooleanValue(document.getElementById('rawUpdateIsExposed').value);
         const fetchedAt = parseStringValue(document.getElementById('rawUpdateFetchedAt').value);
+        const colorsEnabled = document.getElementById('rawUpdateColorsEnabled').checked;
 
         if (source !== null) payload.source = source;
         if (category !== null) payload.category = category;
@@ -5537,8 +5555,35 @@
         if (freeShippingCondition !== null) payload.freeShippingCondition = freeShippingCondition;
         if (isExposed !== null) payload.isExposed = isExposed;
         if (fetchedAt !== null) payload.fetchedAt = fetchedAt;
+        if (colorsEnabled) payload.colors = parseRawProductColorRequests(document.getElementById('rawUpdateColors').value);
 
         return payload;
+    }
+
+    function formatRawProductColorsForInput(colors) {
+        if (!Array.isArray(colors) || colors.length === 0) {
+            return '';
+        }
+        return colors
+            .map(color => color.clientColorName || color.rawColorName || '')
+            .filter(Boolean)
+            .join(', ');
+    }
+
+    function parseRawProductColorRequests(value) {
+        const normalized = parseStringValue(value);
+        if (normalized === null) {
+            return [];
+        }
+
+        return normalized
+            .split(/[,\n]/)
+            .map(color => color.trim())
+            .filter(Boolean)
+            .map(colorName => ({
+                rawColorName: colorName,
+                clientColorName: colorName
+            }));
     }
 
     // --- Loading helpers (skeleton UI) and loader-aware API call ---

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -12,10 +12,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductColorRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductExposureUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
@@ -43,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -124,7 +127,11 @@ class AdminCurationRawProductServiceImplTest {
                 3000L,
                 50000L,
                 false,
-                LocalDateTime.of(2026, 2, 1, 10, 0)
+                LocalDateTime.of(2026, 2, 1, 10, 0),
+                List.of(
+                        new AdminCurationRawProductColorRequest("우드", "우드"),
+                        new AdminCurationRawProductColorRequest("화이트", "화이트")
+                )
         );
 
         when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
@@ -147,6 +154,11 @@ class AdminCurationRawProductServiceImplTest {
         assertEquals("테스트 침대", response.productName());
         assertFalse(response.isExposed());
         verify(curationRawProductRepository).saveAndFlush(any(CurationRawProduct.class));
+        verify(curationRawProductColorRepository).saveAll(argThat(colors ->
+                colors instanceof List<?>
+                        && ((List<?>) colors).size() == 2
+                        && ((List<?>) colors).stream().allMatch(CurationRawProductColor.class::isInstance)
+        ));
     }
 
     @Test
@@ -160,6 +172,7 @@ class AdminCurationRawProductServiceImplTest {
                 "https://soozip.co.kr/product/1001",
                 "테스트 침대",
                 "SOOZIP",
+                null,
                 null,
                 null,
                 null,
@@ -201,6 +214,7 @@ class AdminCurationRawProductServiceImplTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 
@@ -216,6 +230,53 @@ class AdminCurationRawProductServiceImplTest {
         );
 
         assertEquals(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("update()는 colors가 전달되면 기존 색상을 삭제하고 새 색상으로 교체한다")
+    void update_replaceColors_success() {
+        CurationRawProduct rawProduct = rawProduct(10L, "수정 대상 상품", true);
+        AdminCurationRawProductUpdateRequest request = new AdminCurationRawProductUpdateRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                "수정된 상품명",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(
+                        new AdminCurationRawProductColorRequest("블랙", "블랙"),
+                        new AdminCurationRawProductColorRequest("베이지", "베이지")
+                )
+        );
+
+        when(curationRawProductRepository.findById(10L)).thenReturn(Optional.of(rawProduct));
+        when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 3003L))
+                .thenReturn(Optional.of(rawProduct));
+        when(curationRawProductRepository.saveAndFlush(rawProduct)).thenReturn(rawProduct);
+        when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(anyList())).thenReturn(List.of());
+        when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(anyList()))
+                .thenReturn(List.of());
+
+        adminCurationRawProductService.update(10L, request);
+
+        InOrder inOrder = inOrder(curationRawProductRepository, curationRawProductColorRepository);
+        inOrder.verify(curationRawProductRepository).saveAndFlush(rawProduct);
+        inOrder.verify(curationRawProductColorRepository).deleteAllByCurationRawProduct(rawProduct);
+        inOrder.verify(curationRawProductColorRepository).flush();
+        inOrder.verify(curationRawProductColorRepository).saveAll(argThat(colors ->
+                colors instanceof List<?>
+                        && ((List<?>) colors).size() == 2
+                        && ((List<?>) colors).stream().allMatch(CurationRawProductColor.class::isInstance)
+        ));
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #523 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

어드민에서 가구 색상을 관리 할 수 있도록 기능을 구현했습니다.
기획측과 정해진 colormap이 존재하긴 하지만, 정해진 색상으로만 매핑해야하는 점이 아쉽긴 하네요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 원상품 생성 및 수정 시 색상 정보 입력 기능 추가
  * 관리자 대시보드에서 다중 색상 관리 지원
  * 색상 중복 자동 제거 및 정규화 기능

* **테스트**
  * 색상 관리 기능에 대한 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->