### PR TITLE
[CHORE] 상품 검색시 결과 없을때, 추천 상품 제공 (#538)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ seed_local_houme.sql
 
 ### Claude Code ###
 CLAUDE.md
+.claude/

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/CurationProductMetaResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/CurationProductMetaResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record CurationProductMetaResponse(
         Long nextCursor,
         Boolean hasNext,
-        List<CurationProductAppliedFilterResponse> appliedFilters
+        List<CurationProductAppliedFilterResponse> appliedFilters,
+        Boolean isRecommended
 ) {
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
@@ -28,6 +28,14 @@ public interface CurationRawProductRepositoryCustom {
             Pageable pageable
     );
 
+    Slice<CurationRawProduct> findAllByCurationFiltersRecommend(
+            List<Long> typeIds,
+            List<PriceRangeFilter> priceRanges,
+            List<String> colorNames,
+            Long cursor,
+            Pageable pageable
+    );
+
     Page<CurationRawProduct> findExposedRawProductsExcludingLikedByUser(Long userId, Pageable pageable);
     Long findMaxExposedRawProductIdExcludingLikedByUser(Long userId);
     List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserWithCursor(

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -2,6 +2,9 @@ package or.sopt.houme.domain.furniture.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -408,6 +411,93 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
+
+    @Override
+    public Slice<CurationRawProduct> findAllByCurationFiltersRecommend(
+            List<Long> typeIds,
+            List<PriceRangeFilter> priceRanges,
+            List<String> colorNames,
+            Long cursor,
+            Pageable pageable
+    ) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
+        QFurnitureTag fTag = QFurnitureTag.furnitureTag;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType fType = QFurnitureType.furnitureType;
+        QCurationRawProductColor color = QCurationRawProductColor.curationRawProductColor;
+
+        BooleanBuilder baseWhere = new BooleanBuilder();
+        baseWhere.and(rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull()));
+        if (cursor != null) {
+            baseWhere.and(rawProduct.id.lt(cursor));
+        }
+
+        NumberExpression<Integer> matchScore = Expressions.asNumber(0);
+        BooleanBuilder atLeastOne = new BooleanBuilder();
+
+        if (typeIds != null && !typeIds.isEmpty()) {
+            var typeSubquery = JPAExpressions
+                    .select(mapping.curationRawProduct.id)
+                    .from(mapping)
+                    .join(mapping.furnitureTag, fTag)
+                    .join(fTag.furniture, furniture)
+                    .leftJoin(furniture.furnitureType, fType)
+                    .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)));
+
+            matchScore = matchScore.add(
+                    new CaseBuilder().when(rawProduct.id.in(typeSubquery)).then(1).otherwise(0)
+            );
+            atLeastOne.or(rawProduct.id.in(typeSubquery));
+        }
+
+        if (priceRanges != null && !priceRanges.isEmpty()) {
+            BooleanBuilder priceCondition = new BooleanBuilder();
+            for (PriceRangeFilter range : priceRanges) {
+                BooleanBuilder rangeBuilder = new BooleanBuilder();
+                if (range.min() != null) rangeBuilder.and(rawProduct.discountPrice.goe(range.min()));
+                if (range.max() != null) rangeBuilder.and(rawProduct.discountPrice.loe(range.max()));
+                priceCondition.or(rangeBuilder);
+            }
+            matchScore = matchScore.add(
+                    new CaseBuilder().when(priceCondition).then(1).otherwise(0)
+            );
+            atLeastOne.or(priceCondition);
+        }
+
+        if (colorNames != null && !colorNames.isEmpty()) {
+            BooleanBuilder colorCondition = new BooleanBuilder();
+            for (String colorName : colorNames) {
+                colorCondition.or(color.clientColorName.containsIgnoreCase(colorName));
+            }
+            var colorSubquery = JPAExpressions
+                    .select(color.curationRawProduct.id)
+                    .from(color)
+                    .where(colorCondition);
+
+            matchScore = matchScore.add(
+                    new CaseBuilder().when(rawProduct.id.in(colorSubquery)).then(1).otherwise(0)
+            );
+            atLeastOne.or(rawProduct.id.in(colorSubquery));
+        }
+
+        baseWhere.and(atLeastOne);
+
+        List<CurationRawProduct> content = queryFactory
+                .selectFrom(rawProduct)
+                .where(baseWhere)
+                .orderBy(matchScore.desc(), rawProduct.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     private BooleanExpression containsIgnoreCase(com.querydsl.core.types.dsl.StringPath path, String keyword) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -87,6 +87,22 @@ public class CurationProductServiceImpl implements CurationProductService {
                 keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable
         );
 
+        boolean isRecommended = false;
+        if (productSlice.isEmpty()) {
+            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames);
+            if (hasFilter) {
+                productSlice = curationRawProductRepository.findAllByCurationFiltersRecommend(
+                        filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                );
+            }
+            if (productSlice.isEmpty()) {
+                productSlice = curationRawProductRepository.findAllByCurationFilters(
+                        null, null, null, null, cursor, pageable
+                );
+            }
+            isRecommended = true;
+        }
+
         List<CurationProductResponse> products = productSlice.getContent().stream()
                 .map(p -> new CurationProductResponse(
                         p.getId(),
@@ -110,8 +126,18 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         return new CurationProductListResponse(
                 products,
-                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters)
+                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters, isRecommended)
         );
