### PR TITLE
[CHORE] 캐러셀 API 커서 기반 & 랜더마이즈 적용

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
@@ -29,6 +29,13 @@ public interface CurationRawProductRepositoryCustom {
     );
 
     Page<CurationRawProduct> findExposedRawProductsExcludingLikedByUser(Long userId, Pageable pageable);
+    Long findMaxExposedRawProductIdExcludingLikedByUser(Long userId);
+    List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserWithCursor(
+            Long userId,
+            Long cursor,
+            int size,
+            List<Long> excludedIds
+    );
 
     List<CurationRawProduct> findAllSimilarByFurnitureTypeIds(
             List<Long> furnitureTypeIds,

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Objects;
 
 @Repository
 @RequiredArgsConstructor
@@ -258,6 +259,73 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public Long findMaxExposedRawProductIdExcludingLikedByUser(Long userId) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QJjym jjym = QJjym.jjym;
+        QRecommendFurniture recommendFurniture = QRecommendFurniture.recommendFurniture;
+
+        BooleanExpression isNotLikedByUser = JPAExpressions
+                .selectOne()
+                .from(jjym)
+                .join(jjym.recommendFurniture, recommendFurniture)
+                .where(
+                        jjym.user.id.eq(userId),
+                        recommendFurniture.source.eq(CurationSource.RAW),
+                        recommendFurniture.furnitureProductId.eq(rawProduct.productId)
+                )
+                .notExists();
+
+        return queryFactory
+                .select(rawProduct.id.max())
+                .from(rawProduct)
+                .where(
+                        rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull()),
+                        isNotLikedByUser
+                )
+                .fetchOne();
+    }
+
+    @Override
+    public List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserWithCursor(
+            Long userId,
+            Long cursor,
+            int size,
+            List<Long> excludedIds
+    ) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QJjym jjym = QJjym.jjym;
+        QRecommendFurniture recommendFurniture = QRecommendFurniture.recommendFurniture;
+
+        BooleanExpression isNotLikedByUser = JPAExpressions
+                .selectOne()
+                .from(jjym)
+                .join(jjym.recommendFurniture, recommendFurniture)
+                .where(
+                        jjym.user.id.eq(userId),
+                        recommendFurniture.source.eq(CurationSource.RAW),
+                        recommendFurniture.furnitureProductId.eq(rawProduct.productId)
+                )
+                .notExists();
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull()));
+        where.and(isNotLikedByUser);
+        if (cursor != null) {
+            where.and(rawProduct.id.lt(cursor));
+        }
+        if (excludedIds != null && !excludedIds.isEmpty()) {
+            where.and(rawProduct.id.notIn(excludedIds.stream().filter(Objects::nonNull).toList()));
+        }
+
+        return queryFactory
+                .selectFrom(rawProduct)
+                .where(where)
+                .orderBy(rawProduct.id.desc())
+                .limit(size)
+                .fetch();
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
@@ -44,20 +44,20 @@ public class CarouselController {
 
     @GetMapping("/api/v2/carousels")
     @Operation(summary = "캐러셀 조회 API v2",
-            description = "실제 상품을 응답합니다. 한 번 조회 시, 다섯개의 캐러셀을 반환합니다. <br><br>" +
-                    "**page는 0부터** 넣어주세요 (null일시 0이 기본)")
+            description = "실제 상품을 응답합니다. 한 번 조회 시, 10개의 상품을 반환합니다. <br><br>" +
+                    "cursor가 없으면 랜덤 시작점에서 조회하고, cursor가 있으면 해당 id 미만을 이어서 조회합니다.")
     public ResponseEntity<ApiResponse<GetCarouselV2ListResponseDTO>> getCarouselsV2(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(value = "page", required = false, defaultValue = "0")
-            @Min(value = 0, message = "page는 0 이상이어야 합니다.")
-            Integer page) {
+            @RequestParam(value = "cursor", required = false)
+            @Min(value = 1, message = "cursor는 1 이상이어야 합니다.")
+            Long cursor) {
 
-        GetCarouselListResponseDTO carousels = carouselService.getCarouselV2(
-                page,
+        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(
+                cursor,
                 userDetails.getUser()
         );
 
-        return ResponseEntity.ok(ApiResponse.ok(GetCarouselV2ListResponseDTO.of(carousels.carouselResponseDTOS())));
+        return ResponseEntity.ok(ApiResponse.ok(carousels));
     }
 
 

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselV2ListResponseDTO.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselV2ListResponseDTO.java
@@ -2,9 +2,12 @@ package or.sopt.houme.domain.house.presentation.carousel.controller.dto;
 
 import java.util.List;
 
-public record GetCarouselV2ListResponseDTO(List<GetCarouselResponseDTO> carousels) {
+public record GetCarouselV2ListResponseDTO(
+        List<GetCarouselResponseDTO> carousels,
+        Long nextCursor
+) {
 
-    public static GetCarouselV2ListResponseDTO of(List<GetCarouselResponseDTO> carousels) {
-        return new GetCarouselV2ListResponseDTO(carousels);
+    public static GetCarouselV2ListResponseDTO of(List<GetCarouselResponseDTO> carousels, Long nextCursor) {
+        return new GetCarouselV2ListResponseDTO(carousels, nextCursor);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
@@ -1,12 +1,13 @@
 package or.sopt.houme.domain.house.service.carousel;
 
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
+import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.user.model.entity.User;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface CarouselService {
     GetCarouselListResponseDTO getCarousel(int page);
-    GetCarouselListResponseDTO getCarouselV2(int page, User user);
+    GetCarouselV2ListResponseDTO getCarouselV2(Long cursor, User user);
 
     @Transactional
     void likeCarousel(User user, Long carouselId);

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
@@ -7,6 +7,7 @@ import or.sopt.houme.domain.furniture.service.JjymService;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
+import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
 import or.sopt.houme.domain.preference.model.entity.CarouselPreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -15,11 +16,10 @@ import or.sopt.houme.domain.preference.repository.PreferenceRepository;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.CarouselException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +27,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CarouselServiceImpl implements CarouselService {
+    private static final int CAROUSEL_V2_SIZE = 10;
 
     private final CarouselCacheService carouselCacheService;
     private final CarouselRepository carouselRepository;
@@ -54,14 +55,45 @@ public class CarouselServiceImpl implements CarouselService {
     }
 
     @Override
-    public GetCarouselListResponseDTO getCarouselV2(int page, User user) {
-        int pageSize = 5;
-        List<GetCarouselResponseDTO> result = findExposedRawProductsExcludingJjym(user.getId(), page, pageSize)
-                .stream()
+    public GetCarouselV2ListResponseDTO getCarouselV2(Long cursor, User user) {
+        Long userId = user.getId();
+        List<CurationRawProduct> selected = new ArrayList<>();
+
+        Long effectiveCursor = cursor;
+        if (effectiveCursor == null) {
+            Long maxId = curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(userId);
+            if (maxId == null) {
+                return GetCarouselV2ListResponseDTO.of(List.of(), null);
+            }
+            long randomStartId = resolveRandomStartId(userId, maxId);
+            effectiveCursor = randomStartId + 1L;
+        }
+
+        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                userId,
+                effectiveCursor,
+                CAROUSEL_V2_SIZE,
+                List.of()
+        ));
+
+        if (cursor == null && selected.size() < CAROUSEL_V2_SIZE) {
+            List<Long> excludedIds = selected.stream().map(CurationRawProduct::getId).toList();
+            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                    userId,
+                    null,
+                    CAROUSEL_V2_SIZE - selected.size(),
+                    excludedIds
+            ));
+        }
+
+        List<GetCarouselResponseDTO> result = selected.stream()
                 .map(rawProduct -> GetCarouselResponseDTO.of(rawProduct.getId(), rawProduct.getProductImageUrl()))
                 .toList();
+        Long nextCursor = selected.size() < CAROUSEL_V2_SIZE
+                ? null
+                : selected.get(selected.size() - 1).getId();
 
-        return GetCarouselListResponseDTO.of(result);
+        return GetCarouselV2ListResponseDTO.of(result, nextCursor);
     }
     @Override
     @Transactional
@@ -81,15 +113,10 @@ public class CarouselServiceImpl implements CarouselService {
         carouselLikeLogService.createLikeLog(user, rawProductId);
     }
 
-    private Page<CurationRawProduct> findExposedRawProductsExcludingJjym(
-            Long userId,
-            int page,
-            int pageSize
-    ) {
-        return curationRawProductRepository.findExposedRawProductsExcludingLikedByUser(
-                userId,
-                PageRequest.of(page, pageSize)
-        );
+    private long resolveRandomStartId(Long userId, Long maxId) {
+        long seed = java.time.LocalDate.now().toEpochDay() ^ userId;
+        long positive = Math.abs(seed == Long.MIN_VALUE ? 0L : seed);
+        return (positive % maxId) + 1L;
     }
 
     private void updateLike(Long userId, Long carouselId, boolean isLike) {

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.JjymService;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
+import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
 import or.sopt.houme.domain.house.model.carousel.entity.CarouselType;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
@@ -22,8 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -113,16 +112,19 @@ class CarouselServiceImplTest {
                 .productImageUrl("image-102")
                 .build();
 
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUser(1L, PageRequest.of(0, 5)))
-                .thenReturn(new PageImpl<>(List.of(rawProduct1, rawProduct2), PageRequest.of(0, 5), 2));
+        when(curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(1L)).thenReturn(200L);
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                eq(1L), anyLong(), eq(10), eq(List.of())
+        )).thenReturn(List.of(rawProduct1, rawProduct2));
 
-        GetCarouselListResponseDTO result = carouselService.getCarouselV2(0, user);
+        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(null, user);
 
-        assertThat(result.carouselResponseDTOS()).hasSize(2);
-        assertThat(result.carouselResponseDTOS().get(0).carouselId()).isEqualTo(101L);
-        assertThat(result.carouselResponseDTOS().get(1).carouselId()).isEqualTo(102L);
+        assertThat(result.carousels()).hasSize(2);
+        assertThat(result.carousels().get(0).carouselId()).isEqualTo(101L);
+        assertThat(result.carousels().get(1).carouselId()).isEqualTo(102L);
+        assertThat(result.nextCursor()).isNull();
         verify(curationRawProductRepository, times(1))
-                .findExposedRawProductsExcludingLikedByUser(1L, PageRequest.of(0, 5));
+                .findExposedRawProductsExcludingLikedByUserWithCursor(eq(1L), anyLong(), eq(10), eq(List.of()));
         verifyNoInteractions(jjymService);
     }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #533

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- /api/v2/carousels 조회를 page 기반에서 cursor 기반으로 변경했습니다.
- 조회 조건은 기존 요구사항대로 is_exposed=true and 사용자 찜제외 했습니다.
- 첫 호출(cursor 없음)은 랜덤 시작점에서 조회하고, 이후 호출은 id < cursor로 이어서 조회하여 중복을 없애면서 조회 성능을 유지했습니다. (완전 랜덤은 아니라는 것)
- 중복 기준은 curation_raw_products.id이며, 커서 방식으로 연속 조회 시 중복 노출을 방지합니다.
- 응답에 nextCursor를 추가했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 랜덤 시작점은 userId + 날짜 기반 seed로 계산되도록 적용했습니다.
- cursor가 없을 때 (랜덤조회요청일때, id가 뒤쪽일 수도 있음) 10개 미만이면 상단 구간에서 보충 조회하는 fallback을 넣어 빈 응답 가능성을 줄였습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선**
  * 카로셀 API 페이지네이션이 커서 기반으로 개선되어 더 효율적인 데이터 로딩을 지원합니다.
  * API 응답에 다음 페이지 커서 정보가 추가되어 연속적인 스크롤 경험이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->