### PR TITLE
[FEATURE] raw 제품 상세가구 매핑 API 및 View 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProduct.java
@@ -126,6 +126,11 @@ public class CurationRawProduct {
     @Comment("수동 매핑된 가구 태그(다중 매핑)")
     private Set<CurationRawProductFurnitureTag> furnitureTagMappings = new LinkedHashSet<>();
 
+    @OneToMany(mappedBy = "curationRawProduct", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    @Comment("수동 매핑된 하위 가구(다중 매핑)")
+    private Set<CurationRawProductFurniture> furnitureMappings = new LinkedHashSet<>();
+
     public static CurationRawProduct of(
             String source,
             SoozipCategory category,
@@ -253,6 +258,10 @@ public class CurationRawProduct {
 
     public void clearFurnitureTags() {
         furnitureTagMappings.clear();
+    }
+
+    public void clearFurnitures() {
+        furnitureMappings.clear();
     }
 
     public void updateExposure(boolean isExposed) {

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductFurniture.java
@@ -1,0 +1,45 @@
+package or.sopt.houme.domain.furniture.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(name = "curation_raw_product_furnitures")
+@Comment("큐레이션 원본 수집 데이터(curation_raw_products)와 하위 가구(furnitures)의 매핑 테이블입니다.")
+public class CurationRawProductFurniture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "curation_raw_product_id", nullable = false)
+    private CurationRawProduct curationRawProduct;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "furniture_id", nullable = false)
+    private Furniture furniture;
+
+    public static CurationRawProductFurniture of(CurationRawProduct rawProduct, Furniture furniture) {
+        return CurationRawProductFurniture.builder()
+                .curationRawProduct(rawProduct)
+                .furniture(furniture)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductFurniture.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/CurationRawProductFurniture.java
@@ -15,6 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.util.Objects;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
@@ -41,5 +43,39 @@ public class CurationRawProductFurniture {
                 .curationRawProduct(rawProduct)
                 .furniture(furniture)
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof CurationRawProductFurniture other)) {
+            return false;
+        }
+
+        Long rawProductId = getCurationRawProductId();
+        Long furnitureId = getFurnitureId();
+        Long otherRawProductId = other.getCurationRawProductId();
+        Long otherFurnitureId = other.getFurnitureId();
+
+        if (rawProductId == null || furnitureId == null || otherRawProductId == null || otherFurnitureId == null) {
+            return false;
+        }
+        return Objects.equals(rawProductId, otherRawProductId)
+                && Objects.equals(furnitureId, otherFurnitureId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCurationRawProductId(), getFurnitureId());
+    }
+
+    private Long getCurationRawProductId() {
+        return curationRawProduct != null ? curationRawProduct.getId() : null;
+    }
+
+    private Long getFurnitureId() {
+        return furniture != null ? furniture.getId() : null;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductCreateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 
 import java.time.LocalDateTime;
@@ -25,9 +26,11 @@ public record AdminCurationRawProductCreateRequest(
         Long productId,
 
         @NotBlank(message = "productImageUrl은 필수 입력값입니다.")
+        @Size(max = 2048, message = "productImageUrl은 2048자 이하여야 합니다.")
         String productImageUrl,
 
         @NotBlank(message = "productSiteUrl은 필수 입력값입니다.")
+        @Size(max = 2048, message = "productSiteUrl은 2048자 이하여야 합니다.")
         String productSiteUrl,
 
         @NotBlank(message = "productName은 필수 입력값입니다.")
@@ -52,6 +55,8 @@ public record AdminCurationRawProductCreateRequest(
         Long freeShippingCondition,
         Boolean isExposed,
         LocalDateTime fetchedAt,
-        List<AdminCurationRawProductColorRequest> colors
+        List<AdminCurationRawProductColorRequest> colors,
+        List<@Positive(message = "furnitureId는 1 이상이어야 합니다.") Long> furnitureIds,
+        List<@Positive(message = "furnitureTagId는 1 이상이어야 합니다.") Long> furnitureTagIds
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/request/AdminCurationRawProductUpdateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +17,9 @@ public record AdminCurationRawProductUpdateRequest(
         SoozipCategory category,
         @Positive(message = "productId는 1 이상이어야 합니다.")
         Long productId,
+        @Size(max = 2048, message = "productImageUrl은 2048자 이하여야 합니다.")
         String productImageUrl,
+        @Size(max = 2048, message = "productSiteUrl은 2048자 이하여야 합니다.")
         String productSiteUrl,
         String productName,
         String productMallName,
@@ -34,6 +37,8 @@ public record AdminCurationRawProductUpdateRequest(
         Long freeShippingCondition,
         Boolean isExposed,
         LocalDateTime fetchedAt,
-        List<AdminCurationRawProductColorRequest> colors
+        List<AdminCurationRawProductColorRequest> colors,
+        List<@Positive(message = "furnitureId는 1 이상이어야 합니다.") Long> furnitureIds,
+        List<@Positive(message = "furnitureTagId는 1 이상이어야 합니다.") Long> furnitureTagIds
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductFurnitureResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductFurnitureResponse.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+
+public record AdminCurationRawProductFurnitureResponse(
+        Long mappingId,
+        Long furnitureId,
+        String furnitureNameKr,
+        String furnitureNameEng,
+        Long furnitureTypeId,
+        String furnitureTypeNameKr
+) {
+    public static AdminCurationRawProductFurnitureResponse of(CurationRawProductFurniture mapping) {
+        Furniture furniture = mapping.getFurniture();
+
+        return new AdminCurationRawProductFurnitureResponse(
+                mapping.getId(),
+                furniture != null ? furniture.getId() : null,
+                furniture != null ? furniture.getFurnitureNameKr() : null,
+                furniture != null ? furniture.getFurnitureNameEng() : null,
+                furniture != null && furniture.getFurnitureType() != null ? furniture.getFurnitureType().getId() : null,
+                furniture != null && furniture.getFurnitureType() != null ? furniture.getFurnitureType().getNameKr() : null
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductResponse.java
@@ -24,11 +24,13 @@ public record AdminCurationRawProductResponse(
         LocalDateTime fetchedAt,
         Boolean isExposed,
         List<AdminCurationRawProductColorResponse> colors,
+        List<AdminCurationRawProductFurnitureResponse> furnitures,
         List<AdminCurationRawProductFurnitureTagResponse> furnitureTags
 ) {
     public static AdminCurationRawProductResponse of(
             CurationRawProduct rawProduct,
             List<AdminCurationRawProductColorResponse> colors,
+            List<AdminCurationRawProductFurnitureResponse> furnitures,
             List<AdminCurationRawProductFurnitureTagResponse> furnitureTags
     ) {
         return new AdminCurationRawProductResponse(
@@ -49,6 +51,7 @@ public record AdminCurationRawProductResponse(
                 rawProduct.getFetchedAt(),
                 rawProduct.getIsExposed(),
                 colors,
+                furnitures,
                 furnitureTags
         );
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepository.java
@@ -3,25 +3,11 @@ package or.sopt.houme.domain.furniture.repository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface CurationRawProductFurnitureRepository extends JpaRepository<CurationRawProductFurniture, Long> {
-
-    @Query("""
-            select mapping
-            from CurationRawProductFurniture mapping
-            join fetch mapping.furniture furniture
-            join fetch furniture.furnitureType furnitureType
-            where mapping.curationRawProduct.id in :rawProductIds
-            """)
-    List<CurationRawProductFurniture> findAllByCurationRawProductIdInWithFurniture(
-            @Param("rawProductIds") List<Long> rawProductIds
-    );
+public interface CurationRawProductFurnitureRepository
+        extends JpaRepository<CurationRawProductFurniture, Long>, CurationRawProductFurnitureRepositoryCustom {
 
     void deleteAllByCurationRawProduct(CurationRawProduct curationRawProduct);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepository.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationRawProductFurnitureRepository extends JpaRepository<CurationRawProductFurniture, Long> {
+
+    @Query("""
+            select mapping
+            from CurationRawProductFurniture mapping
+            join fetch mapping.furniture furniture
+            join fetch furniture.furnitureType furnitureType
+            where mapping.curationRawProduct.id in :rawProductIds
+            """)
+    List<CurationRawProductFurniture> findAllByCurationRawProductIdInWithFurniture(
+            @Param("rawProductIds") List<Long> rawProductIds
+    );
+
+    void deleteAllByCurationRawProduct(CurationRawProduct curationRawProduct);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryCustom.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+
+import java.util.List;
+
+public interface CurationRawProductFurnitureRepositoryCustom {
+
+    List<CurationRawProductFurniture> findAllByCurationRawProductIdInWithFurniture(List<Long> rawProductIds);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryImpl.java
@@ -1,0 +1,32 @@
+package or.sopt.houme.domain.furniture.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QFurnitureType;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CurationRawProductFurnitureRepositoryImpl implements CurationRawProductFurnitureRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CurationRawProductFurniture> findAllByCurationRawProductIdInWithFurniture(List<Long> rawProductIds) {
+        QCurationRawProductFurniture mapping = QCurationRawProductFurniture.curationRawProductFurniture;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType furnitureType = QFurnitureType.furnitureType;
+
+        return queryFactory
+                .selectFrom(mapping)
+                .join(mapping.furniture, furniture).fetchJoin()
+                .join(furniture.furnitureType, furnitureType).fetchJoin()
+                .where(mapping.curationRawProduct.id.in(rawProductIds))
+                .fetch();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureTagRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureTagRepository.java
@@ -19,7 +19,7 @@ public interface CurationRawProductFurnitureTagRepository extends JpaRepository<
             from CurationRawProductFurnitureTag mapping
             join fetch mapping.furnitureTag furnitureTag
             join fetch furnitureTag.furniture furniture
-            join fetch furnitureTag.tag tag
+            left join fetch furnitureTag.tag tag
             where mapping.curationRawProduct.id in :rawProductIds
             """)
     List<CurationRawProductFurnitureTag> findAllByCurationRawProductIdInWithFurnitureTag(

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureRepository.java
@@ -4,11 +4,14 @@ import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FurnitureRepository extends JpaRepository<Furniture, Long>, FurnitureCustomRepository {
 
     Optional<Furniture> findByFurnitureNameKr (String furnitureName);
+
+    List<Furniture> findAllByFurnitureTypeIdOrderByPriorityAscIdAsc(Long furnitureTypeId);
 
     // 해당 가구 타입을 가진 가구 존재 여부
     boolean existsByFurnitureType(FurnitureType type);

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/FurnitureTagRepositoryImpl.java
@@ -43,7 +43,7 @@ public class FurnitureTagRepositoryImpl implements FurnitureTagRepositoryCustom 
                 .selectFrom(furnitureTag)
                 .join(furnitureTag.furniture, furniture).fetchJoin()
                 .join(furniture.furnitureType, furnitureType).fetchJoin()
-                .join(furnitureTag.tag, tag).fetchJoin()
+                .leftJoin(furnitureTag.tag, tag).fetchJoin()
                 .where(furnitureType.id.eq(furnitureTypeId))
                 .orderBy(
                         furniture.furnitureNameKr.asc(),

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -28,6 +28,7 @@ import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.service.event.CurationRawProductTokenRefreshEvent;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -463,6 +464,10 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
     private boolean hasConstraintName(Throwable throwable, String constraintName) {
         Throwable current = throwable;
         while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolationException
+                    && constraintName.equals(constraintViolationException.getConstraintName())) {
+                return true;
+            }
             String message = current.getMessage();
             if (message != null && message.contains(constraintName)) {
                 return true;

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -3,7 +3,9 @@ package or.sopt.houme.domain.furniture.service.admin;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
@@ -13,12 +15,15 @@ import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawP
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorResponse;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureTagResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.service.event.CurationRawProductTokenRefreshEvent;
 import or.sopt.houme.global.api.ErrorCode;
@@ -44,11 +49,14 @@ import java.util.regex.Pattern;
 public class AdminCurationRawProductServiceImpl implements AdminCurationRawProductService {
 
     private static final int MAX_PAGE_SIZE = 100;
+    private static final String RAW_PRODUCT_UNIQUE_CONSTRAINT = "uk_raw_source_category_product_id";
     private static final Pattern SOURCE_PATTERN = Pattern.compile("^[a-z0-9][a-z0-9_-]{0,49}$");
 
     private final CurationRawProductRepository curationRawProductRepository;
     private final CurationRawProductColorRepository curationRawProductColorRepository;
+    private final CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
     private final CurationRawProductFurnitureTagRepository curationRawProductFurnitureTagRepository;
+    private final FurnitureRepository furnitureRepository;
     private final FurnitureTagRepository furnitureTagRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -124,10 +132,12 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
         try {
             CurationRawProduct saved = curationRawProductRepository.saveAndFlush(rawProduct);
             saveColors(saved, request.colors());
+            saveFurnitureMappings(saved, request.furnitureIds());
+            saveFurnitureTagMappings(saved, request.furnitureTagIds());
             eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
-            throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+            throw toRawProductIntegrityException(e);
         }
     }
 
@@ -165,10 +175,16 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
             if (request.colors() != null) {
                 replaceColors(saved, request.colors());
             }
+            if (request.furnitureIds() != null) {
+                replaceFurnitureMappings(saved, request.furnitureIds());
+            }
+            if (request.furnitureTagIds() != null) {
+                replaceFurnitureTagMappings(saved, request.furnitureTagIds());
+            }
             eventPublisher.publishEvent(new CurationRawProductTokenRefreshEvent(List.of(saved.getId())));
             return buildResponses(List.of(saved)).get(0);
         } catch (DataIntegrityViolationException e) {
-            throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+            throw toRawProductIntegrityException(e);
         }
     }
 
@@ -242,6 +258,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
         try {
             curationRawProductColorRepository.deleteAllByCurationRawProduct(rawProduct);
             rawProduct.clearFurnitureTags();
+            rawProduct.clearFurnitures();
             curationRawProductRepository.delete(rawProduct);
             curationRawProductRepository.flush();
         } catch (DataIntegrityViolationException e) {
@@ -265,6 +282,14 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
                     .add(AdminCurationRawProductColorResponse.of(color));
         }
 
+        Map<Long, List<AdminCurationRawProductFurnitureResponse>> furnituresByRawProductId = new LinkedHashMap<>();
+        List<CurationRawProductFurniture> furnitureMappings =
+                curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(rawProductIds);
+        for (CurationRawProductFurniture mapping : furnitureMappings) {
+            furnituresByRawProductId.computeIfAbsent(mapping.getCurationRawProduct().getId(), key -> new ArrayList<>())
+                    .add(AdminCurationRawProductFurnitureResponse.of(mapping));
+        }
+
         Map<Long, List<AdminCurationRawProductFurnitureTagResponse>> furnitureTagsByRawProductId = new LinkedHashMap<>();
         List<CurationRawProductFurnitureTag> mappings =
                 curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(rawProductIds);
@@ -277,6 +302,7 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
                 .map(rawProduct -> AdminCurationRawProductResponse.of(
                         rawProduct,
                         colorsByRawProductId.getOrDefault(rawProduct.getId(), List.of()),
+                        furnituresByRawProductId.getOrDefault(rawProduct.getId(), List.of()),
                         furnitureTagsByRawProductId.getOrDefault(rawProduct.getId(), List.of())
                 ))
                 .toList();
@@ -330,6 +356,90 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
         return new ArrayList<>(colorsByKey.values());
     }
 
+    private void replaceFurnitureMappings(CurationRawProduct rawProduct, List<Long> furnitureIds) {
+        curationRawProductFurnitureRepository.deleteAllByCurationRawProduct(rawProduct);
+        curationRawProductFurnitureRepository.flush();
+        saveFurnitureMappings(rawProduct, furnitureIds);
+    }
+
+    private void saveFurnitureMappings(CurationRawProduct rawProduct, List<Long> furnitureIds) {
+        List<CurationRawProductFurniture> mappings = buildFurnitureMappings(rawProduct, furnitureIds);
+        if (!mappings.isEmpty()) {
+            curationRawProductFurnitureRepository.saveAll(mappings);
+        }
+    }
+
+    private List<CurationRawProductFurniture> buildFurnitureMappings(
+            CurationRawProduct rawProduct,
+            List<Long> furnitureIds
+    ) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> distinctFurnitureIds = furnitureIds.stream()
+                .distinct()
+                .toList();
+        if (distinctFurnitureIds.stream().anyMatch(id -> id == null || id <= 0)) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        List<Furniture> furnitures = furnitureRepository.findAllById(distinctFurnitureIds);
+        if (furnitures.size() != distinctFurnitureIds.size()) {
+            throw new GeneralException(ErrorCode.NOT_FOUND_FURNITURE);
+        }
+
+        Map<Long, Furniture> furnitureById = furnitures.stream()
+                .collect(java.util.stream.Collectors.toMap(Furniture::getId, furniture -> furniture));
+
+        return distinctFurnitureIds.stream()
+                .map(furnitureById::get)
+                .map(furniture -> CurationRawProductFurniture.of(rawProduct, furniture))
+                .toList();
+    }
+
+    private void replaceFurnitureTagMappings(CurationRawProduct rawProduct, List<Long> furnitureTagIds) {
+        rawProduct.clearFurnitureTags();
+        curationRawProductRepository.flush();
+        saveFurnitureTagMappings(rawProduct, furnitureTagIds);
+    }
+
+    private void saveFurnitureTagMappings(CurationRawProduct rawProduct, List<Long> furnitureTagIds) {
+        List<CurationRawProductFurnitureTag> mappings = buildFurnitureTagMappings(rawProduct, furnitureTagIds);
+        if (!mappings.isEmpty()) {
+            curationRawProductFurnitureTagRepository.saveAll(mappings);
+        }
+    }
+
+    private List<CurationRawProductFurnitureTag> buildFurnitureTagMappings(
+            CurationRawProduct rawProduct,
+            List<Long> furnitureTagIds
+    ) {
+        if (furnitureTagIds == null || furnitureTagIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> distinctFurnitureTagIds = furnitureTagIds.stream()
+                .distinct()
+                .toList();
+        if (distinctFurnitureTagIds.stream().anyMatch(id -> id == null || id <= 0)) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
+
+        List<FurnitureTag> furnitureTags = furnitureTagRepository.findAllById(distinctFurnitureTagIds);
+        if (furnitureTags.size() != distinctFurnitureTagIds.size()) {
+            throw new GeneralException(ErrorCode.NOT_FOUND_FURNITURE_TAG);
+        }
+
+        Map<Long, FurnitureTag> furnitureTagById = furnitureTags.stream()
+                .collect(java.util.stream.Collectors.toMap(FurnitureTag::getId, furnitureTag -> furnitureTag));
+
+        return distinctFurnitureTagIds.stream()
+                .map(furnitureTagById::get)
+                .map(furnitureTag -> CurationRawProductFurnitureTag.of(rawProduct, furnitureTag))
+                .toList();
+    }
+
     private FurnitureTag getFurnitureTagOrThrow(Long furnitureTagId) {
         return furnitureTagRepository.findById(furnitureTagId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE_TAG));
@@ -341,6 +451,25 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
                 .ifPresent(existing -> {
                     throw new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
                 });
+    }
+
+    private GeneralException toRawProductIntegrityException(DataIntegrityViolationException exception) {
+        if (hasConstraintName(exception, RAW_PRODUCT_UNIQUE_CONSTRAINT)) {
+            return new GeneralException(ErrorCode.DUPLICATE_CURATION_RAW_PRODUCT);
+        }
+        return new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+    }
+
+    private boolean hasConstraintName(Throwable throwable, String constraintName) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains(constraintName)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private String normalize(String value) {

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFurnitureController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminFurnitureController.java
@@ -80,6 +80,14 @@ public class AdminFurnitureController {
         return ResponseEntity.ok(ApiResponse.ok(adminFurnitureService.getFurnitureTagsByType(furnitureTypeId)));
     }
 
+    @GetMapping("/furniture/types/{furnitureTypeId}/furnitures")
+    @Operation(summary = "가구 타입별 하위 가구 조회 API")
+    public ResponseEntity<ApiResponse<AdminFurnitureOptionListResponse>> getFurnituresByType(
+            @PathVariable Long furnitureTypeId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminFurnitureService.getFurnituresByType(furnitureTypeId)));
+    }
+
 
     @PatchMapping("/furniture")
     @Operation(summary = "가구 정보 수정 API")

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/furniture/AdminFurnitureOptionListResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/furniture/AdminFurnitureOptionListResponse.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.furniture;
+
+import java.util.List;
+
+public record AdminFurnitureOptionListResponse(
+        List<AdminFurnitureOptionResponse> furnitures
+) {
+    public static AdminFurnitureOptionListResponse of(List<AdminFurnitureOptionResponse> furnitures) {
+        return new AdminFurnitureOptionListResponse(furnitures);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/furniture/AdminFurnitureOptionResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/furniture/AdminFurnitureOptionResponse.java
@@ -1,0 +1,21 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.furniture;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+
+public record AdminFurnitureOptionResponse(
+        @Schema(description = "가구 ID")
+        Long furnitureId,
+        @Schema(description = "가구 한글 이름")
+        String furnitureNameKr,
+        @Schema(description = "가구 영어 이름")
+        String furnitureNameEng
+) {
+    public static AdminFurnitureOptionResponse of(Furniture furniture) {
+        return new AdminFurnitureOptionResponse(
+                furniture.getId(),
+                furniture.getFurnitureNameKr(),
+                furniture.getFurnitureNameEng()
+        );
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureService.java
@@ -17,6 +17,8 @@ public interface AdminFurnitureService {
 
     AdminFurnitureTagOptionListResponse getFurnitureTagsByType(Long furnitureTypeId);
 
+    AdminFurnitureOptionListResponse getFurnituresByType(Long furnitureTypeId);
+
     AdminFurnitureUpdateResponseDTO updateFurniture(AdminFurnitureUpdateRequestDTO dto, String contentType);
 
     void deleteFurnitureTag(AdminFurnitureTagDeleteDTO dto);

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
@@ -176,6 +176,20 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
         return new AdminFurnitureTagOptionListResponse(furnitureTags);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public AdminFurnitureOptionListResponse getFurnituresByType(Long furnitureTypeId) {
+        FurnitureType furnitureType = furnitureTypeRepository.findById(furnitureTypeId)
+                .orElseThrow(() -> new AdminException(ErrorCode.NOT_FOUND_FURNITURE_TYPE));
+
+        List<AdminFurnitureOptionResponse> furnitures = furnitureRepository
+                .findAllByFurnitureTypeIdOrderByPriorityAscIdAsc(furnitureType.getId()).stream()
+                .map(AdminFurnitureOptionResponse::of)
+                .toList();
+
+        return AdminFurnitureOptionListResponse.of(furnitures);
+    }
+
 
     /**
      * 가구 정보를 업데이트하는 메서드입니다

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1267,6 +1267,53 @@
                             <label for="rawCreateBaseShippingFee">Shipping Fee</label>
                             <input type="number" class="form-control" id="rawCreateBaseShippingFee">
                         </div>
+                        <div class="raw-form-field raw-form-field--full">
+                            <div class="border rounded-3 p-3 bg-light">
+                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                    <div>
+                                        <h5 class="mb-1 fw-bold"><i class="fas fa-tags me-2"></i>가구 매핑</h5>
+                                        <p class="text-muted small mb-0">세부가구 기준 또는 Furniture Tag 기준으로 RAW 상품 등록과 동시에 매핑합니다.</p>
+                                    </div>
+                                </div>
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <label for="rawCreateFurnitureTypeId" class="form-label fw-bold small">상위가구 타입</label>
+                                        <select class="form-select" id="rawCreateFurnitureTypeId">
+                                            <option value="" selected disabled>가구 타입 선택...</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="rawCreateFurnitureId" class="form-label fw-bold small">하위가구</label>
+                                        <div class="input-group">
+                                            <select class="form-select" id="rawCreateFurnitureId" disabled>
+                                                <option value="" selected>상위가구를 먼저 선택하세요</option>
+                                            </select>
+                                            <button class="btn btn-outline-primary" type="button" id="rawCreateFurnitureAddButton">추가</button>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div id="rawCreateSelectedFurnitureList" class="raw-tag-picker-preview is-empty">선택된 하위가구가 없습니다.</div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="rawCreateFurnitureTagTypeId" class="form-label fw-bold small">Furniture Tag용 가구 타입</label>
+                                        <select class="form-select" id="rawCreateFurnitureTagTypeId">
+                                            <option value="" selected disabled>가구 타입 선택...</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="rawCreateFurnitureTagKeyword" class="form-label fw-bold small">Furniture Tag</label>
+                                        <div class="input-group">
+                                            <input type="text" class="form-control" id="rawCreateFurnitureTagKeyword" list="rawCreateFurnitureTagOptions" placeholder="가구 타입을 먼저 선택하세요" disabled>
+                                            <datalist id="rawCreateFurnitureTagOptions"></datalist>
+                                            <button class="btn btn-outline-primary" type="button" id="rawCreateFurnitureTagAddButton">추가</button>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div id="rawCreateSelectedFurnitureTagList" class="raw-tag-picker-preview is-empty">선택된 Furniture Tag가 없습니다.</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="raw-form-actions">
                             <button type="button" class="btn btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#rawRegistrationCollapse">취소</button>
                             <button type="submit" class="btn btn-primary">상품 등록 완료</button>
@@ -1441,6 +1488,65 @@
                                 <div class="raw-form-field raw-form-field--quarter">
                                     <label for="rawUpdateFreeShippingCondition">Free Shipping Condition</label>
                                     <input type="number" class="form-control" id="rawUpdateFreeShippingCondition">
+                                </div>
+                                <div class="raw-form-field raw-form-field--full">
+                                    <div class="border rounded-3 p-3 bg-light">
+                                        <div class="d-flex justify-content-between align-items-center mb-3">
+                                            <div>
+                                                <h5 class="mb-1 fw-bold"><i class="fas fa-tags me-2"></i>가구 매핑 교체</h5>
+                                                <p class="text-muted small mb-0">체크한 항목만 저장 시 전체 교체됩니다. 체크 후 비워서 저장하면 해당 매핑이 전체 삭제됩니다.</p>
+                                            </div>
+                                        </div>
+                                        <div class="row g-3">
+                                            <div class="col-12">
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" id="rawUpdateFurnitureMappingEnabled">
+                                                    <label class="form-check-label fw-semibold" for="rawUpdateFurnitureMappingEnabled">하위가구 매핑 수정 반영</label>
+                                                </div>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="rawUpdateFurnitureTypeId" class="form-label fw-bold small">상위가구 타입</label>
+                                                <select class="form-select" id="rawUpdateFurnitureTypeId">
+                                                    <option value="" selected disabled>가구 타입 선택...</option>
+                                                </select>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="rawUpdateFurnitureId" class="form-label fw-bold small">하위가구</label>
+                                                <div class="input-group">
+                                                    <select class="form-select" id="rawUpdateFurnitureId" disabled>
+                                                        <option value="" selected>상위가구를 먼저 선택하세요</option>
+                                                    </select>
+                                                    <button class="btn btn-outline-primary" type="button" id="rawUpdateFurnitureAddButton">추가</button>
+                                                </div>
+                                            </div>
+                                            <div class="col-12">
+                                                <div id="rawUpdateSelectedFurnitureList" class="raw-tag-picker-preview is-empty">선택된 하위가구가 없습니다.</div>
+                                            </div>
+                                            <div class="col-12">
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" id="rawUpdateFurnitureTagMappingEnabled">
+                                                    <label class="form-check-label fw-semibold" for="rawUpdateFurnitureTagMappingEnabled">Furniture Tag 매핑 수정 반영</label>
+                                                </div>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="rawUpdateFurnitureTagTypeId" class="form-label fw-bold small">Furniture Tag용 가구 타입</label>
+                                                <select class="form-select" id="rawUpdateFurnitureTagTypeId">
+                                                    <option value="" selected disabled>가구 타입 선택...</option>
+                                                </select>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="rawUpdateFurnitureTagKeyword" class="form-label fw-bold small">Furniture Tag</label>
+                                                <div class="input-group">
+                                                    <input type="text" class="form-control" id="rawUpdateFurnitureTagKeyword" list="rawUpdateFurnitureTagOptions" placeholder="가구 타입을 먼저 선택하세요" disabled>
+                                                    <datalist id="rawUpdateFurnitureTagOptions"></datalist>
+                                                    <button class="btn btn-outline-primary" type="button" id="rawUpdateFurnitureTagAddButton">추가</button>
+                                                </div>
+                                            </div>
+                                            <div class="col-12">
+                                                <div id="rawUpdateSelectedFurnitureTagList" class="raw-tag-picker-preview is-empty">선택된 Furniture Tag가 없습니다.</div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="raw-form-actions">
                                     <button type="submit" class="btn btn-warning px-4">정보 수정 저장</button>
@@ -1903,6 +2009,14 @@
     };
     let rawFurnitureTagLookup = [];
     let rawFurnitureTypeLookup = [];
+    let rawCreateFurnitureLookup = [];
+    let rawUpdateFurnitureLookup = [];
+    let rawCreateFurnitureTagLookup = [];
+    let rawUpdateFurnitureTagLookup = [];
+    let rawCreateSelectedFurnitures = [];
+    let rawCreateSelectedFurnitureTags = [];
+    let rawUpdateSelectedFurnitures = [];
+    let rawUpdateSelectedFurnitureTags = [];
     let rawProductsFilterState = {
         category: null,
         minListPrice: null,
@@ -2394,8 +2508,16 @@
             event.preventDefault();
             const accessToken = localStorage.getItem('accessToken');
             const resultDiv = document.getElementById('raw-product-create-result');
+            collectPendingRawMappingSelections('create');
             const payload = buildRawProductCreatePayload();
-            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'POST', payload);
+            testApiCall(accessToken, resultDiv, '/api/v1/admin/curation-raw-products', 'POST', payload, (data, target) => {
+                target.innerHTML = '<div class="alert alert-success">RAW 상품과 가구 매핑이 함께 등록되었습니다.</div>';
+                rawCreateSelectedFurnitures = [];
+                rawCreateSelectedFurnitureTags = [];
+                renderInlineRawSelectedFurnitures('create');
+                renderInlineRawSelectedFurnitureTags('create');
+                fetchRawProducts(rawProductsPageState.page, rawProductsPageState.size);
+            });
         });
 
         document.getElementById('raw-product-update-form').addEventListener('submit', function(event) {
@@ -2408,6 +2530,7 @@
                 return;
             }
 
+            collectPendingRawMappingSelections('update');
             const payload = buildRawProductUpdatePayload();
             if (Object.keys(payload).length === 0) {
                 resultDiv.innerHTML = '<div class="alert alert-danger">수정할 값을 최소 1개 이상 입력해주세요.</div>';
@@ -2455,6 +2578,46 @@
 
         document.getElementById('rawFurnitureTagKeyword').addEventListener('blur', function(event) {
             resolveRawFurnitureTagSelection(event.target.value);
+        });
+
+        document.getElementById('rawCreateFurnitureTypeId').addEventListener('change', function(event) {
+            loadRawFurnitureOptionsByType(event.target.value, 'create');
+        });
+
+        document.getElementById('rawUpdateFurnitureTypeId').addEventListener('change', function(event) {
+            loadRawFurnitureOptionsByType(event.target.value, 'update');
+        });
+
+        document.getElementById('rawCreateFurnitureAddButton').addEventListener('click', function() {
+            addSelectedRawFurniture('create');
+        });
+
+        document.getElementById('rawUpdateFurnitureAddButton').addEventListener('click', function() {
+            addSelectedRawFurniture('update');
+        });
+
+        document.getElementById('rawCreateFurnitureTagTypeId').addEventListener('change', function(event) {
+            loadInlineRawFurnitureTagOptionsByType(event.target.value, 'create');
+        });
+
+        document.getElementById('rawUpdateFurnitureTagTypeId').addEventListener('change', function(event) {
+            loadInlineRawFurnitureTagOptionsByType(event.target.value, 'update');
+        });
+
+        document.getElementById('rawCreateFurnitureTagKeyword').addEventListener('change', function(event) {
+            resolveInlineRawFurnitureTagSelection(event.target.value, 'create');
+        });
+
+        document.getElementById('rawUpdateFurnitureTagKeyword').addEventListener('change', function(event) {
+            resolveInlineRawFurnitureTagSelection(event.target.value, 'update');
+        });
+
+        document.getElementById('rawCreateFurnitureTagAddButton').addEventListener('click', function() {
+            addSelectedRawFurnitureTag('create');
+        });
+
+        document.getElementById('rawUpdateFurnitureTagAddButton').addEventListener('click', function() {
+            addSelectedRawFurnitureTag('update');
         });
 
         document.getElementById('get-landings-button').addEventListener('click', function() {
@@ -4372,12 +4535,22 @@
                 }
 
                 rawFurnitureTypeLookup = responseData.furnitureTypeList;
-                selectElement.innerHTML = '<option value="" selected disabled>먼저 가구 타입을 선택하세요...</option>' +
+                const furnitureTypeOptions = '<option value="" selected disabled>먼저 가구 타입을 선택하세요...</option>' +
                     rawFurnitureTypeLookup.map(type => `
                         <option value="${type.furnitureTypeId}">
                             ${type.furnitureTypeNameKr} (ID: ${type.furnitureTypeId})
                         </option>
                     `).join('');
+                selectElement.innerHTML = furnitureTypeOptions;
+                [
+                    'rawCreateFurnitureTypeId',
+                    'rawUpdateFurnitureTypeId',
+                    'rawCreateFurnitureTagTypeId',
+                    'rawUpdateFurnitureTagTypeId'
+                ].forEach(id => {
+                    const target = document.getElementById(id);
+                    if (target) target.innerHTML = furnitureTypeOptions;
+                });
             })
             .catch(error => console.error('Error populating raw furniture type dropdown:', error));
     }
@@ -4429,6 +4602,257 @@
             .catch(error => console.error('Error loading raw furniture tag options by type:', error));
     }
 
+    function getInlineRawMappingState(mode) {
+        return {
+            furnitureLookup: mode === 'create' ? rawCreateFurnitureLookup : rawUpdateFurnitureLookup,
+            setFurnitureLookup: value => {
+                if (mode === 'create') rawCreateFurnitureLookup = value;
+                else rawUpdateFurnitureLookup = value;
+            },
+            furnitureTagLookup: mode === 'create' ? rawCreateFurnitureTagLookup : rawUpdateFurnitureTagLookup,
+            setFurnitureTagLookup: value => {
+                if (mode === 'create') rawCreateFurnitureTagLookup = value;
+                else rawUpdateFurnitureTagLookup = value;
+            },
+            selectedFurnitures: mode === 'create' ? rawCreateSelectedFurnitures : rawUpdateSelectedFurnitures,
+            setSelectedFurnitures: value => {
+                if (mode === 'create') rawCreateSelectedFurnitures = value;
+                else rawUpdateSelectedFurnitures = value;
+            },
+            selectedFurnitureTags: mode === 'create' ? rawCreateSelectedFurnitureTags : rawUpdateSelectedFurnitureTags,
+            setSelectedFurnitureTags: value => {
+                if (mode === 'create') rawCreateSelectedFurnitureTags = value;
+                else rawUpdateSelectedFurnitureTags = value;
+            },
+            furnitureSelectId: mode === 'create' ? 'rawCreateFurnitureId' : 'rawUpdateFurnitureId',
+            furnitureListId: mode === 'create' ? 'rawCreateSelectedFurnitureList' : 'rawUpdateSelectedFurnitureList',
+            furnitureTagKeywordId: mode === 'create' ? 'rawCreateFurnitureTagKeyword' : 'rawUpdateFurnitureTagKeyword',
+            furnitureTagDatalistId: mode === 'create' ? 'rawCreateFurnitureTagOptions' : 'rawUpdateFurnitureTagOptions',
+            furnitureTagListId: mode === 'create' ? 'rawCreateSelectedFurnitureTagList' : 'rawUpdateSelectedFurnitureTagList'
+        };
+    }
+
+    function loadRawFurnitureOptionsByType(furnitureTypeId, mode) {
+        const accessToken = localStorage.getItem('accessToken');
+        const state = getInlineRawMappingState(mode);
+        const selectElement = document.getElementById(state.furnitureSelectId);
+        if (!selectElement) return;
+
+        state.setFurnitureLookup([]);
+        selectElement.disabled = true;
+        selectElement.innerHTML = '<option value="" selected>하위가구를 불러오는 중...</option>';
+
+        if (!accessToken || !furnitureTypeId) {
+            selectElement.innerHTML = '<option value="" selected>상위가구를 먼저 선택하세요</option>';
+            return;
+        }
+
+        fetch(`/api/v1/admin/furniture/types/${furnitureTypeId}/furnitures`, {
+            method: 'GET',
+            headers: {'Authorization': 'Bearer ' + accessToken, 'Content-Type': 'application/json'}
+        })
+            .then(response => response.json())
+            .then(data => {
+                const furnitures = data?.data?.furnitures;
+                if (!Array.isArray(furnitures)) {
+                    selectElement.innerHTML = '<option value="" selected>하위가구를 불러오지 못했습니다</option>';
+                    return;
+                }
+
+                state.setFurnitureLookup(furnitures);
+                selectElement.disabled = furnitures.length === 0;
+                selectElement.innerHTML = furnitures.length === 0
+                    ? '<option value="" selected>선택 가능한 하위가구가 없습니다</option>'
+                    : '<option value="" selected disabled>하위가구 선택...</option>' + furnitures.map(furniture => `
+                        <option value="${furniture.furnitureId}">
+                            ${furniture.furnitureNameKr} (ID: ${furniture.furnitureId})
+                        </option>
+                    `).join('');
+            })
+            .catch(error => {
+                console.error('Error loading raw furniture options by type:', error);
+                selectElement.innerHTML = '<option value="" selected>하위가구 로딩 실패</option>';
+            });
+    }
+
+    function addSelectedRawFurniture(mode) {
+        const state = getInlineRawMappingState(mode);
+        const selectElement = document.getElementById(state.furnitureSelectId);
+        const furnitureId = parseNumberValue(selectElement?.value);
+        if (!furnitureId) return;
+
+        const furniture = state.furnitureLookup.find(item => Number(item.furnitureId) === furnitureId);
+        if (!furniture) return;
+
+        const next = [...state.selectedFurnitures];
+        if (!next.some(item => Number(item.furnitureId) === furnitureId)) {
+            next.push(furniture);
+        }
+        state.setSelectedFurnitures(next);
+        markRawMappingChanged(mode, 'furniture');
+        renderInlineRawSelectedFurnitures(mode);
+    }
+
+    function removeSelectedRawFurniture(mode, furnitureId) {
+        const state = getInlineRawMappingState(mode);
+        state.setSelectedFurnitures(state.selectedFurnitures.filter(item => Number(item.furnitureId) !== Number(furnitureId)));
+        markRawMappingChanged(mode, 'furniture');
+        renderInlineRawSelectedFurnitures(mode);
+    }
+
+    function renderInlineRawSelectedFurnitures(mode) {
+        const state = getInlineRawMappingState(mode);
+        const container = document.getElementById(state.furnitureListId);
+        if (!container) return;
+
+        if (state.selectedFurnitures.length === 0) {
+            container.classList.add('is-empty');
+            container.innerHTML = '선택된 하위가구가 없습니다.';
+            return;
+        }
+
+        container.classList.remove('is-empty');
+        container.innerHTML = state.selectedFurnitures.map(furniture => `
+            <span class="raw-tag-selected-chip">
+                ${furniture.furnitureNameKr || '-'}
+                <small>#${furniture.furnitureId}</small>
+                <button type="button" class="btn-close btn-close-white ms-2" aria-label="삭제" onclick="removeSelectedRawFurniture('${mode}', ${furniture.furnitureId})"></button>
+            </span>
+        `).join('');
+    }
+
+    function loadInlineRawFurnitureTagOptionsByType(furnitureTypeId, mode) {
+        const accessToken = localStorage.getItem('accessToken');
+        const state = getInlineRawMappingState(mode);
+        const keywordInput = document.getElementById(state.furnitureTagKeywordId);
+        const datalistElement = document.getElementById(state.furnitureTagDatalistId);
+        if (!keywordInput || !datalistElement) return;
+
+        state.setFurnitureTagLookup([]);
+        keywordInput.value = '';
+        keywordInput.disabled = true;
+        keywordInput.placeholder = 'Furniture Tag를 불러오는 중...';
+        datalistElement.innerHTML = '';
+
+        if (!accessToken || !furnitureTypeId) {
+            keywordInput.placeholder = '가구 타입을 먼저 선택하세요';
+            return;
+        }
+
+        fetch(`/api/v1/admin/furniture/types/${furnitureTypeId}/tags`, {
+            method: 'GET',
+            headers: {'Authorization': 'Bearer ' + accessToken, 'Content-Type': 'application/json'}
+        })
+            .then(response => response.json())
+            .then(data => {
+                const furnitureTags = data?.data?.furnitureTags;
+                if (!Array.isArray(furnitureTags)) {
+                    keywordInput.placeholder = 'Furniture Tag를 불러오지 못했습니다.';
+                    return;
+                }
+
+                state.setFurnitureTagLookup(furnitureTags);
+                keywordInput.disabled = furnitureTags.length === 0;
+                keywordInput.placeholder = furnitureTags.length === 0
+                    ? '선택한 가구 타입에 연결된 furniture_tag가 없습니다.'
+                    : '가구명, 태그명, furnitureTag ID로 검색하세요.';
+                datalistElement.innerHTML = furnitureTags
+                    .map(option => `<option value="${formatRawFurnitureTagOptionLabel(option)}"></option>`)
+                    .join('');
+            })
+            .catch(error => {
+                console.error('Error loading inline raw furniture tag options:', error);
+                keywordInput.placeholder = 'Furniture Tag 로딩 실패';
+            });
+    }
+
+    function resolveInlineRawFurnitureTagSelection(value, mode) {
+        const state = getInlineRawMappingState(mode);
+        const normalizedValue = (value || '').trim();
+        if (!normalizedValue) return null;
+
+        const matchedByLabel = state.furnitureTagLookup.find(tag => formatRawFurnitureTagOptionLabel(tag) === normalizedValue);
+        if (matchedByLabel) return matchedByLabel;
+
+        const matchedById = state.furnitureTagLookup.find(tag => String(tag.furnitureTagId) === normalizedValue);
+        if (matchedById) return matchedById;
+
+        const normalizedKeyword = normalizedValue.toLowerCase();
+        return state.furnitureTagLookup.find(tag =>
+            (tag.furnitureNameKr || '').toLowerCase() === normalizedKeyword
+            || (tag.tagNameKr || '').toLowerCase() === normalizedKeyword
+            || (tag.searchKeyword || '').toLowerCase() === normalizedKeyword
+            || (`${tag.furnitureNameKr || ''} / ${getRawFurnitureTagDisplayName(tag)}`).toLowerCase() === normalizedKeyword
+        ) || null;
+    }
+
+    function addSelectedRawFurnitureTag(mode) {
+        const state = getInlineRawMappingState(mode);
+        const keywordInput = document.getElementById(state.furnitureTagKeywordId);
+        const selectedTag = resolveInlineRawFurnitureTagSelection(keywordInput?.value, mode);
+        if (!selectedTag) return;
+
+        const next = [...state.selectedFurnitureTags];
+        if (!next.some(item => Number(item.furnitureTagId) === Number(selectedTag.furnitureTagId))) {
+            next.push(selectedTag);
+        }
+        state.setSelectedFurnitureTags(next);
+        markRawMappingChanged(mode, 'furnitureTag');
+        if (keywordInput) keywordInput.value = '';
+        renderInlineRawSelectedFurnitureTags(mode);
+    }
+
+    function removeSelectedRawFurnitureTag(mode, furnitureTagId) {
+        const state = getInlineRawMappingState(mode);
+        state.setSelectedFurnitureTags(state.selectedFurnitureTags.filter(item => Number(item.furnitureTagId) !== Number(furnitureTagId)));
+        markRawMappingChanged(mode, 'furnitureTag');
+        renderInlineRawSelectedFurnitureTags(mode);
+    }
+
+    function markRawMappingChanged(mode, mappingType) {
+        if (mode !== 'update') return;
+
+        const checkboxId = mappingType === 'furniture'
+            ? 'rawUpdateFurnitureMappingEnabled'
+            : 'rawUpdateFurnitureTagMappingEnabled';
+        const checkbox = document.getElementById(checkboxId);
+        if (checkbox) checkbox.checked = true;
+    }
+
+    function collectPendingRawMappingSelections(mode) {
+        const state = getInlineRawMappingState(mode);
+        const furnitureSelect = document.getElementById(state.furnitureSelectId);
+        if (parseNumberValue(furnitureSelect?.value)) {
+            addSelectedRawFurniture(mode);
+        }
+
+        const keywordInput = document.getElementById(state.furnitureTagKeywordId);
+        if (parseStringValue(keywordInput?.value)) {
+            addSelectedRawFurnitureTag(mode);
+        }
+    }
+
+    function renderInlineRawSelectedFurnitureTags(mode) {
+        const state = getInlineRawMappingState(mode);
+        const container = document.getElementById(state.furnitureTagListId);
+        if (!container) return;
+
+        if (state.selectedFurnitureTags.length === 0) {
+            container.classList.add('is-empty');
+            container.innerHTML = '선택된 Furniture Tag가 없습니다.';
+            return;
+        }
+
+        container.classList.remove('is-empty');
+        container.innerHTML = state.selectedFurnitureTags.map(tag => `
+            <span class="raw-tag-selected-chip">
+                ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}
+                <small>#${tag.furnitureTagId}</small>
+                <button type="button" class="btn-close btn-close-white ms-2" aria-label="삭제" onclick="removeSelectedRawFurnitureTag('${mode}', ${tag.furnitureTagId})"></button>
+            </span>
+        `).join('');
+    }
+
     function displayFurnituresAsTable(data, resultDiv) {
         const furnitures = data.data.furnitures;
         let tableHTML = '<table class="table table-hover"><thead>'+
@@ -4467,8 +4891,12 @@
             return '-';
         }
         return furnitureTags
-            .map(tag => `${tag.furnitureNameKr || '-'} / ${tag.tagNameKr || '-'} (#${tag.furnitureTagId})`)
+            .map(tag => `${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)} (#${tag.furnitureTagId})`)
             .join('\n');
+    }
+
+    function getRawFurnitureTagDisplayName(tag) {
+        return tag?.tagNameKr || tag?.searchKeyword || `FurnitureTag #${tag?.furnitureTagId ?? '-'}`;
     }
 
     function toggleRawChipSection(sectionId, button) {
@@ -4555,8 +4983,12 @@
             ? product.colors.map(color => color.clientColorName || color.rawColorName || `ID:${color.id}`)
             : [];
         const tagLabels = Array.isArray(product.furnitureTags)
-            ? product.furnitureTags.map(tag => `${tag.furnitureNameKr || '-'} / ${tag.tagNameKr || '-'} (#${tag.furnitureTagId})`)
+            ? product.furnitureTags.map(tag => `${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)} (#${tag.furnitureTagId})`)
             : [];
+        const furnitureLabels = Array.isArray(product.furnitures)
+            ? product.furnitures.map(furniture => `${furniture.furnitureTypeNameKr || '-'} / ${furniture.furnitureNameKr || '-'} (#${furniture.furnitureId})`)
+            : [];
+        const cardTagLabels = tagLabels.length > 0 ? tagLabels : furnitureLabels;
 
         return `
             <article class="raw-product-card">
@@ -4605,7 +5037,7 @@
                             ${buildRawChipSection('Colors', colorLabels, '없음', `raw-colors-${product.id}`)}
                         </div>
                         <div class="col-6">
-                            ${buildRawChipSection('Tags', tagLabels, '없음', `raw-tags-${product.id}`)}
+                            ${buildRawChipSection('Tags', cardTagLabels, '없음', `raw-tags-${product.id}`)}
                         </div>
                     </div>
                 </div>
@@ -4970,6 +5402,27 @@
         document.getElementById('rawUpdateFetchedAt').value = formatDateTimeLocalValue(product.fetchedAt);
         document.getElementById('rawUpdateColors').value = formatRawProductColorsForInput(product.colors);
         document.getElementById('rawUpdateColorsEnabled').checked = true;
+        rawUpdateSelectedFurnitures = Array.isArray(product.furnitures)
+            ? product.furnitures.map(furniture => ({
+                furnitureId: furniture.furnitureId,
+                furnitureNameKr: furniture.furnitureNameKr,
+                furnitureNameEng: furniture.furnitureNameEng
+            }))
+            : [];
+        rawUpdateSelectedFurnitureTags = Array.isArray(product.furnitureTags)
+            ? product.furnitureTags.map(tag => ({
+                furnitureTagId: tag.furnitureTagId,
+                furnitureNameKr: tag.furnitureNameKr,
+                tagNameKr: tag.tagNameKr,
+                searchKeyword: tag.searchKeyword,
+                furnitureTypeId: tag.furnitureTypeId,
+                furnitureTypeNameKr: tag.furnitureTypeNameKr
+            }))
+            : [];
+        document.getElementById('rawUpdateFurnitureMappingEnabled').checked = false;
+        document.getElementById('rawUpdateFurnitureTagMappingEnabled').checked = false;
+        renderInlineRawSelectedFurnitures('update');
+        renderInlineRawSelectedFurnitureTags('update');
     }
 
     function populateRawProductFurnitureTagForm(product) {
@@ -5001,14 +5454,14 @@
                 ${furnitureTags.map(tag => `
                     <div class="raw-mapping-item">
                         <div>
-                            <div class="raw-mapping-item__title">${tag.furnitureTypeNameKr || '-'} / ${tag.furnitureNameKr || '-'} / ${tag.tagNameKr || '-'}</div>
+                            <div class="raw-mapping-item__title">${tag.furnitureTypeNameKr || '-'} / ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}</div>
                             <div class="raw-mapping-item__meta">
                                 mapping #${tag.mappingId} · furnitureTag #${tag.furnitureTagId} · priority ${tag.priority ?? '-'}<br>
                                 searchKeyword: ${tag.searchKeyword || '-'}
                             </div>
                         </div>
                         <div class="raw-mapping-item__actions">
-                            <button type="button" class="btn btn-sm btn-outline-warning" onclick="fillRawProductFurnitureTagUpdate(${product.id}, ${tag.mappingId}, ${tag.furnitureTagId}, ${tag.furnitureTypeId ?? 'null'}, '${escapeSingleQuotedString(tag.furnitureTypeNameKr || '')}', '${escapeSingleQuotedString(tag.furnitureNameKr || '')}', '${escapeSingleQuotedString(tag.tagNameKr || '')}')">수정 대상으로 선택</button>
+                            <button type="button" class="btn btn-sm btn-outline-warning" onclick="fillRawProductFurnitureTagUpdate(${product.id}, ${tag.mappingId}, ${tag.furnitureTagId}, ${tag.furnitureTypeId ?? 'null'}, '${escapeSingleQuotedString(tag.furnitureTypeNameKr || '')}', '${escapeSingleQuotedString(tag.furnitureNameKr || '')}', '${escapeSingleQuotedString(getRawFurnitureTagDisplayName(tag))}')">수정 대상으로 선택</button>
                             <button type="button" class="btn btn-sm btn-outline-danger" onclick="deleteRawProductFurnitureTagById(${product.id}, ${tag.mappingId})">삭제</button>
                         </div>
                     </div>
@@ -5025,7 +5478,10 @@
             ? product.colors.map(color => color.clientColorName || color.rawColorName || `ID:${color.id}`)
             : [];
         const tagLabels = Array.isArray(product.furnitureTags)
-            ? product.furnitureTags.map(tag => `${tag.furnitureNameKr || '-'} / ${tag.tagNameKr || '-'} (#${tag.furnitureTagId})`)
+            ? product.furnitureTags.map(tag => `${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)} (#${tag.furnitureTagId})`)
+            : [];
+        const furnitureLabels = Array.isArray(product.furnitures)
+            ? product.furnitures.map(furniture => `${furniture.furnitureTypeNameKr || '-'} / ${furniture.furnitureNameKr || '-'} (#${furniture.furnitureId})`)
             : [];
 
         return `
@@ -5122,6 +5578,9 @@
                             <div class="mb-4">
                                 ${buildRawChipSection('보유 컬러 속성', colorLabels, '매핑된 컬러 없음', `raw-detail-colors-${product.id}`)}
                             </div>
+                            <div class="mb-4">
+                                ${buildRawChipSection('연결된 하위가구', furnitureLabels, '매핑된 하위가구 없음', `raw-detail-furnitures-${product.id}`)}
+                            </div>
                             <div>
                                 ${buildRawChipSection('연결된 가구 태그', tagLabels, '매핑된 태그 없음', `raw-detail-tags-${product.id}`)}
                             </div>
@@ -5199,7 +5658,7 @@
         preview.classList.remove('is-empty');
         preview.innerHTML = `
             <span class="raw-tag-selected-chip">
-                ${tag.furnitureNameKr} / ${tag.tagNameKr}
+                ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}
                 <small>#${tag.furnitureTagId}</small>
             </span>
             <span>${tag.furnitureTypeNameKr ? `가구 타입: ${tag.furnitureTypeNameKr}` : '선택 완료'}</span>
@@ -5207,7 +5666,7 @@
     }
 
     function formatRawFurnitureTagOptionLabel(tag) {
-        return `${tag.furnitureNameKr} / ${tag.tagNameKr} (FT#${tag.furnitureTagId})`;
+        return `${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)} (FT#${tag.furnitureTagId})`;
     }
 
     function resolveRawFurnitureTagSelection(value) {
@@ -5233,7 +5692,8 @@
         const matchedByKeyword = rawFurnitureTagLookup.find(tag =>
             (tag.furnitureNameKr || '').toLowerCase() === normalizedKeyword
             || (tag.tagNameKr || '').toLowerCase() === normalizedKeyword
-            || (`${tag.furnitureNameKr || ''} / ${tag.tagNameKr || ''}`).toLowerCase() === normalizedKeyword
+            || (tag.searchKeyword || '').toLowerCase() === normalizedKeyword
+            || (`${tag.furnitureNameKr || ''} / ${getRawFurnitureTagDisplayName(tag)}`).toLowerCase() === normalizedKeyword
         );
         if (matchedByKeyword) {
             setRawFurnitureTagSelection(matchedByKeyword);
@@ -5517,7 +5977,9 @@
             freeShippingCondition: parseNumberValue(getOptionalInputValue('rawCreateFreeShippingCondition')),
             isExposed: parseBooleanValue(document.getElementById('rawCreateIsExposed').value),
             fetchedAt: parseStringValue(getOptionalInputValue('rawCreateFetchedAt')),
-            colors: parseRawProductColorRequests(document.getElementById('rawCreateColors').value)
+            colors: parseRawProductColorRequests(document.getElementById('rawCreateColors').value),
+            furnitureIds: rawCreateSelectedFurnitures.map(furniture => furniture.furnitureId),
+            furnitureTagIds: rawCreateSelectedFurnitureTags.map(tag => tag.furnitureTagId)
         };
     }
 
@@ -5539,6 +6001,8 @@
         const isExposed = parseBooleanValue(document.getElementById('rawUpdateIsExposed').value);
         const fetchedAt = parseStringValue(document.getElementById('rawUpdateFetchedAt').value);
         const colorsEnabled = document.getElementById('rawUpdateColorsEnabled').checked;
+        const furnitureMappingEnabled = document.getElementById('rawUpdateFurnitureMappingEnabled').checked;
+        const furnitureTagMappingEnabled = document.getElementById('rawUpdateFurnitureTagMappingEnabled').checked;
 
         if (source !== null) payload.source = source;
         if (category !== null) payload.category = category;
@@ -5556,6 +6020,8 @@
         if (isExposed !== null) payload.isExposed = isExposed;
         if (fetchedAt !== null) payload.fetchedAt = fetchedAt;
         if (colorsEnabled) payload.colors = parseRawProductColorRequests(document.getElementById('rawUpdateColors').value);
+        if (furnitureMappingEnabled) payload.furnitureIds = rawUpdateSelectedFurnitures.map(furniture => furniture.furnitureId);
+        if (furnitureTagMappingEnabled) payload.furnitureTagIds = rawUpdateSelectedFurnitureTags.map(tag => tag.furnitureTagId);
 
         return payload;
     }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -4589,7 +4589,7 @@
                     ? '선택한 가구 타입에 연결된 furniture_tag가 없습니다.'
                     : '가구명, 태그명, furnitureTag ID로 검색하세요.';
                 datalistElement.innerHTML = rawFurnitureTagLookup
-                    .map(option => `<option value="${formatRawFurnitureTagOptionLabel(option)}"></option>`)
+                    .map(option => `<option value="${escapeHtml(formatRawFurnitureTagOptionLabel(option))}"></option>`)
                     .join('');
 
                 if (preselectedFurnitureTagId) {
@@ -4665,7 +4665,7 @@
                     ? '<option value="" selected>선택 가능한 하위가구가 없습니다</option>'
                     : '<option value="" selected disabled>하위가구 선택...</option>' + furnitures.map(furniture => `
                         <option value="${furniture.furnitureId}">
-                            ${furniture.furnitureNameKr} (ID: ${furniture.furnitureId})
+                            ${escapeHtml(furniture.furnitureNameKr)} (ID: ${furniture.furnitureId})
                         </option>
                     `).join('');
             })
@@ -4714,7 +4714,7 @@
         container.classList.remove('is-empty');
         container.innerHTML = state.selectedFurnitures.map(furniture => `
             <span class="raw-tag-selected-chip">
-                ${furniture.furnitureNameKr || '-'}
+                ${escapeHtml(furniture.furnitureNameKr || '-')}
                 <small>#${furniture.furnitureId}</small>
                 <button type="button" class="btn-close btn-close-white ms-2" aria-label="삭제" onclick="removeSelectedRawFurniture('${mode}', ${furniture.furnitureId})"></button>
             </span>
@@ -4757,7 +4757,7 @@
                     ? '선택한 가구 타입에 연결된 furniture_tag가 없습니다.'
                     : '가구명, 태그명, furnitureTag ID로 검색하세요.';
                 datalistElement.innerHTML = furnitureTags
-                    .map(option => `<option value="${formatRawFurnitureTagOptionLabel(option)}"></option>`)
+                    .map(option => `<option value="${escapeHtml(formatRawFurnitureTagOptionLabel(option))}"></option>`)
                     .join('');
             })
             .catch(error => {
@@ -4832,6 +4832,32 @@
         }
     }
 
+    function resetInlineRawMappingInputs(mode) {
+        const state = getInlineRawMappingState(mode);
+
+        state.setFurnitureLookup([]);
+        state.setFurnitureTagLookup([]);
+
+        const furnitureTypeSelect = document.getElementById(mode === 'create' ? 'rawCreateFurnitureTypeId' : 'rawUpdateFurnitureTypeId');
+        const furnitureSelect = document.getElementById(state.furnitureSelectId);
+        const furnitureTagTypeSelect = document.getElementById(mode === 'create' ? 'rawCreateFurnitureTagTypeId' : 'rawUpdateFurnitureTagTypeId');
+        const keywordInput = document.getElementById(state.furnitureTagKeywordId);
+        const datalistElement = document.getElementById(state.furnitureTagDatalistId);
+
+        if (furnitureTypeSelect) furnitureTypeSelect.value = '';
+        if (furnitureSelect) {
+            furnitureSelect.disabled = true;
+            furnitureSelect.innerHTML = '<option value="" selected>상위가구를 먼저 선택하세요</option>';
+        }
+        if (furnitureTagTypeSelect) furnitureTagTypeSelect.value = '';
+        if (keywordInput) {
+            keywordInput.value = '';
+            keywordInput.disabled = true;
+            keywordInput.placeholder = '가구 타입을 먼저 선택하세요';
+        }
+        if (datalistElement) datalistElement.innerHTML = '';
+    }
+
     function renderInlineRawSelectedFurnitureTags(mode) {
         const state = getInlineRawMappingState(mode);
         const container = document.getElementById(state.furnitureTagListId);
@@ -4846,7 +4872,7 @@
         container.classList.remove('is-empty');
         container.innerHTML = state.selectedFurnitureTags.map(tag => `
             <span class="raw-tag-selected-chip">
-                ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}
+                ${escapeHtml(tag.furnitureNameKr || '-')} / ${escapeHtml(getRawFurnitureTagDisplayName(tag))}
                 <small>#${tag.furnitureTagId}</small>
                 <button type="button" class="btn-close btn-close-white ms-2" aria-label="삭제" onclick="removeSelectedRawFurnitureTag('${mode}', ${tag.furnitureTagId})"></button>
             </span>
@@ -4942,8 +4968,8 @@
         };
 
         const chips = labels.length === 0
-            ? `<span class="raw-chip raw-chip--muted">${emptyText}</span>`
-            : labels.map(item => `<span class="raw-chip">${getDotHtml(item)}${item}</span>`).join('');
+            ? `<span class="raw-chip raw-chip--muted">${escapeHtml(emptyText)}</span>`
+            : labels.map(item => `<span class="raw-chip">${getDotHtml(item)}${escapeHtml(item)}</span>`).join('');
             
         const toggleButton = collapsed
             ? `<button type="button" class="btn btn-sm btn-link p-0 ms-2 text-decoration-none" onclick="toggleRawChipSection('${sectionId}', this)">더보기</button>`
@@ -4952,7 +4978,7 @@
         return `
             <div class="raw-chip-section">
                 <div class="raw-chip-header d-flex align-items-center mb-2">
-                    <span class="raw-chip-title fw-bold small text-muted text-uppercase letter-spacing-1">${title}</span>
+                    <span class="raw-chip-title fw-bold small text-muted text-uppercase letter-spacing-1">${escapeHtml(title)}</span>
                     ${toggleButton}
                 </div>
                 <div id="${sectionId}" class="raw-chip-stack ${collapsed ? 'is-collapsed' : ''}">
@@ -5419,6 +5445,7 @@
                 furnitureTypeNameKr: tag.furnitureTypeNameKr
             }))
             : [];
+        resetInlineRawMappingInputs('update');
         document.getElementById('rawUpdateFurnitureMappingEnabled').checked = false;
         document.getElementById('rawUpdateFurnitureTagMappingEnabled').checked = false;
         renderInlineRawSelectedFurnitures('update');
@@ -5454,10 +5481,10 @@
                 ${furnitureTags.map(tag => `
                     <div class="raw-mapping-item">
                         <div>
-                            <div class="raw-mapping-item__title">${tag.furnitureTypeNameKr || '-'} / ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}</div>
+                            <div class="raw-mapping-item__title">${escapeHtml(tag.furnitureTypeNameKr || '-')} / ${escapeHtml(tag.furnitureNameKr || '-')} / ${escapeHtml(getRawFurnitureTagDisplayName(tag))}</div>
                             <div class="raw-mapping-item__meta">
                                 mapping #${tag.mappingId} · furnitureTag #${tag.furnitureTagId} · priority ${tag.priority ?? '-'}<br>
-                                searchKeyword: ${tag.searchKeyword || '-'}
+                                searchKeyword: ${escapeHtml(tag.searchKeyword || '-')}
                             </div>
                         </div>
                         <div class="raw-mapping-item__actions">
@@ -5658,10 +5685,10 @@
         preview.classList.remove('is-empty');
         preview.innerHTML = `
             <span class="raw-tag-selected-chip">
-                ${tag.furnitureNameKr || '-'} / ${getRawFurnitureTagDisplayName(tag)}
+                ${escapeHtml(tag.furnitureNameKr || '-')} / ${escapeHtml(getRawFurnitureTagDisplayName(tag))}
                 <small>#${tag.furnitureTagId}</small>
             </span>
-            <span>${tag.furnitureTypeNameKr ? `가구 타입: ${tag.furnitureTypeNameKr}` : '선택 완료'}</span>
+            <span>${tag.furnitureTypeNameKr ? `가구 타입: ${escapeHtml(tag.furnitureTypeNameKr)}` : '선택 완료'}</span>
         `;
     }
 

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -13,9 +13,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductColorRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductCreateRequest;
@@ -27,8 +29,10 @@ import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRaw
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import org.springframework.context.ApplicationEventPublisher;
@@ -62,7 +66,13 @@ class AdminCurationRawProductServiceImplTest {
     private CurationRawProductColorRepository curationRawProductColorRepository;
 
     @Mock
+    private CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
+
+    @Mock
     private CurationRawProductFurnitureTagRepository curationRawProductFurnitureTagRepository;
+
+    @Mock
+    private FurnitureRepository furnitureRepository;
 
     @Mock
     private FurnitureTagRepository furnitureTagRepository;
@@ -81,6 +91,8 @@ class AdminCurationRawProductServiceImplTest {
         when(curationRawProductRepository.findAllByFilters(any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(rawProduct)));
         when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(anyList())).thenReturn(List.of());
+        when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(anyList()))
+                .thenReturn(List.of());
         when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(anyList()))
                 .thenReturn(List.of());
 
@@ -131,7 +143,9 @@ class AdminCurationRawProductServiceImplTest {
                 List.of(
                         new AdminCurationRawProductColorRequest("우드", "우드"),
                         new AdminCurationRawProductColorRequest("화이트", "화이트")
-                )
+                ),
+                List.of(5L),
+                List.of(11L)
         );
 
         when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 1001L))
@@ -143,6 +157,10 @@ class AdminCurationRawProductServiceImplTest {
                     return saved;
                 });
         when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(anyList())).thenReturn(List.of());
+        when(furnitureRepository.findAllById(List.of(5L))).thenReturn(List.of(furniture(5L, "싱글 침대")));
+        when(furnitureTagRepository.findAllById(List.of(11L))).thenReturn(List.of(furnitureTag(11L)));
+        when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(anyList()))
+                .thenReturn(List.of());
         when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(anyList()))
                 .thenReturn(List.of());
 
@@ -154,6 +172,16 @@ class AdminCurationRawProductServiceImplTest {
         assertEquals("테스트 침대", response.productName());
         assertFalse(response.isExposed());
         verify(curationRawProductRepository).saveAndFlush(any(CurationRawProduct.class));
+        verify(curationRawProductFurnitureRepository).saveAll(argThat(mappings ->
+                mappings instanceof List<?>
+                        && ((List<?>) mappings).size() == 1
+                        && ((List<?>) mappings).stream().allMatch(CurationRawProductFurniture.class::isInstance)
+        ));
+        verify(curationRawProductFurnitureTagRepository).saveAll(argThat(mappings ->
+                mappings instanceof List<?>
+                        && ((List<?>) mappings).size() == 1
+                        && ((List<?>) mappings).stream().allMatch(CurationRawProductFurnitureTag.class::isInstance)
+        ));
         verify(curationRawProductColorRepository).saveAll(argThat(colors ->
                 colors instanceof List<?>
                         && ((List<?>) colors).size() == 2
@@ -172,6 +200,8 @@ class AdminCurationRawProductServiceImplTest {
                 "https://soozip.co.kr/product/1001",
                 "테스트 침대",
                 "SOOZIP",
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -215,6 +245,8 @@ class AdminCurationRawProductServiceImplTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         );
 
@@ -222,7 +254,7 @@ class AdminCurationRawProductServiceImplTest {
         when(curationRawProductRepository.findBySourceAndCategoryAndProductId("soozip", SoozipCategory.FURNITURE, 4004L))
                 .thenReturn(Optional.empty());
         when(curationRawProductRepository.saveAndFlush(rawProduct))
-                .thenThrow(new DataIntegrityViolationException("duplicate"));
+                .thenThrow(new DataIntegrityViolationException("constraint [uk_raw_source_category_product_id]"));
 
         GeneralException exception = assertThrows(
                 GeneralException.class,
@@ -255,7 +287,9 @@ class AdminCurationRawProductServiceImplTest {
                 List.of(
                         new AdminCurationRawProductColorRequest("블랙", "블랙"),
                         new AdminCurationRawProductColorRequest("베이지", "베이지")
-                )
+                ),
+                null,
+                null
         );
 
         when(curationRawProductRepository.findById(10L)).thenReturn(Optional.of(rawProduct));
@@ -263,6 +297,8 @@ class AdminCurationRawProductServiceImplTest {
                 .thenReturn(Optional.of(rawProduct));
         when(curationRawProductRepository.saveAndFlush(rawProduct)).thenReturn(rawProduct);
         when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(anyList())).thenReturn(List.of());
+        when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(anyList()))
+                .thenReturn(List.of());
         when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(anyList()))
                 .thenReturn(List.of());
 
@@ -417,5 +453,21 @@ class AdminCurationRawProductServiceImplTest {
                 .build();
         ReflectionTestUtils.setField(furnitureTag, "id", furnitureTagId);
         return furnitureTag;
+    }
+
+    private Furniture furniture(Long furnitureId, String furnitureNameKr) {
+        FurnitureType furnitureType = FurnitureType.builder()
+                .nameKr("침대")
+                .nameEng("BED")
+                .build();
+        ReflectionTestUtils.setField(furnitureType, "id", 3L);
+
+        Furniture furniture = Furniture.builder()
+                .furnitureNameKr(furnitureNameKr)
+                .furnitureNameEng("SINGLE_BED")
+                .furnitureType(furnitureType)
+                .build();
+        ReflectionTestUtils.setField(furniture, "id", furnitureId);
+        return furniture;
     }
 }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -155,10 +155,10 @@ class AdminCurationRawProductServiceImplTest {
                     CurationRawProduct saved = invocation.getArgument(0);
                     ReflectionTestUtils.setField(saved, "id", 10L);
                     return saved;
-                });
+        });
         when(curationRawProductColorRepository.findAllByCurationRawProductIdIn(anyList())).thenReturn(List.of());
-        when(furnitureRepository.findAllById(List.of(5L))).thenReturn(List.of(furniture(5L, "싱글 침대")));
-        when(furnitureTagRepository.findAllById(List.of(11L))).thenReturn(List.of(furnitureTag(11L)));
+        when(furnitureRepository.findAllById(any())).thenReturn(List.of(furniture(5L, "싱글 침대")));
+        when(furnitureTagRepository.findAllById(any())).thenReturn(List.of(furnitureTag(11L)));
         when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(anyList()))
                 .thenReturn(List.of());
         when(curationRawProductFurnitureTagRepository.findAllByCurationRawProductIdInWithFurnitureTag(anyList()))
@@ -173,14 +173,10 @@ class AdminCurationRawProductServiceImplTest {
         assertFalse(response.isExposed());
         verify(curationRawProductRepository).saveAndFlush(any(CurationRawProduct.class));
         verify(curationRawProductFurnitureRepository).saveAll(argThat(mappings ->
-                mappings instanceof List<?>
-                        && ((List<?>) mappings).size() == 1
-                        && ((List<?>) mappings).stream().allMatch(CurationRawProductFurniture.class::isInstance)
+                iterableHasOnlyInstances(mappings, CurationRawProductFurniture.class, 1)
         ));
         verify(curationRawProductFurnitureTagRepository).saveAll(argThat(mappings ->
-                mappings instanceof List<?>
-                        && ((List<?>) mappings).size() == 1
-                        && ((List<?>) mappings).stream().allMatch(CurationRawProductFurnitureTag.class::isInstance)
+                iterableHasOnlyInstances(mappings, CurationRawProductFurnitureTag.class, 1)
         ));
         verify(curationRawProductColorRepository).saveAll(argThat(colors ->
                 colors instanceof List<?>
@@ -469,5 +465,16 @@ class AdminCurationRawProductServiceImplTest {
                 .build();
         ReflectionTestUtils.setField(furniture, "id", furnitureId);
         return furniture;
+    }
+
+    private boolean iterableHasOnlyInstances(Iterable<?> values, Class<?> type, int expectedSize) {
+        int count = 0;
+        for (Object value : values) {
+            if (!type.isInstance(value)) {
+                return false;
+            }
+            count++;
+        }
+        return count == expectedSize;
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #524 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 어드민 세부가구 카테고리 생성 API 및 VIEW 구현
- View 코드가 많고, 로직 코드는 많지 않으니 부담갖지 않으셔도 됩니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

### Set을 통한 OneToMany
동일한 가구가 중복되어 들어가지 않게끔 List가 아닌 Set으로 연관관계 매핑을 구현하였습니다.

### CurationRawProduct와 Furniture 매핑테이블 구현

```java
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
@Getter
@Builder
@Entity
@Table(name = "curation_raw_product_furnitures")
@Comment("큐레이션 원본 수집 데이터(curation_raw_products)와 하위 가구(furnitures)의 매핑 테이블입니다.")
public class CurationRawProductFurniture {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "curation_raw_product_id", nullable = false)
    private CurationRawProduct curationRawProduct;

    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "furniture_id", nullable = false)
    private Furniture furniture;

    public static CurationRawProductFurniture of(CurationRawProduct rawProduct, Furniture furniture) {
        return CurationRawProductFurniture.builder()
                .curationRawProduct(rawProduct)
                .furniture(furniture)
                .build();
    }
}
```

신규 테이블이 추가되었습니다.
큐레이션 로직 짜실때 해당 테이블에서 데이터를 가져다 쓰시면 될 것 같습니다 !
@PBEM22 

## 📬 Postman

<img width="1325" height="708" alt="image" src="https://github.com/user-attachments/assets/deea07a9-987b-4697-b540-4cc9a127dc86" />

- 기존에 가구 생성과 별개로 존재하던 Furntiure_tag 매핑 UI를 가구 생성시 함께 주입 할 수 있도록 UI를 수정하였습니다.

<img width="239" height="212" alt="image" src="https://github.com/user-attachments/assets/8825bdd3-0efe-4e46-b41f-dd2ea06d0c01" />

- 데이터 조회는 위와 같이 가능합니다.

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드에 상품 관리 시 하위가구 및 가구 태그 매핑 기능 추가
  * 상품 등록/수정 시 여러 하위가구 선택 및 관리 기능 제공
  * 가구 타입별 하위가구 목록 조회 API 엔드포인트 추가

* **버그 수정**
  * 중복 데이터 발생 시 더 명확한 오류 처리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->