+    }
+
+    private boolean hasAnyFilter(
+            List<Long> typeIds,
+            List<CurationRawProductRepositoryCustom.PriceRangeFilter> priceFilters,
+            List<String> colorNames
+    ) {
+        return (typeIds != null && !typeIds.isEmpty())
+                || (priceFilters != null && !priceFilters.isEmpty())
+                || (colorNames != null && !colorNames.isEmpty());
     }
 
     private void validatePaginationParams(Integer size) {
@@ -223,6 +249,22 @@ public class CurationProductServiceImpl implements CurationProductService {
                 keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable
         );
 
+        boolean isRecommended = false;
+        if (productSlice.isEmpty()) {
+            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames);
+            if (hasFilter) {
+                productSlice = curationRawProductRepository.findAllByCurationFiltersRecommend(
+                        filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                );
+            }
+            if (productSlice.isEmpty()) {
+                productSlice = curationRawProductRepository.findAllByCurationFiltersV2(
+                        null, null, null, null, cursor, pageable
+                );
+            }
+            isRecommended = true;
+        }
+
         List<CurationProductResponse> products = productSlice.getContent().stream()
                 .map(p -> new CurationProductResponse(
                         p.getId(),
@@ -246,7 +288,7 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         return new CurationProductListResponse(
                 products,
-                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters)
+                new CurationProductMetaResponse(nextCursor, hasNext, appliedFilters, isRecommended)
         );
     }
 

