### PR TITLE
[FEATURE] 어드민 제품 등록 시, 색상 선택을 드롭다운으로 선택 기능 구현

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/controller/AdminCurationRawProductController.java
@@ -10,6 +10,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawP
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorOptionResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureTagResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,6 +49,12 @@ public class AdminCurationRawProductController {
         return ResponseEntity.ok(ApiResponse.ok(
                 adminCurationRawProductService.getAll(page, size, category, minListPrice, maxListPrice)
         ));
+    }
+
+    @GetMapping("/color-options")
+    @Operation(summary = "curation_raw_product 색상 옵션 조회 API")
+    public ResponseEntity<ApiResponse<List<AdminCurationRawProductColorOptionResponse>>> getColorOptions() {
+        return ResponseEntity.ok(ApiResponse.ok(adminCurationRawProductService.getColorOptions()));
     }
 
     @GetMapping("/{curationRawProductId}")

--- a/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductColorOptionResponse.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/presentation/dto/response/AdminCurationRawProductColorOptionResponse.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.furniture.presentation.dto.response;
+
+public record AdminCurationRawProductColorOptionResponse(
+        String label,
+        String value
+) {
+    public static AdminCurationRawProductColorOptionResponse of(String label, String value) {
+        return new AdminCurationRawProductColorOptionResponse(label, value);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductService.java
@@ -6,9 +6,12 @@ import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawP
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorOptionResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureTagResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
+
+import java.util.List;
 
 public interface AdminCurationRawProductService {
 
@@ -21,6 +24,8 @@ public interface AdminCurationRawProductService {
     );
 
     AdminCurationRawProductResponse getById(Long curationRawProductId);
+
+    List<AdminCurationRawProductColorOptionResponse> getColorOptions();
 
     AdminCurationRawProductResponse create(AdminCurationRawProductCreateRequest request);
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImpl.java
@@ -14,6 +14,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawP
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorOptionResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureTagResponse;
@@ -25,6 +26,7 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureTagR
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
+import or.sopt.houme.domain.furniture.service.ColorHexMapper;
 import or.sopt.houme.domain.furniture.service.event.CurationRawProductTokenRefreshEvent;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.GeneralException;
@@ -99,6 +101,14 @@ public class AdminCurationRawProductServiceImpl implements AdminCurationRawProdu
     public AdminCurationRawProductResponse getById(Long curationRawProductId) {
         CurationRawProduct rawProduct = getRawProductOrThrow(curationRawProductId);
         return buildResponses(List.of(rawProduct)).get(0);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdminCurationRawProductColorOptionResponse> getColorOptions() {
+        return ColorHexMapper.getStandardColorFilters().entrySet().stream()
+                .map(entry -> AdminCurationRawProductColorOptionResponse.of(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     @Override

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -744,6 +744,9 @@
             height: 0.55rem;
             padding: 0.15rem;
         }
+        .raw-color-option-error {
+            display: none;
+        }
         .floor-plan-image-stack {
             display: grid;
             gap: 12px;
@@ -1265,6 +1268,7 @@
                                 <button class="btn btn-outline-primary" type="button" id="rawCreateColorAddButton">추가</button>
                             </div>
                             <div id="rawCreateSelectedColorList" class="raw-chip-stack mt-2"></div>
+                            <small id="rawCreateColorOptionError" class="text-danger raw-color-option-error">색상 옵션을 불러올 수 없습니다.</small>
                             <small class="text-muted">표준 색상을 선택하면 RAW 상품 등록과 동시에 색상이 저장됩니다.</small>
                         </div>
                         <div class="raw-form-field">
@@ -1480,6 +1484,7 @@
                                         <button class="btn btn-outline-primary" type="button" id="rawUpdateColorAddButton">추가</button>
                                     </div>
                                     <div id="rawUpdateSelectedColorList" class="raw-chip-stack mt-2"></div>
+                                    <small id="rawUpdateColorOptionError" class="text-danger raw-color-option-error">색상 옵션을 불러올 수 없습니다.</small>
                                     <div class="form-check mt-2">
                                         <input class="form-check-input" type="checkbox" id="rawUpdateColorsEnabled">
                                         <label class="form-check-label small" for="rawUpdateColorsEnabled">색상 수정 반영</label>
@@ -2049,6 +2054,7 @@
     let rawColorOptions = [];
     let rawCreateSelectedColors = [];
     let rawUpdateSelectedColors = [];
+    let rawColorOptionsLoadFailed = false;
     let rawProductsFilterState = {
         category: null,
         minListPrice: null,
@@ -2642,8 +2648,9 @@
         });
 
         document.getElementById('rawUpdateColorAddButton').addEventListener('click', function() {
-            addSelectedRawColor('update');
-            document.getElementById('rawUpdateColorsEnabled').checked = true;
+            if (addSelectedRawColor('update')) {
+                document.getElementById('rawUpdateColorsEnabled').checked = true;
+            }
         });
 
         document.getElementById('rawCreateFurnitureTagKeyword').addEventListener('change', function(event) {
@@ -4613,17 +4620,32 @@
             })
             .then(data => {
                 rawColorOptions = Array.isArray(data.data) ? data.data : [];
+                rawColorOptionsLoadFailed = false;
+                setRawColorOptionErrorState(false);
                 renderRawColorOptions('create');
                 renderRawColorOptions('update');
                 renderSelectedRawColors('create');
                 renderSelectedRawColors('update');
             })
-            .catch(error => console.error('Error loading raw color options:', error));
+            .catch(error => {
+                console.error('Error loading raw color options:', error);
+                rawColorOptions = [];
+                rawColorOptionsLoadFailed = true;
+                setRawColorOptionErrorState(true);
+                renderSelectedRawColors('create');
+                renderSelectedRawColors('update');
+            });
     }
 
     function renderRawColorOptions(mode) {
         const select = document.getElementById(`raw${capitalizeMode(mode)}ColorSelect`);
         if (!select) return;
+
+        if (rawColorOptionsLoadFailed) {
+            select.innerHTML = '<option value="" selected>색상 옵션 로딩 실패</option>';
+            select.disabled = true;
+            return;
+        }
 
         const selectedColors = getSelectedRawColors(mode);
         const selectedLabels = new Set(selectedColors.map(color => color.label));
@@ -4635,24 +4657,28 @@
             .join('');
 
         select.innerHTML = `<option value="" selected>색상 선택...</option>${options}`;
+        select.disabled = false;
     }
 
     function addSelectedRawColor(mode) {
         const select = document.getElementById(`raw${capitalizeMode(mode)}ColorSelect`);
-        if (!select || !select.value) return;
+        if (!select || !select.value) return false;
 
         const color = rawColorOptions.find(option => option.label === select.value) || {
             label: select.value,
             value: null
         };
         const selectedColors = getSelectedRawColors(mode);
-        if (!selectedColors.some(selected => selected.label === color.label)) {
-            selectedColors.push(color);
+        if (selectedColors.some(selected => selected.label === color.label)) {
+            select.value = '';
+            return false;
         }
 
+        selectedColors.push(color);
         select.value = '';
         renderRawColorOptions(mode);
         renderSelectedRawColors(mode);
+        return true;
     }
 
     function removeSelectedRawColor(mode, colorLabel) {
@@ -4687,6 +4713,17 @@
 
     function getSelectedRawColors(mode) {
         return mode === 'create' ? rawCreateSelectedColors : rawUpdateSelectedColors;
+    }
+
+    function setRawColorOptionErrorState(hasError) {
+        ['Create', 'Update'].forEach(modeName => {
+            const select = document.getElementById(`raw${modeName}ColorSelect`);
+            const button = document.getElementById(`raw${modeName}ColorAddButton`);
+            const error = document.getElementById(`raw${modeName}ColorOptionError`);
+            if (select) select.disabled = hasError;
+            if (button) button.disabled = hasError;
+            if (error) error.style.display = hasError ? 'block' : 'none';
+        });
     }
 
     function setSelectedRawColors(mode, colors) {
@@ -5615,7 +5652,7 @@
         document.getElementById('rawUpdateIsExposed').value = product.isExposed == null ? '' : String(product.isExposed);
         document.getElementById('rawUpdateFetchedAt').value = formatDateTimeLocalValue(product.fetchedAt);
         setSelectedRawColors('update', product.colors);
-        document.getElementById('rawUpdateColorsEnabled').checked = true;
+        document.getElementById('rawUpdateColorsEnabled').checked = false;
         rawUpdateSelectedFurnitures = Array.isArray(product.furnitures)
             ? product.furnitures.map(furniture => ({
                 furnitureId: furniture.furnitureId,

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -727,6 +727,23 @@
             border: 1px dashed #cbd5e1;
             font-style: italic;
         }
+        .raw-color-selected-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 10px;
+            border-radius: 999px;
+            background: #f8fafc;
+            border: 1px solid #cbd5e1;
+            color: #334155;
+            font-size: 0.85rem;
+            font-weight: 700;
+        }
+        .raw-color-selected-chip .btn-close {
+            width: 0.55rem;
+            height: 0.55rem;
+            padding: 0.15rem;
+        }
         .floor-plan-image-stack {
             display: grid;
             gap: 12px;
@@ -1240,9 +1257,15 @@
                             <input type="text" class="form-control" id="rawCreateBrand">
                         </div>
                         <div class="raw-form-field">
-                            <label for="rawCreateColors">Colors</label>
-                            <input type="text" class="form-control" id="rawCreateColors" placeholder="예: 우드, 화이트, 블랙">
-                            <small class="text-muted">쉼표 또는 줄바꿈으로 여러 색상을 입력합니다.</small>
+                            <label for="rawCreateColorSelect">Colors</label>
+                            <div class="input-group">
+                                <select class="form-select" id="rawCreateColorSelect">
+                                    <option value="" selected>색상 선택...</option>
+                                </select>
+                                <button class="btn btn-outline-primary" type="button" id="rawCreateColorAddButton">추가</button>
+                            </div>
+                            <div id="rawCreateSelectedColorList" class="raw-chip-stack mt-2"></div>
+                            <small class="text-muted">표준 색상을 선택하면 RAW 상품 등록과 동시에 색상이 저장됩니다.</small>
                         </div>
                         <div class="raw-form-field">
                             <label for="rawCreateIsExposed">Exposure Status</label>
@@ -1449,13 +1472,19 @@
                                     <input type="text" class="form-control" id="rawUpdateBrand">
                                 </div>
                                 <div class="raw-form-field">
-                                    <label for="rawUpdateColors">Colors</label>
-                                    <input type="text" class="form-control" id="rawUpdateColors" placeholder="예: 우드, 화이트, 블랙">
+                                    <label for="rawUpdateColorSelect">Colors</label>
+                                    <div class="input-group">
+                                        <select class="form-select" id="rawUpdateColorSelect">
+                                            <option value="" selected>색상 선택...</option>
+                                        </select>
+                                        <button class="btn btn-outline-primary" type="button" id="rawUpdateColorAddButton">추가</button>
+                                    </div>
+                                    <div id="rawUpdateSelectedColorList" class="raw-chip-stack mt-2"></div>
                                     <div class="form-check mt-2">
                                         <input class="form-check-input" type="checkbox" id="rawUpdateColorsEnabled">
                                         <label class="form-check-label small" for="rawUpdateColorsEnabled">색상 수정 반영</label>
                                     </div>
-                                    <small class="text-muted">체크 후 비워서 저장하면 색상이 전체 삭제됩니다.</small>
+                                    <small class="text-muted">체크 후 선택된 색상이 없으면 색상이 전체 삭제됩니다.</small>
                                 </div>
                                 <div class="raw-form-field">
                                     <label for="rawUpdateIsExposed">Exposure Status</label>
@@ -2017,6 +2046,9 @@
     let rawCreateSelectedFurnitureTags = [];
     let rawUpdateSelectedFurnitures = [];
     let rawUpdateSelectedFurnitureTags = [];
+    let rawColorOptions = [];
+    let rawCreateSelectedColors = [];
+    let rawUpdateSelectedColors = [];
     let rawProductsFilterState = {
         category: null,
         minListPrice: null,
@@ -2073,6 +2105,7 @@
         initializeStyleManagement();
         initializeFloorPlanManagement();
         populateRawFurnitureTypeDropdownForRawMapping();
+        loadRawColorOptions();
 
         // Sidebar navigation
         document.querySelectorAll('#sidebar .nav-link').forEach(link => {
@@ -2602,6 +2635,15 @@
 
         document.getElementById('rawUpdateFurnitureTagTypeId').addEventListener('change', function(event) {
             loadInlineRawFurnitureTagOptionsByType(event.target.value, 'update');
+        });
+
+        document.getElementById('rawCreateColorAddButton').addEventListener('click', function() {
+            addSelectedRawColor('create');
+        });
+
+        document.getElementById('rawUpdateColorAddButton').addEventListener('click', function() {
+            addSelectedRawColor('update');
+            document.getElementById('rawUpdateColorsEnabled').checked = true;
         });
 
         document.getElementById('rawCreateFurnitureTagKeyword').addEventListener('change', function(event) {
@@ -4555,6 +4597,152 @@
             .catch(error => console.error('Error populating raw furniture type dropdown:', error));
     }
 
+    function loadRawColorOptions() {
+        const accessToken = localStorage.getItem('accessToken');
+        if (!accessToken) return;
+
+        fetch('/api/v1/admin/curation-raw-products/color-options', {
+            method: 'GET',
+            headers: {'Authorization': 'Bearer ' + accessToken, 'Content-Type': 'application/json'}
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('색상 옵션 조회 실패');
+                }
+                return response.json();
+            })
+            .then(data => {
+                rawColorOptions = Array.isArray(data.data) ? data.data : [];
+                renderRawColorOptions('create');
+                renderRawColorOptions('update');
+                renderSelectedRawColors('create');
+                renderSelectedRawColors('update');
+            })
+            .catch(error => console.error('Error loading raw color options:', error));
+    }
+
+    function renderRawColorOptions(mode) {
+        const select = document.getElementById(`raw${capitalizeMode(mode)}ColorSelect`);
+        if (!select) return;
+
+        const selectedColors = getSelectedRawColors(mode);
+        const selectedLabels = new Set(selectedColors.map(color => color.label));
+        const options = rawColorOptions
+            .map(color => {
+                const disabled = selectedLabels.has(color.label) ? ' disabled' : '';
+                return `<option value="${escapeHtml(color.label)}"${disabled}>${escapeHtml(color.label)}</option>`;
+            })
+            .join('');
+
+        select.innerHTML = `<option value="" selected>색상 선택...</option>${options}`;
+    }
+
+    function addSelectedRawColor(mode) {
+        const select = document.getElementById(`raw${capitalizeMode(mode)}ColorSelect`);
+        if (!select || !select.value) return;
+
+        const color = rawColorOptions.find(option => option.label === select.value) || {
+            label: select.value,
+            value: null
+        };
+        const selectedColors = getSelectedRawColors(mode);
+        if (!selectedColors.some(selected => selected.label === color.label)) {
+            selectedColors.push(color);
+        }
+
+        select.value = '';
+        renderRawColorOptions(mode);
+        renderSelectedRawColors(mode);
+    }
+
+    function removeSelectedRawColor(mode, colorLabel) {
+        if (mode === 'create') {
+            rawCreateSelectedColors = rawCreateSelectedColors.filter(color => color.label !== colorLabel);
+        } else {
+            rawUpdateSelectedColors = rawUpdateSelectedColors.filter(color => color.label !== colorLabel);
+            document.getElementById('rawUpdateColorsEnabled').checked = true;
+        }
+        renderRawColorOptions(mode);
+        renderSelectedRawColors(mode);
+    }
+
+    function renderSelectedRawColors(mode) {
+        const container = document.getElementById(`raw${capitalizeMode(mode)}SelectedColorList`);
+        if (!container) return;
+
+        const selectedColors = getSelectedRawColors(mode);
+        if (selectedColors.length === 0) {
+            container.innerHTML = '<span class="raw-chip raw-chip--muted">선택된 색상이 없습니다.</span>';
+            return;
+        }
+
+        container.innerHTML = selectedColors.map(color => `
+            <span class="raw-color-selected-chip">
+                ${buildRawColorDotHtml(color.value)}
+                ${escapeHtml(color.label)}
+                <button type="button" class="btn-close" aria-label="삭제" onclick="removeSelectedRawColor('${mode}', decodeURIComponent('${encodeURIComponent(color.label)}'))"></button>
+            </span>
+        `).join('');
+    }
+
+    function getSelectedRawColors(mode) {
+        return mode === 'create' ? rawCreateSelectedColors : rawUpdateSelectedColors;
+    }
+
+    function setSelectedRawColors(mode, colors) {
+        const normalizedColors = Array.isArray(colors)
+            ? colors
+                .map(color => normalizeRawColorSelection(color))
+                .filter(color => color.label)
+            : [];
+
+        const uniqueColors = [];
+        const labels = new Set();
+        normalizedColors.forEach(color => {
+            if (!labels.has(color.label)) {
+                labels.add(color.label);
+                uniqueColors.push(color);
+            }
+        });
+
+        if (mode === 'create') {
+            rawCreateSelectedColors = uniqueColors;
+        } else {
+            rawUpdateSelectedColors = uniqueColors;
+        }
+        renderRawColorOptions(mode);
+        renderSelectedRawColors(mode);
+    }
+
+    function normalizeRawColorSelection(color) {
+        const label = parseStringValue(color?.clientColorName || color?.rawColorName || color?.label);
+        const option = rawColorOptions.find(rawColorOption => rawColorOption.label === label);
+        return {
+            label,
+            value: option?.value || color?.value || null
+        };
+    }
+
+    function buildRawProductColorRequests(colors) {
+        return (Array.isArray(colors) ? colors : [])
+            .map(color => parseStringValue(color.label))
+            .filter(Boolean)
+            .map(colorName => ({
+                rawColorName: colorName,
+                clientColorName: colorName
+            }));
+    }
+
+    function buildRawColorDotHtml(hex) {
+        if (!hex) return '';
+        const borderColor = String(hex).toLowerCase() === '#ffffff' ? '#cbd5e1' : 'transparent';
+        return `<span class="raw-color-dot" style="background-color: ${escapeHtml(hex)}; border: 1px solid ${borderColor};"></span>`;
+    }
+
+    function capitalizeMode(mode) {
+        return mode === 'create' ? 'Create' : 'Update';
+    }
+
     function loadRawFurnitureTagOptionsByType(furnitureTypeId, preselectedFurnitureTagId = null) {
         const accessToken = localStorage.getItem('accessToken');
         const keywordInput = document.getElementById('rawFurnitureTagKeyword');
@@ -5426,7 +5614,7 @@
         document.getElementById('rawUpdateFreeShippingCondition').value = product.freeShippingCondition ?? '';
         document.getElementById('rawUpdateIsExposed').value = product.isExposed == null ? '' : String(product.isExposed);
         document.getElementById('rawUpdateFetchedAt').value = formatDateTimeLocalValue(product.fetchedAt);
-        document.getElementById('rawUpdateColors').value = formatRawProductColorsForInput(product.colors);
+        setSelectedRawColors('update', product.colors);
         document.getElementById('rawUpdateColorsEnabled').checked = true;
         rawUpdateSelectedFurnitures = Array.isArray(product.furnitures)
             ? product.furnitures.map(furniture => ({
@@ -6004,7 +6192,7 @@
             freeShippingCondition: parseNumberValue(getOptionalInputValue('rawCreateFreeShippingCondition')),
             isExposed: parseBooleanValue(document.getElementById('rawCreateIsExposed').value),
             fetchedAt: parseStringValue(getOptionalInputValue('rawCreateFetchedAt')),
-            colors: parseRawProductColorRequests(document.getElementById('rawCreateColors').value),
+            colors: buildRawProductColorRequests(rawCreateSelectedColors),
             furnitureIds: rawCreateSelectedFurnitures.map(furniture => furniture.furnitureId),
             furnitureTagIds: rawCreateSelectedFurnitureTags.map(tag => tag.furnitureTagId)
         };
@@ -6046,37 +6234,11 @@
         if (freeShippingCondition !== null) payload.freeShippingCondition = freeShippingCondition;
         if (isExposed !== null) payload.isExposed = isExposed;
         if (fetchedAt !== null) payload.fetchedAt = fetchedAt;
-        if (colorsEnabled) payload.colors = parseRawProductColorRequests(document.getElementById('rawUpdateColors').value);
+        if (colorsEnabled) payload.colors = buildRawProductColorRequests(rawUpdateSelectedColors);
         if (furnitureMappingEnabled) payload.furnitureIds = rawUpdateSelectedFurnitures.map(furniture => furniture.furnitureId);
         if (furnitureTagMappingEnabled) payload.furnitureTagIds = rawUpdateSelectedFurnitureTags.map(tag => tag.furnitureTagId);
 
         return payload;
-    }
-
-    function formatRawProductColorsForInput(colors) {
-        if (!Array.isArray(colors) || colors.length === 0) {
-            return '';
-        }
-        return colors
-            .map(color => color.clientColorName || color.rawColorName || '')
-            .filter(Boolean)
-            .join(', ');
-    }
-
-    function parseRawProductColorRequests(value) {
-        const normalized = parseStringValue(value);
-        if (normalized === null) {
-            return [];
-        }
-
-        return normalized
-            .split(/[,\n]/)
-            .map(color => color.trim())
-            .filter(Boolean)
-            .map(colorName => ({
-                rawColorName: colorName,
-                clientColorName: colorName
-            }));
     }
 
     // --- Loading helpers (skeleton UI) and loader-aware API call ---

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -25,6 +25,7 @@ import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawP
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagCreateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductFurnitureTagUpdateRequest;
 import or.sopt.houme.domain.furniture.presentation.dto.request.AdminCurationRawProductUpdateRequest;
+import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductColorOptionResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductFurnitureTagResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductListResponse;
 import or.sopt.houme.domain.furniture.presentation.dto.response.AdminCurationRawProductResponse;
@@ -119,6 +120,16 @@ class AdminCurationRawProductServiceImplTest {
         );
 
         assertEquals(ErrorCode.NOT_VALID_EXCEPTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("getColorOptions()는 RAW 상품 등록용 표준 색상 옵션을 반환한다")
+    void getColorOptions_success() {
+        List<AdminCurationRawProductColorOptionResponse> response = adminCurationRawProductService.getColorOptions();
+
+        assertFalse(response.isEmpty());
+        assertTrue(response.stream().anyMatch(color -> "화이트".equals(color.label()) && "#FFFFFF".equals(color.value())));
+        assertTrue(response.stream().anyMatch(color -> "블랙".equals(color.label()) && "#000000".equals(color.value())));
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/admin/AdminCurationRawProductServiceImplTest.java
@@ -127,7 +127,11 @@ class AdminCurationRawProductServiceImplTest {
     void getColorOptions_success() {
         List<AdminCurationRawProductColorOptionResponse> response = adminCurationRawProductService.getColorOptions();
 
-        assertFalse(response.isEmpty());
+        assertEquals(15, response.size());
+        assertEquals("화이트", response.get(0).label());
+        assertEquals("#FFFFFF", response.get(0).value());
+        assertEquals("블랙", response.get(2).label());
+        assertEquals("#000000", response.get(2).value());
         assertTrue(response.stream().anyMatch(color -> "화이트".equals(color.label()) && "#FFFFFF".equals(color.value())));
         assertTrue(response.stream().anyMatch(color -> "블랙".equals(color.label()) && "#000000".equals(color.value())));
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #536 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 어드민 제품 등록 시, 색상 선택을 드롭다운으로 선택 할 수 있도록 업데이트 했습니다.
- 색상값은 이전에 회의때 논의된 값 기반으로 구현된 하드코딩 값을 기반으로 합니다.

## 📬 Postman

<img width="1170" height="415" alt="image" src="https://github.com/user-attachments/assets/16cecb3e-c2a5-4a7e-8050-d6a797a9537b" />


<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 원자재 상품 등록/수정 화면의 색상 입력을 단일 텍스트에서 표준 색상 드롭다운 + 컬러 칩(색상 도트 포함) 방식으로 전환했습니다.
  * 서버에서 표준 색상 옵션을 불러와 중복 선택 비활성화, 선택 칩 렌더링, 로드 실패 시 에러 표기 등을 지원합니다.
  * 수정 폼에서 색상 수정 반영 체크 자동 활성화 및 안내 문구 개선이 적용되었습니다.

* **Tests**
  * 색상 옵션 조회 동작에 대한 자동화 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->