### PR TITLE
[CHORE] #541 CurationRawProductFurniture 경로 추가로 큐레이션 카테고리·상품 조회 개선

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryCustom.java
@@ -7,4 +7,10 @@ import java.util.List;
 public interface CurationRawProductFurnitureRepositoryCustom {
 
     List<CurationRawProductFurniture> findAllByCurationRawProductIdInWithFurniture(List<Long> rawProductIds);
+
+    // [pbem22, 2026-05-28, #541] CurationRawProductFurniture 경로 폴백을 위해 추가
+    List<Long> findFurnitureIdsHavingProducts(List<Long> furnitureIds);
+
+    // [pbem22, 2026-05-28, #541] furnitureId 기준으로 노출 가능한 원본 상품 매핑 조회
+    List<CurationRawProductFurniture> findExposedByFurnitureId(Long furnitureId);
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductFurnitureRepositoryImpl.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.furniture.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QCurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QFurnitureType;
@@ -27,6 +28,46 @@ public class CurationRawProductFurnitureRepositoryImpl implements CurationRawPro
                 .join(mapping.furniture, furniture).fetchJoin()
                 .join(furniture.furnitureType, furnitureType).fetchJoin()
                 .where(mapping.curationRawProduct.id.in(rawProductIds))
+                .fetch();
+    }
+
+    // [pbem22, 2026-05-28, #541] 선택된 가구 중 노출 가능한 상품이 매핑된 가구 ID 목록 반환
+    @Override
+    public List<Long> findFurnitureIdsHavingProducts(List<Long> furnitureIds) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
+            return List.of();
+        }
+
+        QCurationRawProductFurniture mapping = QCurationRawProductFurniture.curationRawProductFurniture;
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+
+        return queryFactory
+                .select(mapping.furniture.id)
+                .distinct()
+                .from(mapping)
+                .join(mapping.curationRawProduct, rawProduct)
+                .where(
+                        mapping.furniture.id.in(furnitureIds),
+                        rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull())
+                )
+                .fetch();
+    }
+
+    // [pbem22, 2026-05-28, #541] furnitureId 기준 노출 가능한 원본 상품 매핑 목록 반환
+    @Override
+    public List<CurationRawProductFurniture> findExposedByFurnitureId(Long furnitureId) {
+        QCurationRawProductFurniture mapping = QCurationRawProductFurniture.curationRawProductFurniture;
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QFurniture furniture = QFurniture.furniture;
+
+        return queryFactory
+                .selectFrom(mapping)
+                .join(mapping.curationRawProduct, rawProduct).fetchJoin()
+                .join(mapping.furniture, furniture).fetchJoin()
+                .where(
+                        mapping.furniture.id.eq(furnitureId),
+                        rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull())
+                )
                 .fetch();
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureService.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.domain.furniture.service;
+
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
+import or.sopt.houme.domain.user.model.entity.User;
+
+import java.util.List;
+
+/**
+ * [pbem22, 2026-05-28, #541]
+ * CurationRawProductFurniture(직접 매핑) 경로를 통한 가구 상품 조회 서비스.
+ * FurnitureTag 경로가 존재하지 않는 가구에 대한 카테고리·상품 폴백을 담당합니다.
+ */
+public interface CurationRawProductFurnitureService {
+
+    List<Long> getFurnitureIdsHavingProducts(List<Long> furnitureIds);
+
+    FurnitureProductsInfoResponseV2 buildProductsResponseByFurnitureId(User user, Long furnitureId);
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImpl.java
@@ -81,7 +81,7 @@ public class CurationRawProductFurnitureServiceImpl implements CurationRawProduc
                 .map(raw -> {
                     List<ProductColorResponse> colors =
                             colorsByRawProductId.getOrDefault(raw.getId(), List.of());
-                    boolean isLiked = likedRawProductIds.contains(raw.getId());
+                    boolean isLiked = likedRawProductIds.contains(raw.getProductId());
 
                     FurnitureProductsInfoResponseV2.ProductInfo product = new FurnitureProductsInfoResponseV2.ProductInfo(
                             raw.getId(),
@@ -155,7 +155,7 @@ public class CurationRawProductFurnitureServiceImpl implements CurationRawProduc
         return jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(user.getId(), recommendIds).stream()
                 .map(Jjym::getRecommendFurniture)
                 .filter(Objects::nonNull)
-                .map(RecommendFurniture::getId)
+                .map(RecommendFurniture::getFurnitureProductId)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImpl.java
@@ -1,0 +1,171 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.CurationSource;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.Jjym;
+import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
+import or.sopt.houme.domain.furniture.presentation.dto.response.ProductColorResponse;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * [pbem22, 2026-05-28, #541]
+ * CurationRawProductFurniture(직접 매핑) 경로를 통한 가구 상품 조회 구현체.
+ * FurnitureTag 경로가 없는 가구에 대한 카테고리·상품 폴백을 담당합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CurationRawProductFurnitureServiceImpl implements CurationRawProductFurnitureService {
+
+    private final CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
+    private final CurationRawProductColorRepository curationRawProductColorRepository;
+    private final RecommendFurnitureRepository recommendFurnitureRepository;
+    private final JjymRepository jjymRepository;
+    private final FurnitureRepository furnitureRepository;
+
+    @Override
+    public List<Long> getFurnitureIdsHavingProducts(List<Long> furnitureIds) {
+        return curationRawProductFurnitureRepository.findFurnitureIdsHavingProducts(furnitureIds);
+    }
+
+    @Override
+    public FurnitureProductsInfoResponseV2 buildProductsResponseByFurnitureId(User user, Long furnitureId) {
+        Furniture furniture = furnitureRepository.findById(furnitureId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE));
+
+        List<CurationRawProductFurniture> mappings =
+                curationRawProductFurnitureRepository.findExposedByFurnitureId(furnitureId);
+
+        if (mappings.isEmpty()) {
+            return FurnitureProductsInfoResponseV2.of(
+                    user != null ? user.getName() : null,
+                    List.of()
+            );
+        }
+
+        List<CurationRawProduct> rawProducts = mappings.stream()
+                .map(CurationRawProductFurniture::getCurationRawProduct)
+                .toList();
+
+        List<Long> rawProductIds = rawProducts.stream()
+                .map(CurationRawProduct::getId)
+                .toList();
+
+        Map<Long, List<ProductColorResponse>> colorsByRawProductId = buildColorMap(rawProductIds);
+        Set<Long> likedRawProductIds = findLikedRawProductIds(user, rawProducts);
+
+        String categoryName = furniture.getFurnitureNameKr();
+        String userName = user != null ? user.getName() : null;
+
+        List<FurnitureProductsInfoResponseV2.ProductWrapper> products = rawProducts.stream()
+                .map(raw -> {
+                    List<ProductColorResponse> colors =
+                            colorsByRawProductId.getOrDefault(raw.getId(), List.of());
+                    boolean isLiked = likedRawProductIds.contains(raw.getId());
+
+                    FurnitureProductsInfoResponseV2.ProductInfo product = new FurnitureProductsInfoResponseV2.ProductInfo(
+                            raw.getId(),
+                            raw.getProductId(),
+                            categoryName,
+                            raw.getSource(),
+                            raw.getBrand(),
+                            raw.getProductName(),
+                            raw.getProductImageUrl(),
+                            raw.getListPrice(),
+                            raw.getDiscountRate(),
+                            raw.getDiscountPrice(),
+                            raw.getProductMallName(),
+                            raw.getProductSiteUrl(),
+                            colors,
+                            isLiked
+                    );
+                    return FurnitureProductsInfoResponseV2.ProductWrapper.of(product);
+                })
+                .toList();
+
+        return FurnitureProductsInfoResponseV2.of(userName, products);
+    }
+
+    private Map<Long, List<ProductColorResponse>> buildColorMap(List<Long> rawProductIds) {
+        List<CurationRawProductColor> colorEntities =
+                curationRawProductColorRepository.findAllByCurationRawProductIdIn(rawProductIds);
+
+        return colorEntities.stream()
+                .filter(c -> c.getCurationRawProduct() != null && c.getCurationRawProduct().getId() != null)
+                .collect(Collectors.groupingBy(
+                        c -> c.getCurationRawProduct().getId(),
+                        Collectors.collectingAndThen(
+                                Collectors.toList(),
+                                list -> list.stream()
+                                        .map(this::resolveColorName)
+                                        .filter(Objects::nonNull)
+                                        .distinct()
+                                        .map(ProductColorResponse::fromName)
+                                        .toList()
+                        )
+                ));
+    }
+
+    private Set<Long> findLikedRawProductIds(User user, List<CurationRawProduct> rawProducts) {
+        if (user == null) {
+            return Set.of();
+        }
+
+        List<Long> productIds = rawProducts.stream()
+                .map(CurationRawProduct::getProductId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (productIds.isEmpty()) {
+            return Set.of();
+        }
+
+        List<RecommendFurniture> recommendFurnitures =
+                recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, productIds);
+
+        if (recommendFurnitures.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Long> recommendIds = recommendFurnitures.stream()
+                .map(RecommendFurniture::getId)
+                .toList();
+
+        return jjymRepository.findAllByUserIdAndRecommendFurnitureIdIn(user.getId(), recommendIds).stream()
+                .map(Jjym::getRecommendFurniture)
+                .filter(Objects::nonNull)
+                .map(RecommendFurniture::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private String resolveColorName(CurationRawProductColor colorEntity) {
+        if (colorEntity.getClientColorName() != null && !colorEntity.getClientColorName().isBlank()) {
+            return colorEntity.getClientColorName();
+        }
+        if (colorEntity.getRawColorName() != null && !colorEntity.getRawColorName().isBlank()) {
+            return colorEntity.getRawColorName();
+        }
+        return null;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -52,6 +52,9 @@ public class FurnitureServiceImpl implements FurnitureService {
     private final NaverShopApiClient naverShopApiClient;
     private final FastApiImageHashClient imageHashClient;
 
+    // [pbem22, 2026-05-28, #541] CurationRawProductFurniture 경로 폴백을 위해 추가
+    private final CurationRawProductFurnitureService curationRawProductFurnitureService;
+
     // 가구 반환
     @Cacheable(value = "furnitureAndActivityCache")
     @Override
@@ -164,7 +167,21 @@ public class FurnitureServiceImpl implements FurnitureService {
 
         // 3. 선택 가구들과 스타일 태그에 해당하는 매핑 객체를 furniture_tags에서 조회
         List<FurnitureTag> matchedTags = furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), selectedFurnitures);
-        return buildCategoryResponse(matchedTags);
+
+        // [pbem22, 2026-05-28, #541] FurnitureTag 경로에 없는 가구도 CurationRawProductFurniture로 매핑된 경우 카테고리에 포함
+        List<Long> selectedFurnitureIds = selectedFurnitures.stream().map(Furniture::getId).toList();
+        Set<Long> taggedFurnitureIds = matchedTags.stream()
+                .map(ft -> ft.getFurniture().getId())
+                .collect(Collectors.toSet());
+        List<Long> extraFurnitureIds = curationRawProductFurnitureService
+                .getFurnitureIdsHavingProducts(selectedFurnitureIds).stream()
+                .filter(id -> !taggedFurnitureIds.contains(id))
+                .toList();
+        List<Furniture> extraFurnitures = extraFurnitureIds.isEmpty()
+                ? List.of()
+                : furnitureRepository.findAllById(extraFurnitureIds);
+
+        return buildCategoryResponseWithExtra(matchedTags, extraFurnitures);
     }
 
     @Override
@@ -254,5 +271,32 @@ public class FurnitureServiceImpl implements FurnitureService {
                 .toList();
 
         return FurnitureCategoriesResponse.of(categoryResponses);
+    }
+
+    // [pbem22, 2026-05-28, #541] FurnitureTag 경로 카테고리 + CurationRawProductFurniture 경로 카테고리 합산 반환
+    private FurnitureCategoriesResponse buildCategoryResponseWithExtra(
+            List<FurnitureTag> matchedTags,
+            List<Furniture> extraFurnitures
+    ) {
+        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> fromTags = matchedTags.stream()
+                .sorted(Comparator.comparingInt(FurnitureTag::getPriority))
+                .map(ft -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
+                        ft.getFurniture().getId(),
+                        ft.getFurniture().getFurnitureNameKr()
+                ))
+                .toList();
+
+        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> fromExtra = extraFurnitures.stream()
+                .map(f -> FurnitureCategoriesResponse.FurnitureCategoryResponse.of(
+                        f.getId(),
+                        f.getFurnitureNameKr()
+                ))
+                .toList();
+
+        List<FurnitureCategoriesResponse.FurnitureCategoryResponse> combined = new ArrayList<>();
+        combined.addAll(fromTags);
+        combined.addAll(fromExtra);
+
+        return FurnitureCategoriesResponse.of(combined);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/facade/FurnitureFacadeImpl.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
 import or.sopt.houme.domain.furniture.service.CurationFurnitureService;
+import or.sopt.houme.domain.furniture.service.CurationRawProductFurnitureService;
 import or.sopt.houme.domain.furniture.service.CurationRawProductService;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
 import or.sopt.houme.domain.furniture.service.ImageHashService;
@@ -39,6 +40,9 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
     private final CurationRawProductService curationRawProductService;
     private final NaverProperties naverProperties;
 
+    // [pbem22, 2026-05-28, #541] CurationRawProductFurniture 경로 폴백을 위해 추가
+    private final CurationRawProductFurnitureService curationRawProductFurnitureService;
+
     @Override
     public FurnitureProductsInfoResponseV2 getFurnitureProductInfoFromNaverApi(User user, Long imageId, Long categoryId) {
 
@@ -48,7 +52,17 @@ public class FurnitureFacadeImpl implements FurnitureFacade {
 
         // 1. FurnitureTag 조회 (DB)
         log.info("연관된 가구들을 조회합니다:{}",formatted);
-        FurnitureTag furnitureTag = furnitureService.findFurnitureTag(user, imageId, categoryId);
+        // [pbem22, 2026-05-28, #541] FurnitureTag 없을 경우 CurationRawProductFurniture 경로로 폴백
+        FurnitureTag furnitureTag;
+        try {
+            furnitureTag = furnitureService.findFurnitureTag(user, imageId, categoryId);
+        } catch (GeneralException e) {
+            if (ErrorCode.NOT_FOUND_FURNITURE_TAG.equals(e.getErrorCode())) {
+                log.info("FurnitureTag 없음, CurationRawProductFurniture 경로로 폴백: categoryId={}", categoryId);
+                return curationRawProductFurnitureService.buildProductsResponseByFurnitureId(user, categoryId);
+            }
+            throw e;
+        }
 
         // 네이버 큐레이션은 현재 비활성화합니다.
         // 기존 로직은 추후 복구를 위해 주석으로 유지합니다.

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationRawProductFurnitureServiceImplTest.java
@@ -1,0 +1,160 @@
+package or.sopt.houme.domain.furniture.service;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.presentation.dto.response.FurnitureProductsInfoResponseV2;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.global.api.GeneralException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CurationRawProductFurniture 서비스 단위 테스트")
+class CurationRawProductFurnitureServiceImplTest {
+
+    @InjectMocks
+    private CurationRawProductFurnitureServiceImpl service;
+
+    @Mock
+    private CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
+
+    @Mock
+    private CurationRawProductColorRepository curationRawProductColorRepository;
+
+    @Mock
+    private RecommendFurnitureRepository recommendFurnitureRepository;
+
+    @Mock
+    private JjymRepository jjymRepository;
+
+    @Mock
+    private FurnitureRepository furnitureRepository;
+
+    @Test
+    @DisplayName("getFurnitureIdsHavingProducts()는 레포지토리 결과를 그대로 반환한다")
+    void getFurnitureIdsHavingProducts() {
+        given(curationRawProductFurnitureRepository.findFurnitureIdsHavingProducts(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(1L, 3L));
+
+        List<Long> result = service.getFurnitureIdsHavingProducts(List.of(1L, 2L, 3L));
+
+        assertThat(result).containsExactly(1L, 3L);
+    }
+
+    @Test
+    @DisplayName("buildProductsResponseByFurnitureId()는 매핑 상품이 없으면 빈 products를 반환한다")
+    void buildProductsResponseByFurnitureId_emptyWhenNoMappings() {
+        Long furnitureId = 1L;
+        User user = User.builder().id(1L).name("테스트").build();
+        Furniture furniture = Furniture.builder().id(furnitureId).furnitureNameKr("소파").build();
+
+        given(furnitureRepository.findById(furnitureId)).willReturn(Optional.of(furniture));
+        given(curationRawProductFurnitureRepository.findExposedByFurnitureId(furnitureId))
+                .willReturn(List.of());
+
+        FurnitureProductsInfoResponseV2 response = service.buildProductsResponseByFurnitureId(user, furnitureId);
+
+        assertThat(response.products()).isEmpty();
+        assertThat(response.userName()).isEqualTo("테스트");
+    }
+
+    @Test
+    @DisplayName("buildProductsResponseByFurnitureId()는 매핑 상품의 카테고리명을 가구명으로 채운다")
+    void buildProductsResponseByFurnitureId_setsCategoryNameFromFurniture() {
+        Long furnitureId = 1L;
+        User user = User.builder().id(1L).name("홍길동").build();
+        Furniture furniture = Furniture.builder().id(furnitureId).furnitureNameKr("소파").build();
+
+        CurationRawProduct rawProduct = CurationRawProduct.builder()
+                .id(100L)
+                .productId(9999L)
+                .productName("모던 소파")
+                .productImageUrl("https://img.example.com/sofa.jpg")
+                .productSiteUrl("https://store.example.com/sofa")
+                .source("raw")
+                .discountPrice(150000L)
+                .isExposed(true)
+                .build();
+
+        CurationRawProductFurniture mapping = CurationRawProductFurniture.builder()
+                .curationRawProduct(rawProduct)
+                .furniture(furniture)
+                .build();
+
+        given(furnitureRepository.findById(furnitureId)).willReturn(Optional.of(furniture));
+        given(curationRawProductFurnitureRepository.findExposedByFurnitureId(furnitureId))
+                .willReturn(List.of(mapping));
+        given(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(100L)))
+                .willReturn(List.of());
+        given(recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(any(), any()))
+                .willReturn(List.of());
+
+        FurnitureProductsInfoResponseV2 response = service.buildProductsResponseByFurnitureId(user, furnitureId);
+
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().get(0).product().categoryName()).isEqualTo("소파");
+        assertThat(response.products().get(0).product().name()).isEqualTo("모던 소파");
+    }
+
+    @Test
+    @DisplayName("buildProductsResponseByFurnitureId()는 가구가 없으면 예외를 던진다")
+    void buildProductsResponseByFurnitureId_throwsWhenFurnitureNotFound() {
+        User user = User.builder().id(1L).build();
+        given(furnitureRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buildProductsResponseByFurnitureId(user, 99L))
+                .isInstanceOf(GeneralException.class);
+    }
+
+    @Test
+    @DisplayName("buildProductsResponseByFurnitureId()는 user가 null이면 isLiked false로 반환한다")
+    void buildProductsResponseByFurnitureId_noLikedWhenUserNull() {
+        Long furnitureId = 1L;
+        Furniture furniture = Furniture.builder().id(furnitureId).furnitureNameKr("침대").build();
+
+        CurationRawProduct rawProduct = CurationRawProduct.builder()
+                .id(200L)
+                .productId(8888L)
+                .productName("킹침대")
+                .productImageUrl("https://img.example.com/bed.jpg")
+                .productSiteUrl("https://store.example.com/bed")
+                .source("raw")
+                .discountPrice(300000L)
+                .isExposed(true)
+                .build();
+
+        CurationRawProductFurniture mapping = CurationRawProductFurniture.builder()
+                .curationRawProduct(rawProduct)
+                .furniture(furniture)
+                .build();
+
+        given(furnitureRepository.findById(furnitureId)).willReturn(Optional.of(furniture));
+        given(curationRawProductFurnitureRepository.findExposedByFurnitureId(furnitureId))
+                .willReturn(List.of(mapping));
+        given(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(200L)))
+                .willReturn(List.of());
+
+        FurnitureProductsInfoResponseV2 response = service.buildProductsResponseByFurnitureId(null, furnitureId);
+
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().get(0).product().isLiked()).isFalse();
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImplTest.java
@@ -68,6 +68,8 @@ class FurnitureServiceImplTest {
     FurnitureTypeRepository furnitureTypeRepository;
     @Mock
     ActivityFurnitureRepository activityFurnitureRepository;
+    @Mock
+    CurationRawProductFurnitureService curationRawProductFurnitureService;
 
     @Test
     @DisplayName("주요활동, 가구들에 대한 정보들을 받을 수 있다.")
@@ -395,12 +397,70 @@ class FurnitureServiceImplTest {
         when(furnitureRepository.findAllByHouseId(house.getId())).thenReturn(List.of(bed, chair, tv, dining));
         when(furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), List.of(bed, chair, tv, dining)))
                 .thenReturn(List.of(ftBed, ftChair, ftTv, ftDining));
+        when(curationRawProductFurnitureService.getFurnitureIdsHavingProducts(List.of(1L, 2L, 3L, 4L)))
+                .thenReturn(List.of());
 
         FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyleV2(user, imageId);
 
         assertThat(response.categories())
                 .extracting(FurnitureCategoriesResponse.FurnitureCategoryResponse::categoryName)
                 .containsExactly("식탁", "TV", "의자", "침대");
+    }
+
+    @Test
+    @DisplayName("V2 카테고리 조회 - FurnitureTag 없는 가구도 CurationRawProductFurniture 매핑 있으면 카테고리에 포함된다")
+    void getFurnitureCategoriesByStyleV2_includesExtraFromCurationRawProductFurniture() {
+        Long imageId = 10L;
+
+        Tag tag = Tag.builder().id(100L).build();
+        House house = House.builder().id(200L).build();
+
+        Furniture sofa = Furniture.builder().id(1L).furnitureNameKr("소파").build();
+        Furniture desk = Furniture.builder().id(2L).furnitureNameKr("책상").build();
+
+        FurnitureTag ftSofa = FurnitureTag.builder().id(11L).tag(tag).furniture(sofa).priority(1).build();
+
+        when(tagRepository.findTagByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(tag));
+        when(houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(house));
+        when(furnitureRepository.findAllByHouseId(house.getId())).thenReturn(List.of(sofa, desk));
+        when(furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), List.of(sofa, desk)))
+                .thenReturn(List.of(ftSofa));
+        when(curationRawProductFurnitureService.getFurnitureIdsHavingProducts(List.of(1L, 2L)))
+                .thenReturn(List.of(2L));
+        when(furnitureRepository.findAllById(List.of(2L))).thenReturn(List.of(desk));
+
+        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyleV2(user, imageId);
+
+        assertThat(response.categories()).hasSize(2);
+        assertThat(response.categories())
+                .extracting(FurnitureCategoriesResponse.FurnitureCategoryResponse::categoryName)
+                .containsExactly("소파", "책상");
+    }
+
+    @Test
+    @DisplayName("V2 카테고리 조회 - FurnitureTag와 CurationRawProductFurniture에 모두 있는 가구는 중복 없이 한 번만 반환된다")
+    void getFurnitureCategoriesByStyleV2_noDuplicateWhenBothPathsExist() {
+        Long imageId = 10L;
+
+        Tag tag = Tag.builder().id(100L).build();
+        House house = House.builder().id(200L).build();
+
+        Furniture bed = Furniture.builder().id(1L).furnitureNameKr("침대").build();
+
+        FurnitureTag ftBed = FurnitureTag.builder().id(11L).tag(tag).furniture(bed).priority(1).build();
+
+        when(tagRepository.findTagByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(tag));
+        when(houseRepository.findHouseByUserIdAndImageId(user.getId(), imageId)).thenReturn(Optional.of(house));
+        when(furnitureRepository.findAllByHouseId(house.getId())).thenReturn(List.of(bed));
+        when(furnitureTagRepository.findAllByTagIdAndFurnitureIn(tag.getId(), List.of(bed)))
+                .thenReturn(List.of(ftBed));
+        when(curationRawProductFurnitureService.getFurnitureIdsHavingProducts(List.of(1L)))
+                .thenReturn(List.of(1L));
+
+        FurnitureCategoriesResponse response = furnitureService.getFurnitureCategoriesByStyleV2(user, imageId);
+
+        assertThat(response.categories()).hasSize(1);
+        assertThat(response.categories().get(0).categoryName()).isEqualTo("침대");
     }
 
     private Furniture createFurniture(Long id, String eng, String kr, FurnitureType type) {


### PR DESCRIPTION
## 📣 Related Issue

- close #541

## 📝 Summary

FurnitureTag가 없는 가구도 큐레이션 카테고리·상품 조회가 가능하도록 `CurationRawProductFurniture` 직접 매핑 경로를 폴백으로 추가합니다.

**기존 문제**
- `GET /api/v2/generated-images/{imageId}/curations/categories`: `FurnitureTag`로만 카테고리를 조회하여, `CurationRawProductFurniture`로만 매핑된 가구는 카테고리에 노출되지 않음
- `GET /api/v1/generated-images/{imageId}/curations/products/{categoryId}`: `FurnitureTag`가 없으면 `NOT_FOUND_FURNITURE_TAG` 예외 발생

**변경 내용**
- `CurationRawProductFurnitureRepositoryCustom`: `findFurnitureIdsHavingProducts`, `findExposedByFurnitureId` 메서드 추가
- `CurationRawProductFurnitureService` / `CurationRawProductFurnitureServiceImpl` 신규 생성 (pbem22)
  - 선택된 가구 중 `CurationRawProductFurniture` 매핑 상품이 있는 가구 ID 반환
  - furnitureId 기준으로 상품 응답(`FurnitureProductsInfoResponseV2`) 빌드
- `FurnitureServiceImpl.getFurnitureCategoriesByStyleV2()`: FurnitureTag 카테고리 + CurationRawProductFurniture 카테고리 합산 반환
- `FurnitureFacadeImpl.getFurnitureProductInfoFromNaverApi()`: FurnitureTag 없을 때 try-catch로 CurationRawProductFurniture 경로 폴백 처리

## 🙏 Question & PR point

- 기존 코드(bontak) 로직 변경 없이 추가만 하였으며, 변경 지점에 `[pbem22, 2026-05-28, #541]` 주석 표기
- 기존 FurnitureTag 경로가 정상이면 기존 동작 그대로 유지됨

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 가구 상품을 조회하는 새로운 경로가 추가되었습니다. 기존 태그 기반 조회 외에도 상품 매핑을 통해 추가 가구들을 발견할 수 있습니다.

* **Tests**
  * 새로운 기능에 대한 단위 테스트와 통합 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->