--- a/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/presentation/controller/CurationProductV2ControllerTest.java
@@ -51,7 +51,7 @@ class CurationProductV2ControllerTest {
         // given
         CurationProductListResponse mockResponse = new CurationProductListResponse(
                 List.of(),
-                new CurationProductMetaResponse(null, false, List.of())
+                new CurationProductMetaResponse(null, false, List.of(), false)
         );
         given(curationProductService.getProductsV2(any(), any(), any(), any(), any(), any()))
                 .willReturn(mockResponse);
@@ -74,7 +74,7 @@ class CurationProductV2ControllerTest {
         // given
         CurationProductListResponse mockResponse = new CurationProductListResponse(
                 List.of(),
-                new CurationProductMetaResponse(null, false, List.of())
+                new CurationProductMetaResponse(null, false, List.of(), false)
         );
         given(curationProductService.getProductsV2(eq("매트리스"), any(), any(), any(), any(), any()))
                 .willReturn(mockResponse);

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -13,6 +13,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductF
 import or.sopt.houme.domain.furniture.presentation.dto.response.CurationProductListResponse;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepositoryCustom;
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
@@ -161,6 +162,126 @@ class CurationProductServiceImplTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().get(0).name()).isEqualTo("SS매트리스 침대");
         assertThat(response.meta().hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getProducts()는 AND 필터 결과가 없고 필터가 있으면 OR 추천 쿼리를 호출하고 isRecommended=true를 반환한다")
+    void getProducts_withEmptyResultAndFilter_returnsRecommended() {
+        // given
+        List<Long> typeIds = List.of(1L);
+        List<String> priceRangeIds = List.of("P1");
+        Integer size = 20;
+
+        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
+        given(furnitureRepository.findAll()).willReturn(List.of());
+
+        Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
+        CurationRawProduct recommended = CurationRawProduct.builder()
+                .id(10L).productId(1000L).productName("추천 침대").discountPrice(80000L)
+                .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
+        Slice<CurationRawProduct> recommendSlice = new SliceImpl<>(List.of(recommended), PageRequest.of(0, size), false);
+
+        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any()))
+                .willReturn(emptySlice);
+        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any()))
+                .willReturn(recommendSlice);
+
+        // when
+        CurationProductListResponse response = curationProductService.getProducts(
+                null, typeIds, priceRangeIds, null, null, size
+        );
+
+        // then
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.meta().isRecommended()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getProducts()는 AND 필터 결과가 없고 필터도 없으면 전체 상품 fallback으로 isRecommended=true를 반환한다")
+    void getProducts_withEmptyResultAndNoFilter_returnsFallback() {
+        // given
+        String keyword = "없는상품xyz";
+        Integer size = 20;
+
+        CurationRawProduct fallback = CurationRawProduct.builder()
+                .id(5L).productId(500L).productName("전체 상품").discountPrice(30000L)
+                .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
+        Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
+        Slice<CurationRawProduct> fallbackSlice = new SliceImpl<>(List.of(fallback), PageRequest.of(0, size), false);
+
+        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any()))
+                .willReturn(emptySlice)
+                .willReturn(fallbackSlice);
+
+        // when
+        CurationProductListResponse response = curationProductService.getProducts(
+                keyword, null, null, null, null, size
+        );
+
+        // then
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.meta().isRecommended()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getProductsV2()는 AND 필터 결과가 없고 필터가 있으면 OR 추천 쿼리를 호출하고 isRecommended=true를 반환한다")
+    void getProductsV2_withEmptyResultAndFilter_returnsRecommended() {
+        // given
+        List<Long> typeIds = List.of(1L);
+        List<String> priceRangeIds = List.of("P1");
+        Integer size = 20;
+
+        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
+        given(furnitureRepository.findAll()).willReturn(List.of());
+
+        Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
+        CurationRawProduct recommended = CurationRawProduct.builder()
+                .id(10L).productId(1000L).productName("추천 침대").discountPrice(80000L)
+                .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
+        Slice<CurationRawProduct> recommendSlice = new SliceImpl<>(List.of(recommended), PageRequest.of(0, size), false);
+
+        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any()))
+                .willReturn(emptySlice);
+        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any()))
+                .willReturn(recommendSlice);
+
+        // when
+        CurationProductListResponse response = curationProductService.getProductsV2(
+                null, typeIds, priceRangeIds, null, null, size
+        );
+
+        // then
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.meta().isRecommended()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getProductsV2()는 AND 필터 결과가 없고 필터도 없으면 전체 상품 fallback으로 isRecommended=true를 반환한다")
+    void getProductsV2_withEmptyResultAndNoFilter_returnsFallback() {
+        // given
+        String keyword = "없는상품xyz";
+        Integer size = 20;
+
+        CurationRawProduct fallback = CurationRawProduct.builder()
+                .id(5L).productId(500L).productName("전체 상품").discountPrice(30000L)
+                .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
+        Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
+        Slice<CurationRawProduct> fallbackSlice = new SliceImpl<>(List.of(fallback), PageRequest.of(0, size), false);
+
+        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any()))
+                .willReturn(emptySlice)
+                .willReturn(fallbackSlice);
+
+        // when
+        CurationProductListResponse response = curationProductService.getProductsV2(
+                keyword, null, null, null, null, size
+        );
+
+        // then
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.meta().isRecommended()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue
- close #538

## 📝 Summary
- 상품 목록 조회(v1, v2) 시 AND 필터 결과가 없는 경우 추천 상품 자동 반환
- 필터(가구유형/가격대/색상)가 있으면 OR로 완화하여 교집합 많은 순 추천
- 키워드만 입력하거나 OR 결과도 없으면 전체 노출 상품 fallback 반환
- 응답 meta에 `isRecommended` 플래그 추가로 일반 결과와 추천 결과 구분 가능

## 🙏 Question & PR point
- `isRecommended: true`일 때 클라이언트에서 '이런 상품은 어떠세요?' 문구 노출 예정
- 교집합 정렬은 가구유형/가격대/색상 각 1점씩 부여 후 합산 내림차순 정렬

## 📬 Postman
- `GET /api/v1/curations/products?typeIds=-1&priceRangeIds=P1&size=20` → `isRecommended: true`
- `GET /api/v2/curations/products?typeIds=-1&priceRangeIds=P1&size=20` → `isRecommended: true`
- `GET /api/v2/curations/products?keyword=zzzznotexist&size=20` → `isRecommended: true`
- `GET /api/v2/curations/products?size=20` → `isRecommended: false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 초기 검색 결과가 없을 때 추천 상품 조회 기능 추가
  * 추천 상품 여부를 나타내는 플래그 추가

* **Tests**
  * 추천 쿼리 및 폴백 동작 관련 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->