### PR TITLE
[CHORE] 상품탭 상품 상세 - 해당 상품의 찜 갯수 추가 반환

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/CurationProductDetailResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/CurationProductDetailResponse.java
@@ -17,7 +17,8 @@ public record CurationProductDetailResponse(ProductDetail product) {
             String mallName,
             String linkUrl,
             List<ProductColorDetail> colors,
-            Boolean isLiked
+            Boolean isLiked,
+            Long jjymCount
     ) {}
 
     public record ProductColorDetail(

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/JjymRepository.java
@@ -10,5 +10,7 @@ public interface JjymRepository extends JpaRepository<Jjym, Long>, JjymRepositor
 
     boolean existsByUserIdAndRecommendFurnitureId(Long userId, Long recommendFurnitureId);
 
+    long countByRecommendFurnitureId(Long recommendFurnitureId);
+
     List<Jjym> findAllByUserIdAndRecommendFurnitureIdIn(Long userId, List<Long> recommendFurnitureIds);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.furniture.service;
 
 import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
@@ -8,6 +9,7 @@ import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
 import or.sopt.houme.domain.furniture.presentation.dto.response.ColorFilterResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductAppliedFilterResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductDetailResponse;
@@ -255,7 +257,16 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         String categoryName = extractCategoryName(product);
         List<CurationProductDetailResponse.ProductColorDetail> colors = extractColorDetails(id);
-        boolean isLiked = checkIsLiked(product, user);
+
+        Optional<RecommendFurniture> recommendFurniture = recommendFurnitureRepository
+                .findBySourceAndFurnitureProductId(CurationSource.RAW, product.getProductId());
+
+        boolean isLiked = recommendFurniture
+                .map(rf -> user != null && jjymRepository.existsByUserIdAndRecommendFurnitureId(user.getId(), rf.getId()))
+                .orElse(false);
+        long jjymCount = recommendFurniture
+                .map(rf -> jjymRepository.countByRecommendFurnitureId(rf.getId()))
+                .orElse(0L);
 
         return new CurationProductDetailResponse(
                 new CurationProductDetailResponse.ProductDetail(
@@ -272,18 +283,10 @@ public class CurationProductServiceImpl implements CurationProductService {
                         product.getProductMallName(),
                         product.getProductSiteUrl(),
                         colors,
-                        isLiked
+                        isLiked,
+                        jjymCount
                 )
         );
-    }
-
-    private boolean checkIsLiked(CurationRawProduct product, User user) {
-        if (user == null) {
-            return false;
-        }
-        return recommendFurnitureRepository.findBySourceAndFurnitureProductId(CurationSource.RAW, product.getProductId())
-                .map(recommend -> jjymRepository.existsByUserIdAndRecommendFurnitureId(user.getId(), recommend.getId()))
-                .orElse(false);
     }
 
     private List<CurationProductDetailResponse.ProductColorDetail> extractColorDetails(Long productId) {

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -3,9 +3,11 @@ package or.sopt.houme.domain.furniture.service;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductDetailResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductFilterResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductListResponse;
@@ -196,5 +198,61 @@ class CurationProductServiceImplTest {
 
         // then
         assertThat(response.product().categoryName()).isEqualTo("소파");
+    }
+
+    @Test
+    @DisplayName("getProductDetail()은 RecommendFurniture가 존재하면 jjymCount를 함께 반환한다")
+    void getProductDetail_withJjymCount() {
+        // given
+        Long id = 1L;
+        User user = User.builder().id(1L).build();
+
+        CurationRawProduct product = CurationRawProduct.builder()
+                .id(id)
+                .productId(3003L)
+                .isExposed(true)
+                .furnitureTagMappings(new HashSet<>())
+                .build();
+
+        RecommendFurniture recommendFurniture = RecommendFurniture.builder().id(10L).build();
+
+        given(curationRawProductRepository.findByIdAndIsExposedTrueOrNull(id)).willReturn(Optional.of(product));
+        given(curationRawProductColorRepository.findAllByCurationRawProductId(id)).willReturn(List.of());
+        given(recommendFurnitureRepository.findBySourceAndFurnitureProductId(eq(CurationSource.RAW), eq(3003L)))
+                .willReturn(Optional.of(recommendFurniture));
+        given(jjymRepository.existsByUserIdAndRecommendFurnitureId(1L, 10L)).willReturn(true);
+        given(jjymRepository.countByRecommendFurnitureId(10L)).willReturn(5L);
+
+        // when
+        CurationProductDetailResponse response = curationProductService.getProductDetail(id, user);
+
+        // then
+        assertThat(response.product().isLiked()).isTrue();
+        assertThat(response.product().jjymCount()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("getProductDetail()은 RecommendFurniture가 없으면 jjymCount를 0으로 반환한다")
+    void getProductDetail_withNoRecommendFurniture() {
+        // given
+        Long id = 2L;
+
+        CurationRawProduct product = CurationRawProduct.builder()
+                .id(id)
+                .productId(9999L)
+                .isExposed(true)
+                .furnitureTagMappings(new HashSet<>())
+                .build();
+
+        given(curationRawProductRepository.findByIdAndIsExposedTrueOrNull(id)).willReturn(Optional.of(product));
+        given(curationRawProductColorRepository.findAllByCurationRawProductId(id)).willReturn(List.of());
+        given(recommendFurnitureRepository.findBySourceAndFurnitureProductId(any(), any())).willReturn(Optional.empty());
+
+        // when
+        CurationProductDetailResponse response = curationProductService.getProductDetail(id, null);
+
+        // then
+        assertThat(response.product().isLiked()).isFalse();
+        assertThat(response.product().jjymCount()).isEqualTo(0L);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #530

## 📝 Summary

- 상품 상세 조회 API(`GET /api/v1/curations/products/{productId}`) 응답에 `jjymCount` 필드 추가
- `RecommendFurniture` 조회를 한 번만 수행하여 `isLiked`와 `jjymCount`를 함께 처리
  - `RecommendFurniture`가 없는 경우 `jjymCount` = 0 반환
- `JjymRepository`에 `countByRecommendFurnitureId` 메서드 추가 (JPA 자동 생성)

## 🙏 Question & PR point

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상품 상세 정보 페이지에 찜 개수를 함께 표시하도록 기능 개선

* **Tests**
  * 찜 개수 표시 기능에 대한 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->