### PR TITLE
[CHORE] 이미지 생성 타입 정합성 개선 및 응답 타입 세분화

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImageRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImageRawProduct.java
@@ -1,0 +1,56 @@
+package or.sopt.houme.domain.generateImage.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "generate_image_raw_products")
+@Comment("생성 이미지와 원천 상품(raw product) 매핑 테이블")
+public class GenerateImageRawProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "generate_image_id", nullable = false)
+    private GenerateImage generateImage;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "curation_raw_product_id", nullable = false)
+    private CurationRawProduct curationRawProduct;
+
+    @Comment("노출 순서")
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    public static GenerateImageRawProduct of(
+            GenerateImage generateImage,
+            CurationRawProduct curationRawProduct,
+            Integer sortOrder
+    ) {
+        return GenerateImageRawProduct.builder()
+                .generateImage(generateImage)
+                .curationRawProduct(curationRawProduct)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImageType.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/model/entity/GenerateImageType.java
@@ -4,8 +4,13 @@ import lombok.Getter;
 
 @Getter
 public enum GenerateImageType {
-    LIST("목록형 이미지"),
-    RECOMMEND("추천형 이미지");
+    BANNER("배너 기반 목록형 이미지"),
+    STYLE("스타일 기반 목록형 이미지"),
+    PRODUCT("상품 기반 목록형 이미지"),
+    FULL_FUNNEL("추천형 이미지"),
+    LEGACY("레거시 이미지 타입"),
+    @Deprecated LIST("목록형 이미지"),
+    @Deprecated RECOMMEND("추천형 이미지");
 
     private final String description;
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepository.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.generateImage.repository;
+
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GenerateImageRawProductRepository extends JpaRepository<GenerateImageRawProduct, Long>,
+        GenerateImageRawProductRepositoryCustom {
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepositoryCustom.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.domain.generateImage.repository;
+
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
+
+import java.util.List;
+
+public interface GenerateImageRawProductRepositoryCustom {
+
+    List<GenerateImageRawProduct> findAllByGenerateImageIdWithRawProduct(Long generateImageId);
+
+    List<GenerateImageRawProduct> findAllByGenerateImageIdInWithRawProduct(List<Long> generateImageIds);
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepositoryImpl.java
@@ -1,0 +1,46 @@
+package or.sopt.houme.domain.generateImage.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.QCurationRawProduct;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
+import or.sopt.houme.domain.generateImage.model.entity.QGenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.QGenerateImageRawProduct;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GenerateImageRawProductRepositoryImpl implements GenerateImageRawProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GenerateImageRawProduct> findAllByGenerateImageIdWithRawProduct(Long generateImageId) {
+        if (generateImageId == null) {
+            return List.of();
+        }
+
+        return findAllByGenerateImageIdInWithRawProduct(List.of(generateImageId));
+    }
+
+    @Override
+    public List<GenerateImageRawProduct> findAllByGenerateImageIdInWithRawProduct(List<Long> generateImageIds) {
+        if (generateImageIds == null || generateImageIds.isEmpty()) {
+            return List.of();
+        }
+
+        QGenerateImageRawProduct mapping = QGenerateImageRawProduct.generateImageRawProduct;
+        QGenerateImage generateImage = QGenerateImage.generateImage;
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+
+        return queryFactory
+                .selectFrom(mapping)
+                .join(mapping.generateImage, generateImage).fetchJoin()
+                .join(mapping.curationRawProduct, rawProduct).fetchJoin()
+                .where(generateImage.id.in(generateImageIds))
+                .orderBy(generateImage.id.asc(), mapping.sortOrder.asc(), mapping.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryCustom.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface GenerateImageRepositoryCustom {
 
@@ -23,6 +24,6 @@ public interface GenerateImageRepositoryCustom {
             List<Long> rawProductIds,
             Long excludeImageId,
             int limit,
-            GenerateImageType generationType
+            Set<GenerateImageType> generationTypes
     );
 }

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -148,8 +148,12 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
             QGenerateImage generateImage,
             Set<GenerateImageType> generationTypes
     ) {
-        if (generationTypes == null || generationTypes.isEmpty()) {
+        if (generationTypes == null) {
             return null;
+        }
+        if (generationTypes.isEmpty()) {
+            // empty set means "allow no generation type"
+            return generateImage.id.isNull();
         }
         return generateImage.generationType.in(generationTypes);
     }

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -8,7 +8,7 @@ import or.sopt.houme.domain.banner.model.entity.QBannerCurationRawProduct;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.model.entity.QGenerateImage;
-import or.sopt.houme.domain.generateImage.model.entity.QGenerateImageUsedProduct;
+import or.sopt.houme.domain.generateImage.model.entity.QGenerateImageRawProduct;
 import or.sopt.houme.domain.banner.model.entity.QBanner;
 import or.sopt.houme.domain.house.model.entity.QHouse;
 import org.springframework.stereotype.Repository;
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -102,7 +103,7 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
             List<Long> rawProductIds,
             Long excludeImageId,
             int limit,
-            GenerateImageType generationType
+            Set<GenerateImageType> generationTypes
     ) {
         if (rawProductIds == null || rawProductIds.isEmpty() || limit < 1) {
             return List.of();
@@ -110,16 +111,16 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
 
         QGenerateImage generateImage = QGenerateImage.generateImage;
         QBannerCurationRawProduct bannerRawMapping = QBannerCurationRawProduct.bannerCurationRawProduct;
-        QGenerateImageUsedProduct usedProductMapping = QGenerateImageUsedProduct.generateImageUsedProduct;
+        QGenerateImageRawProduct rawProductMapping = QGenerateImageRawProduct.generateImageRawProduct;
 
         List<Long> imageIds = queryFactory
                 .select(generateImage.id)
                 .from(generateImage)
                 .where(
                         generateImage.id.ne(excludeImageId),
-                        resolvedGenerationTypeCondition(generateImage, generationType),
+                        resolvedGenerationTypeCondition(generateImage, generationTypes),
                         hasBannerMappedRawProducts(generateImage, bannerRawMapping, rawProductIds)
-                                .or(hasUsedRawProducts(generateImage, usedProductMapping, rawProductIds))
+                                .or(hasRawProductMappings(generateImage, rawProductMapping, rawProductIds))
                 )
                 .orderBy(generateImage.createdAt.desc(), generateImage.id.desc())
                 .limit(limit)
@@ -145,17 +146,12 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
 
     private BooleanExpression resolvedGenerationTypeCondition(
             QGenerateImage generateImage,
-            GenerateImageType generationType
+            Set<GenerateImageType> generationTypes
     ) {
-        if (generationType == null) {
+        if (generationTypes == null || generationTypes.isEmpty()) {
             return null;
         }
-        if (generationType == GenerateImageType.LIST) {
-            return generateImage.generationType.eq(GenerateImageType.LIST)
-                    .or(generateImage.generationType.isNull().and(generateImage.house.banner.isNotNull()));
-        }
-        return generateImage.generationType.eq(GenerateImageType.RECOMMEND)
-                .or(generateImage.generationType.isNull().and(generateImage.house.banner.isNull()));
+        return generateImage.generationType.in(generationTypes);
     }
 
     private BooleanExpression hasBannerMappedRawProducts(
@@ -174,16 +170,16 @@ public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCusto
         return mappedByHouseBanner;
     }
 
-    private BooleanExpression hasUsedRawProducts(
+    private BooleanExpression hasRawProductMappings(
             QGenerateImage generateImage,
-            QGenerateImageUsedProduct usedProductMapping,
+            QGenerateImageRawProduct rawProductMapping,
             List<Long> rawProductIds
     ) {
         return JPAExpressions.selectOne()
-                .from(usedProductMapping)
+                .from(rawProductMapping)
                 .where(
-                        usedProductMapping.generateImage.id.eq(generateImage.id),
-                        usedProductMapping.curationRawProduct.id.in(rawProductIds)
+                        rawProductMapping.generateImage.id.eq(generateImage.id),
+                        rawProductMapping.curationRawProduct.id.in(rawProductIds)
                 )
                 .exists();
     }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -25,6 +25,7 @@ import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.GenerateImageException;
 import or.sopt.houme.global.api.handler.HouseException;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.springframework.stereotype.Service;
@@ -225,7 +226,14 @@ public class GenerateImageTransactionService {
     }
 
     private void saveGenerateImageRawProducts(GenerateImage generateImage, List<CurationRawProduct> selectedProducts) {
-        if (generateImage == null || selectedProducts == null || selectedProducts.isEmpty()) {
+        if (generateImage == null) {
+            return;
+        }
+        if (generateImage.getGenerationType() == GenerateImageType.PRODUCT
+                && (selectedProducts == null || selectedProducts.isEmpty())) {
+            throw new GenerateImageException(ErrorCode.MISSING_SELECTED_PRODUCTS);
+        }
+        if (selectedProducts == null || selectedProducts.isEmpty()) {
             return;
         }
 

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -2,14 +2,18 @@ package or.sopt.houme.domain.generateImage.service;
 
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.service.CreditService;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.generateImage.presentation.dto.request.GenerateImageRequest;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.ImageInfoResponse;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
@@ -38,6 +42,7 @@ public class GenerateImageTransactionService {
     private final HouseService houseService;
     private final HouseFloorPlanRepository houseFloorPlanRepository;
     private final GenerateImageService generateImageService;
+    private final GenerateImageRawProductRepository generateImageRawProductRepository;
     private final UserService userService;
 
     // DB 관련 로직을 위한 별도의 @Transactional 메서드 생성
@@ -141,7 +146,7 @@ public class GenerateImageTransactionService {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
-                GenerateImageType.LIST
+                resolveListGenerationType(banner)
         );
 
         creditService.commitCreditDeletion(lockedCredit);
@@ -174,7 +179,7 @@ public class GenerateImageTransactionService {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
-                GenerateImageType.LIST
+                GenerateImageType.FULL_FUNNEL
         );
 
         creditService.commitCreditDeletion(lockedCredit);
@@ -189,19 +194,53 @@ public class GenerateImageTransactionService {
             Long floorPlanId,
             boolean isMirror,
             String finalPrompt,
-            ImageUploadResponseDTO imageResponse
+            ImageUploadResponseDTO imageResponse,
+            List<CurationRawProduct> selectedProducts
     ) {
         House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror);
 
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
-                GenerateImageType.LIST
+                GenerateImageType.PRODUCT
         );
+        saveGenerateImageRawProducts(generateImage, selectedProducts);
 
         creditService.commitCreditDeletion(lockedCredit);
         userService.updateHasGeneratedImage(user);
         return GenerateImageV4Response.of(generateImage.getId(), generateImage.getUrl(), isMirror);
+    }
+
+    private GenerateImageType resolveListGenerationType(Banner banner) {
+        if (banner == null || banner.getBannerType() == null) {
+            return GenerateImageType.LEGACY;
+        }
+        if (banner.getBannerType() == BannerType.BANNER) {
+            return GenerateImageType.BANNER;
+        }
+        if (banner.getBannerType() == BannerType.STYLE) {
+            return GenerateImageType.STYLE;
+        }
+        return GenerateImageType.LEGACY;
+    }
+
+    private void saveGenerateImageRawProducts(GenerateImage generateImage, List<CurationRawProduct> selectedProducts) {
+        if (generateImage == null || selectedProducts == null || selectedProducts.isEmpty()) {
+            return;
+        }
+
+        List<GenerateImageRawProduct> mappings = new ArrayList<>();
+        int sortOrder = 1;
+        for (CurationRawProduct selectedProduct : selectedProducts) {
+            if (selectedProduct == null) {
+                continue;
+            }
+            mappings.add(GenerateImageRawProduct.of(generateImage, selectedProduct, sortOrder));
+            sortOrder++;
+        }
+        if (!mappings.isEmpty()) {
+            generateImageRawProductRepository.saveAll(mappings);
+        }
     }
 
     private FloorPlan getFloorPlanOrThrow(House house) {

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -190,7 +190,7 @@ public class GenerateImageFacade {
                 generateImage = generateImageService.createGenerateImage(
                         imageUploadResponseDTO,
                         house,
-                        GenerateImageType.RECOMMEND
+                        GenerateImageType.FULL_FUNNEL
                 );
 
             } catch (Exception e) {
@@ -304,7 +304,7 @@ public class GenerateImageFacade {
                     imageUploadResponseDTO,
                     priorityTag,
                     activity,
-                    GenerateImageType.RECOMMEND
+                    GenerateImageType.FULL_FUNNEL
             );
 
             // 만약 Fallback 이미지라면, 예외처리
@@ -622,7 +622,8 @@ public class GenerateImageFacade {
                     request.floorPlanId(),
                     request.isMirror(),
                     prompt,
-                    imageUploadResponseDTO
+                    imageUploadResponseDTO,
+                    selectedProducts
             );
         } catch (ValidException validException) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
@@ -750,7 +751,7 @@ public class GenerateImageFacade {
                         generateImageRequest,
                         priorityIdList,
                         lockedCredit,
-                        GenerateImageType.RECOMMEND
+                        GenerateImageType.FULL_FUNNEL
                 );
 
 

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GeneratedImageMetaResponse.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/presentation/dto/response/GeneratedImageMetaResponse.java
@@ -3,10 +3,11 @@ package or.sopt.houme.domain.generateImageResult.presentation.dto.response;
 public record GeneratedImageMetaResponse(
         Long imageId,
         String imageUrl,
-        boolean isMirror
+        boolean isMirror,
+        String generationType
 ) {
 
-    public static GeneratedImageMetaResponse of(Long imageId, String imageUrl, boolean isMirror) {
-        return new GeneratedImageMetaResponse(imageId, imageUrl, isMirror);
+    public static GeneratedImageMetaResponse of(Long imageId, String imageUrl, boolean isMirror, String generationType) {
+        return new GeneratedImageMetaResponse(imageId, imageUrl, isMirror, generationType);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -103,7 +103,8 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
         return GeneratedImageMetaResponse.of(
                 generateImage.getId(),
                 generateImage.getUrl(),
-                isMirror
+                isMirror,
+                resolveApiGenerationType(generateImage)
         );
     }
 
@@ -223,6 +224,17 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
             return false;
         }
         return houseService.getIsMirrorByHouseId(generateImage.getHouse().getId());
+    }
+
+    private String resolveApiGenerationType(GenerateImage generateImage) {
+        GenerateImageType generationType = generateImage.getGenerationType();
+        if (generationType == null || generationType == GenerateImageType.LIST) {
+            return GenerateImageType.LEGACY.name();
+        }
+        if (generationType == GenerateImageType.RECOMMEND) {
+            return GenerateImageType.FULL_FUNNEL.name();
+        }
+        return generationType.name();
     }
 
     private void validateListResultAccessible(GenerateImage generateImage) {

--- a/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImpl.java
@@ -18,7 +18,9 @@ import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultProductResponse;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
@@ -51,6 +53,7 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
 
     private final GenerateImageService generateImageService;
     private final GenerateImageRepository generateImageRepository;
+    private final GenerateImageRawProductRepository generateImageRawProductRepository;
     private final BannerRepository bannerRepository;
     private final CurationRawProductColorRepository curationRawProductColorRepository;
     private final CurationRawProductRepository curationRawProductRepository;
@@ -198,7 +201,11 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
                         selectedRawProductIds,
                         generateImage.getId(),
                         RELATED_IMAGE_LIMIT,
-                        GenerateImageType.LIST
+                        Set.of(
+                                GenerateImageType.BANNER,
+                                GenerateImageType.STYLE,
+                                GenerateImageType.PRODUCT
+                        )
                 )
                 .stream()
                 .map(related -> RelatedImageResponse.of(
@@ -219,14 +226,27 @@ public class GenerateImageResultServiceImpl implements GenerateImageResultServic
     }
 
     private void validateListResultAccessible(GenerateImage generateImage) {
-        boolean hasBanner = generateImage.getHouse() != null && generateImage.getHouse().getBanner() != null;
-        boolean isListType = generateImage.getGenerationType() == GenerateImageType.LIST;
-        if (!hasBanner || !isListType) {
+        GenerateImageType type = generateImage.getGenerationType();
+        boolean supportedType = type == GenerateImageType.BANNER
+                || type == GenerateImageType.STYLE
+                || type == GenerateImageType.PRODUCT;
+        if (!supportedType) {
             throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_TYPE);
         }
     }
 
     private List<CurationRawProduct> resolveSelectedRawProducts(GenerateImage generateImage) {
+        GenerateImageType type = generateImage.getGenerationType();
+
+        if (type == GenerateImageType.PRODUCT) {
+            List<GenerateImageRawProduct> mappings =
+                    generateImageRawProductRepository.findAllByGenerateImageIdWithRawProduct(generateImage.getId());
+            return mappings.stream()
+                    .map(GenerateImageRawProduct::getCurationRawProduct)
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
+
         Banner banner = generateImage.getHouse() != null ? generateImage.getHouse().getBanner() : null;
         if (banner == null) {
             throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_TYPE);

--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageGeneratedImageV2Response.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageGeneratedImageV2Response.java
@@ -91,7 +91,10 @@ public record MyPageGeneratedImageV2Response(
     }
 
     public enum ViewType {
-        LIST,
-        RECOMMEND
+        BANNER,
+        STYLE,
+        PRODUCT,
+        FULL_FUNNEL,
+        LEGACY
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -226,6 +226,15 @@ public class UserServiceImpl implements UserService {
             throw new GenerateImageException(ErrorCode.NOT_FOUND_GENERATE_IMAGE_ENTITY);
         }
 
+        // 추천형 결과 페이지는 FULL_FUNNEL 타입만 허용합니다.
+        // LEGACY 포함 비허용 타입은 기존 컨벤션대로 INVALID_GENERATE_IMAGE_TYPE(40030)로 처리합니다.
+        List<GenerateImage> fullFunnelImages = generateImages.stream()
+                .filter(generateImage -> generateImage.getGenerationType() == GenerateImageType.FULL_FUNNEL)
+                .toList();
+        if (fullFunnelImages.isEmpty()) {
+            throw new GenerateImageException(ErrorCode.INVALID_GENERATE_IMAGE_TYPE);
+        }
+
         List<Boolean> likes = new ArrayList<>();
         List<Tag> tags = new ArrayList<>();
         // 선택했던 factor 조회
@@ -235,7 +244,7 @@ public class UserServiceImpl implements UserService {
         Optional<Preference> preference;
 
         // 3. 최신 GenerateImagePreference 조회 (선호 여부)
-        for (GenerateImage generateImage : generateImages) {
+        for (GenerateImage generateImage : fullFunnelImages) {
             Optional<GenerateImagePreference> optionalGenerateImagePreference =
                     generateImagePreferenceRepository.findFirstByGenerateImageIdOrderByIdDesc(generateImage.getId());
 
@@ -269,9 +278,9 @@ public class UserServiceImpl implements UserService {
 
         // 4. GenerateImage 리스트와 likes 리스트를 함께 사용하여 DTO 변환
         List<ImageHistoriesResultPageResponse.ImageHistoryResultPageResponse> histories =
-                IntStream.range(0, generateImages.size()) // 인덱스를 활용하여 스트림 생성
+                IntStream.range(0, fullFunnelImages.size()) // 인덱스를 활용하여 스트림 생성
                         .mapToObj(i -> {
-                            GenerateImage generateImage = generateImages.get(i);
+                            GenerateImage generateImage = fullFunnelImages.get(i);
                             Boolean isLike = likes.get(i); // likes 리스트에서 해당 인덱스의 값 가져오기
                             Tag tag = tags.get(i);
                             Factor factor = factors.get(i);

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -192,7 +192,7 @@ public class UserServiceImpl implements UserService {
             Banner banner = resolveBanner(generateImage, bannersById);
             MyPageGeneratedImageV2Response.ItemResponse item = MyPageGeneratedImageV2Response.ItemResponse.of(
                     generateImage.getId(),
-                    MyPageGeneratedImageV2Response.ViewType.valueOf(generationType.name()),
+                    resolveMyPageViewType(generationType),
                     generateImage.getUrl(),
                     generateImage.getCreatedAt(),
                     banner != null ? banner.getBannerTitle() : null,
@@ -209,6 +209,19 @@ public class UserServiceImpl implements UserService {
                 .toList();
 
         return MyPageGeneratedImageV2Response.of(groups);
+    }
+
+    private MyPageGeneratedImageV2Response.ViewType resolveMyPageViewType(GenerateImageType generationType) {
+        if (generationType == null) {
+            return MyPageGeneratedImageV2Response.ViewType.LEGACY;
+        }
+        if (generationType == GenerateImageType.RECOMMEND) {
+            return MyPageGeneratedImageV2Response.ViewType.FULL_FUNNEL;
+        }
+        if (generationType == GenerateImageType.LIST) {
+            return MyPageGeneratedImageV2Response.ViewType.LEGACY;
+        }
+        return MyPageGeneratedImageV2Response.ViewType.valueOf(generationType.name());
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -15,8 +15,10 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductColorReposito
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageUsedProduct;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
@@ -87,6 +89,7 @@ public class UserServiceImpl implements UserService {
     private final PreferenceRepository preferenceRepository;
     private final PreferenceFactorRepository preferenceFactorRepository;
     private final BannerRepository bannerRepository;
+    private final GenerateImageRawProductRepository generateImageRawProductRepository;
     private final GenerateImageUsedProductRepository generateImageUsedProductRepository;
     private final RecommendFurnitureRepository recommendFurnitureRepository;
     private final JjymRepository jjymRepository;
@@ -457,16 +460,38 @@ public class UserServiceImpl implements UserService {
         }
 
         if (!mappedProductImageIds.isEmpty()) {
-            List<GenerateImageUsedProduct> mappings = generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(mappedProductImageIds);
-            Map<Long, List<CurationRawProduct>> mappedProductsByImageId = mappings.stream()
+            List<GenerateImageRawProduct> rawMappings =
+                    generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(mappedProductImageIds);
+            Map<Long, List<CurationRawProduct>> rawMappedProductsByImageId = rawMappings.stream()
                     .collect(Collectors.groupingBy(
                             mapping -> mapping.getGenerateImage().getId(),
                             LinkedHashMap::new,
-                            Collectors.mapping(GenerateImageUsedProduct::getCurationRawProduct, Collectors.toList())
+                            Collectors.mapping(GenerateImageRawProduct::getCurationRawProduct, Collectors.toList())
                     ));
 
+            List<Long> fallbackImageIds = mappedProductImageIds.stream()
+                    .filter(imageId -> !rawMappedProductsByImageId.containsKey(imageId))
+                    .toList();
+
+            Map<Long, List<CurationRawProduct>> usedMappedProductsByImageId = Map.of();
+            if (!fallbackImageIds.isEmpty()) {
+                List<GenerateImageUsedProduct> usedMappings =
+                        generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(fallbackImageIds);
+                usedMappedProductsByImageId = usedMappings.stream()
+                        .collect(Collectors.groupingBy(
+                                mapping -> mapping.getGenerateImage().getId(),
+                                LinkedHashMap::new,
+                                Collectors.mapping(GenerateImageUsedProduct::getCurationRawProduct, Collectors.toList())
+                        ));
+            }
+
             for (Long imageId : mappedProductImageIds) {
-                rawProductsByImageId.put(imageId, mappedProductsByImageId.getOrDefault(imageId, List.of()));
+                List<CurationRawProduct> rawMapped = rawMappedProductsByImageId.get(imageId);
+                if (rawMapped != null) {
+                    rawProductsByImageId.put(imageId, rawMapped);
+                    continue;
+                }
+                rawProductsByImageId.put(imageId, usedMappedProductsByImageId.getOrDefault(imageId, List.of()));
             }
         }
 

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     INVALID_GENERATE_IMAGE_RESULT_REQUEST(HttpStatus.BAD_REQUEST, 40029, "이미지 결과 조회 요청 값이 유효하지 않습니다."),
     INVALID_GENERATE_IMAGE_TYPE(HttpStatus.BAD_REQUEST, 40030, "해당 API에서 지원하지 않는 이미지 생성 타입입니다."),
     INVALID_FLOOR_PLAN_VIEW(HttpStatus.BAD_REQUEST, 40031, "도면 뷰 문자열을 찾을 수 없습니다."),
+    MISSING_SELECTED_PRODUCTS(HttpStatus.BAD_REQUEST, 40032, "상품 기반 이미지 생성에는 선택한 상품이 필요합니다."),
 
     // 네이버 쇼핑 API 관련 예외
     NAVER_API_DATA_PARSE_ERROR(HttpStatus.BAD_REQUEST, 40013, "네이버 API 응답의 productId 필드를 숫자로 변환하는 중 오류가 발생했습니다."),

--- a/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
@@ -129,7 +129,7 @@ class GenerateImageRepositoryImplTest {
                 .originalFilename("current-origin.png")
                 .fileExtension("png")
                 .house(house)
-                .generationType(GenerateImageType.LIST)
+                .generationType(GenerateImageType.BANNER)
                 .build();
         em.persist(current);
 
@@ -139,7 +139,7 @@ class GenerateImageRepositoryImplTest {
                 .originalFilename("related1-origin.png")
                 .fileExtension("png")
                 .house(house)
-                .generationType(GenerateImageType.LIST)
+                .generationType(GenerateImageType.BANNER)
                 .build();
         em.persist(related1);
 
@@ -149,7 +149,7 @@ class GenerateImageRepositoryImplTest {
                 .originalFilename("related2-origin.png")
                 .fileExtension("png")
                 .house(house)
-                .generationType(GenerateImageType.RECOMMEND)
+                .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
         em.persist(related2);
 
@@ -166,7 +166,7 @@ class GenerateImageRepositoryImplTest {
                 .originalFilename("non-matched-origin.png")
                 .fileExtension("png")
                 .house(nonMatchedHouse)
-                .generationType(GenerateImageType.LIST)
+                .generationType(GenerateImageType.BANNER)
                 .build();
         em.persist(nonMatched);
 
@@ -205,5 +205,14 @@ class GenerateImageRepositoryImplTest {
         assertThat(result).extracting(GenerateImage::getId).doesNotContain(current.getId());
         assertThat(result).extracting(GenerateImage::getId).doesNotHaveDuplicates();
         assertThat(result).extracting(GenerateImage::getId).containsExactly(related1.getId());
+
+        List<GenerateImage> emptyTypeResult = generateImageRepositoryImpl.findRelatedImagesByRawProductIds(
+                List.of(targetRawProduct.getId()),
+                current.getId(),
+                10,
+                Set.of()
+        );
+
+        assertThat(emptyTypeResult).isEmpty();
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImplTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -198,7 +199,7 @@ class GenerateImageRepositoryImplTest {
                 List.of(targetRawProduct.getId()),
                 current.getId(),
                 10,
-                GenerateImageType.LIST
+                Set.of(GenerateImageType.BANNER, GenerateImageType.STYLE, GenerateImageType.PRODUCT)
         );
 
         assertThat(result).extracting(GenerateImage::getId).doesNotContain(current.getId());

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
@@ -15,6 +15,8 @@ import or.sopt.houme.domain.house.service.HouseService;
 import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.GenerateImageException;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -214,5 +216,46 @@ class GenerateImageTransactionServiceTest {
         verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.FULL_FUNNEL);
         verify(creditService).commitCreditDeletion(lockedCredit);
         verify(userService).updateHasGeneratedImage(user);
+    }
+
+    @Test
+    @DisplayName("PRODUCT 이미지 저장 시 선택 상품이 비어있으면 예외를 던진다")
+    void saveProductImageAndConfirmCredit_throwsWhenSelectedProductsMissing() {
+        User user = mock(User.class);
+        Credit lockedCredit = mock(Credit.class);
+        House house = mock(House.class);
+        ImageUploadResponseDTO imageResponse = ImageUploadResponseDTO.from(
+                "file.jpg",
+                "origin.jpg",
+                "https://cdn.example.com/file.jpg",
+                "image/jpeg"
+        );
+
+        GenerateImage generateImage = GenerateImage.builder()
+                .id(777L)
+                .url("https://cdn.example.com/file.jpg")
+                .house(house)
+                .generationType(GenerateImageType.PRODUCT)
+                .build();
+
+        when(houseService.createTemplateHouse(user, null, "prompt", 1L, false)).thenReturn(house);
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.PRODUCT))
+                .thenReturn(generateImage);
+
+        assertThatThrownBy(() -> generateImageTransactionService.saveProductImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                1L,
+                false,
+                "prompt",
+                imageResponse,
+                List.of()
+        ))
+                .isInstanceOf(GenerateImageException.class)
+                .extracting(exception -> ((GenerateImageException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.MISSING_SELECTED_PRODUCTS);
+
+        verify(creditService, never()).commitCreditDeletion(any());
+        verify(userService, never()).updateHasGeneratedImage(any());
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
@@ -1,13 +1,18 @@
 package or.sopt.houme.domain.generateImage.service;
 
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.presentation.dto.response.BannerGenerateImageResponse;
+import or.sopt.houme.domain.generateImage.presentation.dto.response.GenerateImageV4Response;
+import or.sopt.houme.domain.house.model.entity.enums.Activity;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.service.HouseService;
+import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.service.UserService;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
@@ -17,6 +22,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,9 +41,13 @@ class GenerateImageTransactionServiceTest {
 
     @Mock
     private HouseService houseService;
+    @Mock
+    private HouseFloorPlanRepository houseFloorPlanRepository;
 
     @Mock
     private GenerateImageService generateImageService;
+    @Mock
+    private GenerateImageRawProductRepository generateImageRawProductRepository;
 
     @Mock
     private UserService userService;
@@ -69,9 +80,10 @@ class GenerateImageTransactionServiceTest {
                 .generationType(GenerateImageType.LIST)
                 .build();
 
+        when(banner.getBannerType()).thenReturn(BannerType.BANNER);
         when(houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror))
                 .thenReturn(house);
-        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenReturn(generateImage);
 
         BannerGenerateImageResponse response = generateImageTransactionService.saveBannerImageAndConfirmCredit(
@@ -88,7 +100,7 @@ class GenerateImageTransactionServiceTest {
         assertThat(response.imageUrl()).isEqualTo("https://cdn.example.com/file.jpg");
         assertThat(response.isMirror()).isTrue();
         verify(houseService).createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
-        verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.LIST);
+        verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.BANNER);
         verify(creditService).commitCreditDeletion(lockedCredit);
         verify(userService).updateHasGeneratedImage(user);
     }
@@ -107,8 +119,9 @@ class GenerateImageTransactionServiceTest {
                 "image/jpeg"
         );
 
+        when(banner.getBannerType()).thenReturn(BannerType.BANNER);
         when(houseService.createTemplateHouse(user, banner, "prompt", 1L, false)).thenReturn(house);
-        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenThrow(new RuntimeException("image save failed"));
 
         assertThatThrownBy(() -> generateImageTransactionService.saveBannerImageAndConfirmCredit(
@@ -134,6 +147,7 @@ class GenerateImageTransactionServiceTest {
                 "image/jpeg"
         );
 
+        when(banner.getBannerType()).thenReturn(BannerType.BANNER);
         GenerateImage generateImage = GenerateImage.builder()
                 .id(102L)
                 .url("https://cdn.example.com/file.jpg")
@@ -145,7 +159,7 @@ class GenerateImageTransactionServiceTest {
                 .build();
 
         when(houseService.createTemplateHouse(user, banner, "prompt", 2L, true)).thenReturn(house);
-        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.LIST))
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenReturn(generateImage);
         doThrow(new RuntimeException("credit commit failed"))
                 .when(creditService).commitCreditDeletion(lockedCredit);
@@ -157,5 +171,48 @@ class GenerateImageTransactionServiceTest {
 
         verify(creditService).commitCreditDeletion(lockedCredit);
         verify(userService, never()).updateHasGeneratedImage(any());
+    }
+
+    @Test
+    @DisplayName("v4 이미지 저장 성공 시 FULL_FUNNEL 타입으로 저장한다")
+    void saveV4ImageAndConfirmCredit_savesFullFunnelType() {
+        User user = mock(User.class);
+        Credit lockedCredit = mock(Credit.class);
+        House house = mock(House.class);
+        ImageUploadResponseDTO imageResponse = ImageUploadResponseDTO.from(
+                "file.jpg",
+                "origin.jpg",
+                "https://cdn.example.com/file.jpg",
+                "image/jpeg"
+        );
+
+        GenerateImage generateImage = GenerateImage.builder()
+                .id(501L)
+                .url("https://cdn.example.com/file.jpg")
+                .house(house)
+                .generationType(GenerateImageType.FULL_FUNNEL)
+                .build();
+
+        when(houseService.createTemplateHouse(user, null, "prompt", 3L, false)).thenReturn(house);
+        when(houseService.updateHouseActivity(anyLong(), eq(Activity.REMOTE_WORK))).thenReturn(house);
+        when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.FULL_FUNNEL))
+                .thenReturn(generateImage);
+
+        GenerateImageV4Response response = generateImageTransactionService.saveV4ImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                3L,
+                false,
+                "prompt",
+                imageResponse,
+                Activity.REMOTE_WORK,
+                List.of(),
+                List.of()
+        );
+
+        assertThat(response.imageId()).isEqualTo(501L);
+        verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.FULL_FUNNEL);
+        verify(creditService).commitCreditDeletion(lockedCredit);
+        verify(userService).updateHasGeneratedImage(user);
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -232,7 +232,7 @@ class GenerateImageFacadeTest {
         when(generateImageService.createGenerateImage(
                 imageUploadResponseDTO,
                 house,
-                GenerateImageType.RECOMMEND
+                GenerateImageType.FULL_FUNNEL
         )).thenReturn(generateImage);
 
         // When
@@ -355,7 +355,7 @@ class GenerateImageFacadeTest {
                 imageUploadResponseDTO,
                 tag,
                 Activity.valueOf(generateImageRequest.activity()),
-                GenerateImageType.RECOMMEND
+                GenerateImageType.FULL_FUNNEL
         )).thenReturn(tempImageInfoResponse);
 
         // When

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -685,7 +685,7 @@ class GenerateImageFacadeTest {
                 .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
         when(geminiImageService.createImageWithReferences(any(), any())).thenReturn(imageUploadResponseDTO);
         when(generateImageTransactionService.saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO)
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
         )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
 
         GenerateImageV4Response response = generateImageFacade.generateImageByProducts(user, request);
@@ -702,7 +702,7 @@ class GenerateImageFacadeTest {
                         && urls.contains("https://p3"))
         );
         verify(generateImageTransactionService).saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO)
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
         );
     }
 }

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -89,12 +89,13 @@ class GenerateImageResultServiceImplTest {
     private HouseService houseService;
 
     @Test
-    @DisplayName("이미지 메타 조회 시 imageUrl과 isMirror를 반환한다")
-    void getGeneratedImageMeta_returnsImageUrlAndIsMirror() {
+    @DisplayName("이미지 메타 조회 시 imageUrl/isMirror/generationType을 반환한다")
+    void getGeneratedImageMeta_returnsImageUrlAndIsMirrorAndGenerationType() {
         House house = House.builder().id(100L).build();
         GenerateImage image = GenerateImage.builder()
                 .id(1L)
                 .url("https://generated-image")
+                .generationType(GenerateImageType.PRODUCT)
                 .house(house)
                 .build();
         User user = User.builder().id(1L).build();
@@ -107,6 +108,7 @@ class GenerateImageResultServiceImplTest {
         assertThat(response.imageId()).isEqualTo(1L);
         assertThat(response.imageUrl()).isEqualTo("https://generated-image");
         assertThat(response.isMirror()).isTrue();
+        assertThat(response.generationType()).isEqualTo("PRODUCT");
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImageResult/service/GenerateImageResultServiceImplTest.java
@@ -23,8 +23,10 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.generateImage.service.GenerateImageService;
 import or.sopt.houme.domain.generateImageResult.presentation.dto.response.GenerateImageResultResponse;
@@ -39,6 +41,7 @@ import or.sopt.houme.global.api.handler.GenerateImageException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,6 +67,8 @@ class GenerateImageResultServiceImplTest {
 
     @Mock
     private GenerateImageUsedProductRepository generateImageUsedProductRepository;
+    @Mock
+    private GenerateImageRawProductRepository generateImageRawProductRepository;
 
     @Mock
     private CurationRawProductColorRepository curationRawProductColorRepository;
@@ -105,12 +110,12 @@ class GenerateImageResultServiceImplTest {
     }
 
     @Test
-    @DisplayName("LIST 타입이 아닌 이미지 조회 요청이면 예외가 발생한다")
-    void getListResultItems_throws_whenGenerationTypeIsNotList() {
+    @DisplayName("목록형 지원 타입(BANNER/STYLE/PRODUCT)이 아닌 이미지 조회 요청이면 예외가 발생한다")
+    void getListResultItems_throws_whenGenerationTypeIsNotListFamily() {
         GenerateImage recommendImage = GenerateImage.builder()
                 .id(1L)
                 .url("https://image")
-                .generationType(GenerateImageType.RECOMMEND)
+                .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
 
         when(generateImageService.findGenerateImage(1L)).thenReturn(recommendImage);
@@ -122,7 +127,7 @@ class GenerateImageResultServiceImplTest {
     }
 
     @Test
-    @DisplayName("LIST 타입 이미지 조회 시 배너에 매핑된 raw product 목록을 응답한다")
+    @DisplayName("BANNER 타입 이미지 조회 시 배너에 매핑된 raw product 목록을 응답한다")
     void getListResultItems_returnsProductsFromBanner() {
         Banner bannerRef = Banner.builder()
                 .id(10L)
@@ -136,7 +141,7 @@ class GenerateImageResultServiceImplTest {
         GenerateImage listImage = GenerateImage.builder()
                 .id(1L)
                 .url("https://generated-image")
-                .generationType(GenerateImageType.LIST)
+                .generationType(GenerateImageType.BANNER)
                 .house(house)
                 .build();
 
@@ -198,17 +203,11 @@ class GenerateImageResultServiceImplTest {
     }
 
     @Test
-    @DisplayName("유사 상품 조회는 가구타입 우선 후보를 먼저 채우고 최대 4개를 반환한다")
-    void getSimilarItems_prioritizesFurnitureTypeAndLimitsToFour() {
-        Banner bannerRef = Banner.builder().id(10L).build();
-        House house = House.builder()
-                .id(100L)
-                .banner(bannerRef)
-                .build();
-        GenerateImage listImage = GenerateImage.builder()
+    @DisplayName("PRODUCT 타입 유사 상품 조회는 선택상품 기준으로 후보를 채우고 최대 4개를 반환한다")
+    void getSimilarItems_productType_prioritizesFurnitureTypeAndLimitsToFour() {
+        GenerateImage productImage = GenerateImage.builder()
                 .id(1L)
-                .generationType(GenerateImageType.LIST)
-                .house(house)
+                .generationType(GenerateImageType.PRODUCT)
                 .build();
 
         CurationRawProduct selected = CurationRawProduct.builder()
@@ -218,14 +217,7 @@ class GenerateImageResultServiceImplTest {
                 .productName("선택 상품")
                 .build();
 
-        BannerCurationRawProduct mapping = BannerCurationRawProduct.builder()
-                .id(1L)
-                .curationRawProduct(selected)
-                .build();
-        Banner bannerWithRawProducts = Banner.builder()
-                .id(10L)
-                .bannerRawProducts(List.of(mapping))
-                .build();
+        GenerateImageRawProduct mapping = GenerateImageRawProduct.of(productImage, selected, 1);
 
         FurnitureType furnitureType = FurnitureType.builder().id(1L).build();
         Furniture furniture = Furniture.builder().id(1L).furnitureType(furnitureType).build();
@@ -241,8 +233,9 @@ class GenerateImageResultServiceImplTest {
         CurationRawProduct c3 = CurationRawProduct.builder().id(203L).productId(2003L).productName("furniture-type-3").build();
         CurationRawProduct c4 = CurationRawProduct.builder().id(204L).productId(2004L).productName("furniture-type-4").build();
 
-        when(generateImageService.findGenerateImage(1L)).thenReturn(listImage);
-        when(bannerRepository.findAllByIdInWithRawProducts(List.of(10L))).thenReturn(List.of(bannerWithRawProducts));
+        when(generateImageService.findGenerateImage(1L)).thenReturn(productImage);
+        when(generateImageRawProductRepository.findAllByGenerateImageIdWithRawProduct(1L))
+                .thenReturn(List.of(mapping));
         when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(List.of(101L)))
                 .thenReturn(List.of(selectedProductMapping));
         when(curationRawProductRepository.findAllSimilarByFurnitureTypeIds(eq(List.of(1L)), eq(List.of(101L)), any()))
@@ -287,46 +280,34 @@ class GenerateImageResultServiceImplTest {
     }
 
     @Test
-    @DisplayName("related-images는 LIST 타입 기준으로 현재 이미지를 제외하고 최신순/중복제거 결과를 반환한다")
+    @DisplayName("related-images는 PRODUCT 타입 기준으로 현재 이미지를 제외하고 최신순/중복제거 결과를 반환한다")
     void getRelatedImages_returnsLatestDistinctImagesExcludingCurrent() {
-        Banner bannerRef = Banner.builder().id(10L).build();
-        House house = House.builder()
-                .id(100L)
-                .banner(bannerRef)
-                .build();
         GenerateImage current = GenerateImage.builder()
                 .id(1L)
-                .generationType(GenerateImageType.LIST)
-                .house(house)
+                .generationType(GenerateImageType.PRODUCT)
                 .build();
 
         CurationRawProduct selected = CurationRawProduct.builder()
                 .id(101L)
                 .productName("선택 상품")
                 .build();
-        BannerCurationRawProduct mapping = BannerCurationRawProduct.builder()
-                .id(1L)
-                .curationRawProduct(selected)
-                .build();
-        Banner bannerWithRawProducts = Banner.builder()
-                .id(10L)
-                .bannerRawProducts(List.of(mapping))
-                .build();
+        GenerateImageRawProduct mapping = GenerateImageRawProduct.of(current, selected, 1);
 
         GenerateImage related1 = GenerateImage.builder()
                 .id(200L)
                 .url("https://image-200")
-                .generationType(GenerateImageType.LIST)
-                .build();
-        GenerateImage related2 = GenerateImage.builder()
-                .id(199L)
-                .url("https://image-199")
-                .generationType(GenerateImageType.RECOMMEND)
+                .generationType(GenerateImageType.STYLE)
                 .build();
 
         when(generateImageService.findGenerateImage(1L)).thenReturn(current);
-        when(bannerRepository.findAllByIdInWithRawProducts(List.of(10L))).thenReturn(List.of(bannerWithRawProducts));
-        when(generateImageRepository.findRelatedImagesByRawProductIds(List.of(101L), 1L, 10, GenerateImageType.LIST))
+        when(generateImageRawProductRepository.findAllByGenerateImageIdWithRawProduct(1L))
+                .thenReturn(List.of(mapping));
+        when(generateImageRepository.findRelatedImagesByRawProductIds(
+                List.of(101L),
+                1L,
+                10,
+                Set.of(GenerateImageType.BANNER, GenerateImageType.STYLE, GenerateImageType.PRODUCT)
+        ))
                 .thenReturn(List.of(related1));
 
         User user = mock(User.class);
@@ -337,6 +318,6 @@ class GenerateImageResultServiceImplTest {
         assertThat(response.name()).isEqualTo("최윤하");
         assertThat(response.images()).hasSize(1);
         assertThat(response.images().get(0).id()).isEqualTo(200L);
-        assertThat(response.images().get(0).resultType()).isEqualTo("LIST");
+        assertThat(response.images().get(0).resultType()).isEqualTo("STYLE");
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -16,8 +16,10 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductColorReposito
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageType;
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImageUsedProduct;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
@@ -74,6 +76,7 @@ class UserServiceImplTest {
     private final PreferenceRepository preferenceRepository = mock(PreferenceRepository.class);
     private final PreferenceFactorRepository preferenceFactorRepository = mock(PreferenceFactorRepository.class);
     private final BannerRepository bannerRepository = mock(BannerRepository.class);
+    private final GenerateImageRawProductRepository generateImageRawProductRepository = mock(GenerateImageRawProductRepository.class);
     private final GenerateImageUsedProductRepository generateImageUsedProductRepository = mock(GenerateImageUsedProductRepository.class);
     private final RecommendFurnitureRepository recommendFurnitureRepository = mock(RecommendFurnitureRepository.class);
     private final JjymRepository jjymRepository = mock(JjymRepository.class);
@@ -93,6 +96,7 @@ class UserServiceImplTest {
             preferenceRepository,
             preferenceFactorRepository,
             bannerRepository,
+            generateImageRawProductRepository,
             generateImageUsedProductRepository,
             recommendFurnitureRepository,
             jjymRepository,
@@ -126,6 +130,7 @@ class UserServiceImplTest {
                 .id(100L)
                 .url("https://cdn.com/image.png")
                 .house(house)
+                .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
         ReflectionTestUtils.setField(generateImage, "createdAt", LocalDateTime.of(2026, 3, 24, 10, 0));
     }
@@ -241,12 +246,14 @@ class UserServiceImplTest {
                 .id(1L)
                 .url("https://example.com/image1.png")
                 .house(house)
+                .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
 
         GenerateImage generateImage2 = GenerateImage.builder()
                 .id(2L)
                 .url("https://example.com/image2.png")
                 .house(house)
+                .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
 
         GenerateImagePreference generateImagePreference1 = GenerateImagePreference.builder()
@@ -394,7 +401,7 @@ class UserServiceImplTest {
                 .id(201L)
                 .url("https://cdn.com/banner-image.png")
                 .house(houseWithBanner)
-                .generationType(GenerateImageType.LIST)
+                .generationType(GenerateImageType.BANNER)
                 .build();
         ReflectionTestUtils.setField(bannerImage, "createdAt", LocalDateTime.of(2026, 3, 24, 11, 0));
 
@@ -412,20 +419,20 @@ class UserServiceImplTest {
                 .fetchedAt(LocalDateTime.of(2026, 3, 24, 9, 30))
                 .build();
 
-        GenerateImage regularImage = GenerateImage.builder()
+        GenerateImage productImage = GenerateImage.builder()
                 .id(202L)
                 .url("https://cdn.com/regular-image.png")
                 .house(house)
-                .generationType(GenerateImageType.RECOMMEND)
+                .generationType(GenerateImageType.PRODUCT)
                 .build();
-        ReflectionTestUtils.setField(regularImage, "createdAt", LocalDateTime.of(2026, 3, 24, 10, 0));
+        ReflectionTestUtils.setField(productImage, "createdAt", LocalDateTime.of(2026, 3, 24, 10, 0));
 
         given(generateImageRepository.findAllByUserIdWithHouseAndBanner(user.getId()))
-                .willReturn(List.of(bannerImage, regularImage));
+                .willReturn(List.of(bannerImage, productImage));
         given(bannerRepository.findAllByIdInWithRawProducts(List.of(11L)))
                 .willReturn(List.of(banner));
-        given(generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(202L)))
-                .willReturn(List.of(GenerateImageUsedProduct.of(regularImage, regularRawProduct, 1)));
+        given(generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(202L)))
+                .willReturn(List.of(GenerateImageRawProduct.of(productImage, regularRawProduct, 1)));
 
         CurationRawProductColor bannerColor = CurationRawProductColor.builder()
                 .id(1L)
@@ -473,14 +480,14 @@ class UserServiceImplTest {
         assertThat(group.items()).hasSize(2);
 
         MyPageGeneratedImageV2Response.ItemResponse firstItem = group.items().get(0);
-        assertThat(firstItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.LIST);
+        assertThat(firstItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.LIST); // BANNER 계열
         assertThat(firstItem.bannerTitle()).isEqualTo("테스트 배너");
         assertThat(firstItem.productSummaryText()).isEqualTo("배너 가구로 생성된 이미지");
         assertThat(firstItem.usedProducts()).hasSize(1);
         assertThat(firstItem.usedProducts().get(0).isJjym()).isFalse();
 
         MyPageGeneratedImageV2Response.ItemResponse secondItem = group.items().get(1);
-        assertThat(secondItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.RECOMMEND);
+        assertThat(secondItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.LIST); // PRODUCT 계열
         assertThat(secondItem.bannerTitle()).isNull();
         assertThat(secondItem.productSummaryText()).isEqualTo("일반 가구로 생성된 이미지");
         assertThat(secondItem.usedProducts()).hasSize(1);

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -480,14 +480,14 @@ class UserServiceImplTest {
         assertThat(group.items()).hasSize(2);
 
         MyPageGeneratedImageV2Response.ItemResponse firstItem = group.items().get(0);
-        assertThat(firstItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.LIST); // BANNER 계열
+        assertThat(firstItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.BANNER);
         assertThat(firstItem.bannerTitle()).isEqualTo("테스트 배너");
         assertThat(firstItem.productSummaryText()).isEqualTo("배너 가구로 생성된 이미지");
         assertThat(firstItem.usedProducts()).hasSize(1);
         assertThat(firstItem.usedProducts().get(0).isJjym()).isFalse();
 
         MyPageGeneratedImageV2Response.ItemResponse secondItem = group.items().get(1);
-        assertThat(secondItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.LIST); // PRODUCT 계열
+        assertThat(secondItem.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.PRODUCT);
         assertThat(secondItem.bannerTitle()).isNull();
         assertThat(secondItem.productSummaryText()).isEqualTo("일반 가구로 생성된 이미지");
         assertThat(secondItem.usedProducts()).hasSize(1);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #529 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
1. 이미지 생성 타입 정합성 개선에 맞춰 응답 타입을 세분화했습니다.
  - `LIST`/`RECOMMEND` -> `BANNER`/`STYLE`/`PRODUCT`/`FULL_FUNNEL`/`LEGACY`
2. `/api/v2/mypage/images`의 `viewType`을 위 생성 타입에 맞게 변경했습니다.
3. `/api/v1/generated-images/{imageId}/meta` 응답에 `generationType` 필드를 추가했습니다.
4. 코드 병합하면서 dev DB의 레거시 데이터를 아래의 규칙에 따라 수정하겠습니다.
  - RECOMMEND -> FULL_FUNNEL
  - LIST && 매핑된 banner.type == BANNER -> BANNER
  - LIST && 매핑된 banner.type == STYLE -> STYLE
  - LIST && 매핑된 banner == null -> PRODUCT
  - 그 외는 LEGACY

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- LEGACY 타입의 이미지가 있다면 추적해서 `BANNER`/`STYLE`/`PRODUCT`/`FULL_FUNNEL` 중으로 맞출 필요가 있을 것 같습니다. (dev DB이기에 prod에는 LEGACY 데이터가 영향이 없기에 큰 문제가 될 것 같지는 않습니다.)

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 생성 이미지와 원본 상품 간 매핑 시스템 추가
  * API 응답에 생성 유형 정보 포함

* **개선 사항**
  * 생성 이미지 유형 세분화 (배너, 스타일, 상품, 풀퍼널, 레거시)
  * 상품 필터링 및 조회 로직 개선

* **더 이상 권장되지 않음**
  * 기존 LIST 및 RECOMMEND 생성 유형은 새로운 유형으로 대체됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->