### PR TITLE
[CHORE] #548 DB 등록된 가구 타입 기준으로 상품 필터 매핑 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
@@ -16,7 +16,8 @@ public interface CurationRawProductRepositoryCustom {
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     );
 
     Slice<CurationRawProduct> findAllByCurationFiltersV2(
@@ -25,7 +26,8 @@ public interface CurationRawProductRepositoryCustom {
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     );
 
     Slice<CurationRawProduct> findAllByCurationFiltersRecommend(
@@ -33,8 +35,11 @@ public interface CurationRawProductRepositoryCustom {
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     );
+
+    List<Long> findEtcProductIds(Long selectiveTypeId, List<Long> excludedFurnitureIds, Long etcDirectFurnitureId);
 
     Page<CurationRawProduct> findExposedRawProductsExcludingLikedByUser(Long userId, Pageable pageable);
     Long findMaxExposedRawProductIdExcludingLikedByUser(Long userId);

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -12,6 +12,7 @@ import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductColor;
+import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.QFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QFurnitureTag;
@@ -75,7 +76,8 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     ) {
         QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
         QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
@@ -96,15 +98,22 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
                     .or(rawProduct.brand.containsIgnoreCase(keyword)));
         }
 
-        if (typeIds != null && !typeIds.isEmpty()) {
-            finalWhere.and(rawProduct.id.in(
-                    queryFactory.select(mapping.curationRawProduct.id)
-                            .from(mapping)
-                            .join(mapping.furnitureTag, fTag)
-                            .join(fTag.furniture, furniture)
-                            .leftJoin(furniture.furnitureType, fType)
-                            .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
-            ));
+        if ((typeIds != null && !typeIds.isEmpty()) || (additionalProductIds != null && !additionalProductIds.isEmpty())) {
+            BooleanBuilder typeOrEtc = new BooleanBuilder();
+            if (typeIds != null && !typeIds.isEmpty()) {
+                typeOrEtc.or(rawProduct.id.in(
+                        queryFactory.select(mapping.curationRawProduct.id)
+                                .from(mapping)
+                                .join(mapping.furnitureTag, fTag)
+                                .join(fTag.furniture, furniture)
+                                .leftJoin(furniture.furnitureType, fType)
+                                .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
+                ));
+            }
+            if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
+                typeOrEtc.or(rawProduct.id.in(additionalProductIds));
+            }
+            finalWhere.and(typeOrEtc);
         }
 
         if (priceRanges != null && !priceRanges.isEmpty()) {
@@ -153,7 +162,8 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     ) {
         QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
         QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
@@ -174,15 +184,22 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             finalWhere.and(rawProduct.searchTokens.contains(keyword.toLowerCase()));
         }
 
-        if (typeIds != null && !typeIds.isEmpty()) {
-            finalWhere.and(rawProduct.id.in(
-                    queryFactory.select(mapping.curationRawProduct.id)
-                            .from(mapping)
-                            .join(mapping.furnitureTag, fTag)
-                            .join(fTag.furniture, furniture)
-                            .leftJoin(furniture.furnitureType, fType)
-                            .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
-            ));
+        if ((typeIds != null && !typeIds.isEmpty()) || (additionalProductIds != null && !additionalProductIds.isEmpty())) {
+            BooleanBuilder typeOrEtc = new BooleanBuilder();
+            if (typeIds != null && !typeIds.isEmpty()) {
+                typeOrEtc.or(rawProduct.id.in(
+                        queryFactory.select(mapping.curationRawProduct.id)
+                                .from(mapping)
+                                .join(mapping.furnitureTag, fTag)
+                                .join(fTag.furniture, furniture)
+                                .leftJoin(furniture.furnitureType, fType)
+                                .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
+                ));
+            }
+            if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
+                typeOrEtc.or(rawProduct.id.in(additionalProductIds));
+            }
+            finalWhere.and(typeOrEtc);
         }
 
         if (priceRanges != null && !priceRanges.isEmpty()) {
@@ -419,7 +436,8 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             List<PriceRangeFilter> priceRanges,
             List<String> colorNames,
             Long cursor,
-            Pageable pageable
+            Pageable pageable,
+            List<Long> additionalProductIds
     ) {
         QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
         QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
@@ -450,6 +468,13 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
                     new CaseBuilder().when(rawProduct.id.in(typeSubquery)).then(1).otherwise(0)
             );
             atLeastOne.or(rawProduct.id.in(typeSubquery));
+        }
+
+        if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
+            matchScore = matchScore.add(
+                    new CaseBuilder().when(rawProduct.id.in(additionalProductIds)).then(1).otherwise(0)
+            );
+            atLeastOne.or(rawProduct.id.in(additionalProductIds));
         }
 
         if (priceRanges != null && !priceRanges.isEmpty()) {
@@ -498,6 +523,47 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
         }
 
         return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public List<Long> findEtcProductIds(Long selectiveTypeId, List<Long> excludedFurnitureIds, Long etcDirectFurnitureId) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
+        QFurnitureTag fTag = QFurnitureTag.furnitureTag;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType fType = QFurnitureType.furnitureType;
+        QCurationRawProductFurniture directMapping = QCurationRawProductFurniture.curationRawProductFurniture;
+
+        java.util.Set<Long> result = new java.util.HashSet<>();
+
+        // FurnitureTag 경로: SELECTIVE 타입 하위 중 개별 필터 가구 제외
+        if (selectiveTypeId != null) {
+            com.querydsl.core.types.dsl.BooleanExpression typeCondition = fType.id.eq(selectiveTypeId);
+            if (excludedFurnitureIds != null && !excludedFurnitureIds.isEmpty()) {
+                typeCondition = typeCondition.and(furniture.id.notIn(excludedFurnitureIds));
+            }
+            List<Long> fromTag = queryFactory
+                    .select(mapping.curationRawProduct.id)
+                    .from(mapping)
+                    .join(mapping.furnitureTag, fTag)
+                    .join(fTag.furniture, furniture)
+                    .join(furniture.furnitureType, fType)
+                    .where(typeCondition)
+                    .fetch();
+            result.addAll(fromTag);
+        }
+
+        // 직접 매핑 경로: ETC Furniture에 바로 매핑된 상품
+        if (etcDirectFurnitureId != null) {
+            List<Long> fromDirect = queryFactory
+                    .select(directMapping.curationRawProduct.id)
+                    .from(directMapping)
+                    .where(directMapping.furniture.id.eq(etcDirectFurnitureId))
+                    .fetch();
+            result.addAll(fromDirect);
+        }
+
+        return new java.util.ArrayList<>(result);
     }
 
     private BooleanExpression containsIgnoreCase(com.querydsl.core.types.dsl.StringPath path, String keyword) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -384,7 +384,9 @@ public class CurationProductServiceImpl implements CurationProductService {
             case "CLOSET": return "옷장";
             case "SINGLE_SOFA":
             case "CHAIR": return "의자/스툴";
-            case "DRESSER": return "화장대/협탁";
+            case "DRESSER":
+            case "DRESSING_TABLE": return "화장대/협탁"; // [pbem22, 2026-05-28, #548] DB nameEng 실제값 DRESSING_TABLE 추가
+            case "LIGHTING": return "조명"; // [pbem22, 2026-05-28, #548] DB Furniture LIGHTING(id=24) 대응
             default: break;
         }
 
@@ -403,6 +405,7 @@ public class CurationProductServiceImpl implements CurationProductService {
         List<FurnitureType> types = furnitureTypeRepository.findAll();
         List<Furniture> furnitures = furnitureRepository.findAll();
 
+        // [pbem22, 2026-05-28, #548] DB 실제 등록값 기준으로 고정 음수 ID → findFurniture() 전환
         return List.of(
                 new FurnitureTypeFilterResponse(0L, "전체", "ALL"),
                 findType(types, "BED", "침대/프레임", -10L),
@@ -412,9 +415,9 @@ public class CurationProductServiceImpl implements CurationProductService {
                 findFurniture(furnitures, "CLOSET", "옷장", -14L),
                 findType(types, "STORAGE", "수납/장식장", -15L),
                 findType(types, "SOFA", "소파", -16L),
-                new FurnitureTypeFilterResponse(-1L, "의자/스툴", "CHAIR"),
-                new FurnitureTypeFilterResponse(-2L, "화장대/협탁", "DRESSER"),
-                new FurnitureTypeFilterResponse(-3L, "조명", "LIGHTING"),
+                findFurniture(furnitures, "CHAIR", "의자/스툴", -1L),
+                findFurniture(furnitures, "DRESSING_TABLE", "화장대/협탁", -2L),
+                findFurniture(furnitures, "LIGHTING", "조명", -3L),
                 findType(types, "ETC", "기타", -17L)
         );
     }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -48,7 +48,7 @@ public class CurationProductServiceImpl implements CurationProductService {
     private static final String SELECTIVE_TYPE_NAMEENG = "SELECTIVE";
     private static final List<String> INDIVIDUAL_FILTER_FURNITURE_NAMEENGS = List.of(
             "OFFICE_DESK", "DINING_TABLE", "SITTING_TABLE", "CLOSET",
-            "DISPLAY_CABINET", "CHAIR", "DRESSING_TABLE", "LIGHTING"
+            "DISPLAY_CABINET", "CHAIR", "DRESSER", "DRESSING_TABLE", "LIGHTING"
     );
 
     private final FurnitureTypeRepository furnitureTypeRepository;

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -415,7 +415,6 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         return switch (typeEng) {
             case "BED" -> "침대/프레임";
-            case "STORAGE" -> "수납/장식장";
             case "SOFA" -> "소파";
             case "LIGHTING" -> "조명";
             case "SELECTIVE" -> "그 외";

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -91,10 +91,12 @@ public class CurationProductServiceImpl implements CurationProductService {
         }
 
         // ETC 필터 처리: SELECTIVE 타입 중 개별 필터 없는 상품 + 직접 매핑 상품
-        List<Long> etcProductIds = resolveEtcProductIds(typeIds, filteredTypeIds);
+        EtcResolution etc = resolveEtc(typeIds);
+        List<Long> etcProductIds = etc.productIds();
         if (etcProductIds != null) {
+            Long etcTypeId = etc.typeId();
             filteredTypeIds = filteredTypeIds == null ? null :
-                    filteredTypeIds.stream().filter(id -> !id.equals(getEtcTypeId())).toList();
+                    filteredTypeIds.stream().filter(id -> !id.equals(etcTypeId)).toList();
             if (filteredTypeIds != null && filteredTypeIds.isEmpty()) filteredTypeIds = null;
         }
 
@@ -261,10 +263,12 @@ public class CurationProductServiceImpl implements CurationProductService {
         }
 
         // ETC 필터 처리: SELECTIVE 타입 중 개별 필터 없는 상품 + 직접 매핑 상품
-        List<Long> etcProductIds = resolveEtcProductIds(typeIds, filteredTypeIds);
+        EtcResolution etc = resolveEtc(typeIds);
+        List<Long> etcProductIds = etc.productIds();
         if (etcProductIds != null) {
+            Long etcTypeId = etc.typeId();
             filteredTypeIds = filteredTypeIds == null ? null :
-                    filteredTypeIds.stream().filter(id -> !id.equals(getEtcTypeId())).toList();
+                    filteredTypeIds.stream().filter(id -> !id.equals(etcTypeId)).toList();
             if (filteredTypeIds != null && filteredTypeIds.isEmpty()) filteredTypeIds = null;
         }
 
@@ -444,39 +448,37 @@ public class CurationProductServiceImpl implements CurationProductService {
         );
     }
 
-    private Long getEtcTypeId() {
-        return furnitureTypeRepository.findAll().stream()
+    private record EtcResolution(Long typeId, List<Long> productIds) {}
+
+    private EtcResolution resolveEtc(List<Long> rawTypeIds) {
+        if (rawTypeIds == null || rawTypeIds.contains(0L)) return new EtcResolution(null, null);
+
+        List<FurnitureType> allTypes = furnitureTypeRepository.findAll();
+        Long etcTypeId = allTypes.stream()
                 .filter(t -> ETC_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
                 .map(FurnitureType::getId)
-                .findFirst()
-                .orElse(null);
-    }
+                .findFirst().orElse(null);
+        if (etcTypeId == null || !rawTypeIds.contains(etcTypeId)) return new EtcResolution(etcTypeId, null);
 
-    private List<Long> resolveEtcProductIds(List<Long> rawTypeIds, List<Long> filteredTypeIds) {
-        if (rawTypeIds == null || rawTypeIds.contains(0L)) return null;
-
-        Long etcTypeId = getEtcTypeId();
-        if (etcTypeId == null || !rawTypeIds.contains(etcTypeId)) return null;
-
-        Long selectiveTypeId = furnitureTypeRepository.findAll().stream()
+        Long selectiveTypeId = allTypes.stream()
                 .filter(t -> SELECTIVE_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
                 .map(FurnitureType::getId)
-                .findFirst()
-                .orElse(null);
+                .findFirst().orElse(null);
 
-        List<Long> excludedFurnitureIds = furnitureRepository.findAll().stream()
+        List<Furniture> allFurnitures = furnitureRepository.findAll();
+        List<Long> excludedFurnitureIds = allFurnitures.stream()
                 .filter(f -> f.getFurnitureNameEng() != null &&
                         INDIVIDUAL_FILTER_FURNITURE_NAMEENGS.contains(f.getFurnitureNameEng().toUpperCase()))
                 .map(Furniture::getId)
                 .toList();
-
-        Long etcDirectFurnitureId = furnitureRepository.findAll().stream()
+        Long etcDirectFurnitureId = allFurnitures.stream()
                 .filter(f -> ETC_TYPE_NAMEENG.equalsIgnoreCase(f.getFurnitureNameEng()))
                 .map(Furniture::getId)
-                .findFirst()
-                .orElse(null);
+                .findFirst().orElse(null);
 
-        return curationRawProductRepository.findEtcProductIds(selectiveTypeId, excludedFurnitureIds, etcDirectFurnitureId);
+        List<Long> productIds = curationRawProductRepository.findEtcProductIds(
+                selectiveTypeId, excludedFurnitureIds, etcDirectFurnitureId);
+        return new EtcResolution(etcTypeId, productIds);
     }
 
     private FurnitureTypeFilterResponse findType(List<FurnitureType> types, String nameEng, String labelKr, Long fallbackId) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -44,6 +44,13 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CurationProductServiceImpl implements CurationProductService {
 
+    private static final String ETC_TYPE_NAMEENG = "ETC";
+    private static final String SELECTIVE_TYPE_NAMEENG = "SELECTIVE";
+    private static final List<String> INDIVIDUAL_FILTER_FURNITURE_NAMEENGS = List.of(
+            "OFFICE_DESK", "DINING_TABLE", "SITTING_TABLE", "CLOSET",
+            "DISPLAY_CABINET", "CHAIR", "DRESSING_TABLE", "LIGHTING"
+    );
+
     private final FurnitureTypeRepository furnitureTypeRepository;
     private final FurnitureRepository furnitureRepository;
     private final CurationRawProductRepository curationRawProductRepository;
@@ -77,27 +84,35 @@ public class CurationProductServiceImpl implements CurationProductService {
 
         // Sentinel 값(0L, 음수) 전처리
         List<Long> filteredTypeIds = preprocessTypeIds(typeIds);
-        
+
         // 0L(전체)이 포함되어 있다면 가구 유형 필터링을 적용하지 않음
         if (typeIds != null && typeIds.contains(0L)) {
-            filteredTypeIds = null; 
+            filteredTypeIds = null;
+        }
+
+        // ETC 필터 처리: SELECTIVE 타입 중 개별 필터 없는 상품 + 직접 매핑 상품
+        List<Long> etcProductIds = resolveEtcProductIds(typeIds, filteredTypeIds);
+        if (etcProductIds != null) {
+            filteredTypeIds = filteredTypeIds == null ? null :
+                    filteredTypeIds.stream().filter(id -> !id.equals(getEtcTypeId())).toList();
+            if (filteredTypeIds != null && filteredTypeIds.isEmpty()) filteredTypeIds = null;
         }
 
         Slice<CurationRawProduct> productSlice = curationRawProductRepository.findAllByCurationFilters(
-                keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable, etcProductIds
         );
 
         boolean isRecommended = false;
         if (productSlice.isEmpty()) {
-            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames);
+            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames) || (etcProductIds != null && !etcProductIds.isEmpty());
             if (hasFilter) {
                 productSlice = curationRawProductRepository.findAllByCurationFiltersRecommend(
-                        filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                        filteredTypeIds, priceFilters, colorNames, cursor, pageable, etcProductIds
                 );
             }
             if (productSlice.isEmpty()) {
                 productSlice = curationRawProductRepository.findAllByCurationFilters(
-                        null, null, null, null, cursor, pageable
+                        null, null, null, null, cursor, pageable, null
                 );
             }
             isRecommended = true;
@@ -245,21 +260,29 @@ public class CurationProductServiceImpl implements CurationProductService {
             filteredTypeIds = null;
         }
 
+        // ETC 필터 처리: SELECTIVE 타입 중 개별 필터 없는 상품 + 직접 매핑 상품
+        List<Long> etcProductIds = resolveEtcProductIds(typeIds, filteredTypeIds);
+        if (etcProductIds != null) {
+            filteredTypeIds = filteredTypeIds == null ? null :
+                    filteredTypeIds.stream().filter(id -> !id.equals(getEtcTypeId())).toList();
+            if (filteredTypeIds != null && filteredTypeIds.isEmpty()) filteredTypeIds = null;
+        }
+
         Slice<CurationRawProduct> productSlice = curationRawProductRepository.findAllByCurationFiltersV2(
-                keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                keyword, filteredTypeIds, priceFilters, colorNames, cursor, pageable, etcProductIds
         );
 
         boolean isRecommended = false;
         if (productSlice.isEmpty()) {
-            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames);
+            boolean hasFilter = hasAnyFilter(filteredTypeIds, priceFilters, colorNames) || (etcProductIds != null && !etcProductIds.isEmpty());
             if (hasFilter) {
                 productSlice = curationRawProductRepository.findAllByCurationFiltersRecommend(
-                        filteredTypeIds, priceFilters, colorNames, cursor, pageable
+                        filteredTypeIds, priceFilters, colorNames, cursor, pageable, etcProductIds
                 );
             }
             if (productSlice.isEmpty()) {
                 productSlice = curationRawProductRepository.findAllByCurationFiltersV2(
-                        null, null, null, null, cursor, pageable
+                        null, null, null, null, cursor, pageable, null
                 );
             }
             isRecommended = true;
@@ -413,13 +436,48 @@ public class CurationProductServiceImpl implements CurationProductService {
                 findFurniture(furnitures, "DINING_TABLE", "식탁", -12L),
                 findFurniture(furnitures, "SITTING_TABLE", "좌식 테이블", -13L),
                 findFurniture(furnitures, "CLOSET", "옷장", -14L),
-                findType(types, "STORAGE", "수납/장식장", -15L),
+                findFurniture(furnitures, "DISPLAY_CABINET", "수납/장식장", -15L),
                 findType(types, "SOFA", "소파", -16L),
                 findFurniture(furnitures, "CHAIR", "의자/스툴", -1L),
                 findFurniture(furnitures, "DRESSING_TABLE", "화장대/협탁", -2L),
                 findFurniture(furnitures, "LIGHTING", "조명", -3L),
                 findType(types, "ETC", "기타", -17L)
         );
+    }
+
+    private Long getEtcTypeId() {
+        return furnitureTypeRepository.findAll().stream()
+                .filter(t -> ETC_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
+                .map(FurnitureType::getId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<Long> resolveEtcProductIds(List<Long> rawTypeIds, List<Long> filteredTypeIds) {
+        if (rawTypeIds == null || rawTypeIds.contains(0L)) return null;
+
+        Long etcTypeId = getEtcTypeId();
+        if (etcTypeId == null || !rawTypeIds.contains(etcTypeId)) return null;
+
+        Long selectiveTypeId = furnitureTypeRepository.findAll().stream()
+                .filter(t -> SELECTIVE_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
+                .map(FurnitureType::getId)
+                .findFirst()
+                .orElse(null);
+
+        List<Long> excludedFurnitureIds = furnitureRepository.findAll().stream()
+                .filter(f -> f.getFurnitureNameEng() != null &&
+                        INDIVIDUAL_FILTER_FURNITURE_NAMEENGS.contains(f.getFurnitureNameEng().toUpperCase()))
+                .map(Furniture::getId)
+                .toList();
+
+        Long etcDirectFurnitureId = furnitureRepository.findAll().stream()
+                .filter(f -> ETC_TYPE_NAMEENG.equalsIgnoreCase(f.getFurnitureNameEng()))
+                .map(Furniture::getId)
+                .findFirst()
+                .orElse(null);
+
+        return curationRawProductRepository.findEtcProductIds(selectiveTypeId, excludedFurnitureIds, etcDirectFurnitureId);
     }
 
     private FurnitureTypeFilterResponse findType(List<FurnitureType> types, String nameEng, String labelKr, Long fallbackId) {

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureServiceImpl.java
@@ -41,6 +41,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class FurnitureServiceImpl implements FurnitureService {
 
+    private static final Set<String> FUNNEL_EXCLUDED_TYPE_NAMEENGS = Set.of("ETC");
+    private static final Set<String> FUNNEL_EXCLUDED_FURNITURE_NAMEENGS = Set.of(
+            "CHAIR", "DRESSING_TABLE", "LIGHTING", "CLOSET", "ETC"
+    );
+
     private final FurnitureRepository furnitureRepository;
     private final UserRepository userRepository;
     private final TagRepository tagRepository;
@@ -69,11 +74,13 @@ public class FurnitureServiceImpl implements FurnitureService {
 
     @Override
     public List<FurnitureCategoryGroup> getDashboardCategories() {
-        // 모든 카테고리 가져오기
-        List<FurnitureType> furnitureTypes = furnitureTypeRepository.findAll();
+        List<FurnitureType> furnitureTypes = furnitureTypeRepository.findAll().stream()
+                .filter(t -> t.getNameEng() == null || !FUNNEL_EXCLUDED_TYPE_NAMEENGS.contains(t.getNameEng().toUpperCase()))
+                .toList();
 
-        // findAllWithFurnitureType() 으로 N+1 방지
-        List<Furniture> furnitureList = furnitureRepository.findAllWithFurnitureType();
+        List<Furniture> furnitureList = furnitureRepository.findAllWithFurnitureType().stream()
+                .filter(f -> f.getFurnitureNameEng() == null || !FUNNEL_EXCLUDED_FURNITURE_NAMEENGS.contains(f.getFurnitureNameEng().toUpperCase()))
+                .toList();
 
         // FurnitureType 별로 그룹화
         Map<Long, List<FurnitureItem>> furnitureByCategory = furnitureList.stream()

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -112,7 +112,7 @@ class CurationProductServiceImplTest {
         );
 
         given(curationRawProductRepository.findAllByCurationFilters(
-                eq(keyword), any(), any(), any(), eq(cursor), any()
+                eq(keyword), any(), any(), any(), eq(cursor), any(), any()
         )).willReturn(slice);
 
         // when
@@ -150,7 +150,7 @@ class CurationProductServiceImplTest {
         );
 
         given(curationRawProductRepository.findAllByCurationFiltersV2(
-                eq(keyword), any(), any(), any(), any(), any()
+                eq(keyword), any(), any(), any(), any(), any(), any()
         )).willReturn(slice);
 
         // when
@@ -182,9 +182,9 @@ class CurationProductServiceImplTest {
                 .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
         Slice<CurationRawProduct> recommendSlice = new SliceImpl<>(List.of(recommended), PageRequest.of(0, size), false);
 
-        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(emptySlice);
-        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any(), any()))
                 .willReturn(recommendSlice);
 
         // when
@@ -210,7 +210,7 @@ class CurationProductServiceImplTest {
         Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
         Slice<CurationRawProduct> fallbackSlice = new SliceImpl<>(List.of(fallback), PageRequest.of(0, size), false);
 
-        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFilters(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(emptySlice)
                 .willReturn(fallbackSlice);
 
@@ -242,9 +242,9 @@ class CurationProductServiceImplTest {
                 .isExposed(true).furnitureTagMappings(new HashSet<>()).build();
         Slice<CurationRawProduct> recommendSlice = new SliceImpl<>(List.of(recommended), PageRequest.of(0, size), false);
 
-        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(emptySlice);
-        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFiltersRecommend(any(), any(), any(), any(), any(), any()))
                 .willReturn(recommendSlice);
 
         // when
@@ -270,7 +270,7 @@ class CurationProductServiceImplTest {
         Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
         Slice<CurationRawProduct> fallbackSlice = new SliceImpl<>(List.of(fallback), PageRequest.of(0, size), false);
 
-        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any()))
+        given(curationRawProductRepository.findAllByCurationFiltersV2(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(emptySlice)
                 .willReturn(fallbackSlice);
 


### PR DESCRIPTION
## 📣 Related Issue

- close #548

## 📝 Summary

상품 탭 필터에서 고정 음수 ID로 하드코딩되어 있던 항목들을 DB 실제 등록값 기준으로 동적 조회하도록 수정합니다.

**변경 내용**

| 필터명 | 기존 | 변경 |
|--------|------|------|
| 의자/스툴 | 고정 `-1L` | `findFurniture("CHAIR")` → Furniture id=22 |
| 화장대/협탁 | 고정 `-2L`, nameEng=`DRESSER` | `findFurniture("DRESSING_TABLE")` → Furniture id=25 |
| 조명 | 고정 `-3L` | `findFurniture("LIGHTING")` → Furniture id=24 |

- `mapToFriendlyLabel()`에 `DRESSING_TABLE` 케이스 추가 (기존 `DRESSER`만 처리)
- `mapToFriendlyLabel()`에 `LIGHTING` Furniture 케이스 추가

## 🙏 Question & PR point

- 화장대/협탁 필터 응답의 `nameEng`이 `DRESSER` → `DRESSING_TABLE`으로 변경됩니다. 프론트에서 해당 값 사용 여부 확인 필요합니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 큐레이션에 추가 상품을 직접 포함하는 필터 지원
  * ETC(특수 카테고리) 상품 식별 및 결합 로직 도입(필터 처리·추천 반영)
  * 대시보드 카테고리에서 지정한 타입/가구 자동 제외
  * 카테고리 라벨 매핑 개선(화장대/조명 표기 개선)

* **Bug Fixes**
  * 추천 전환 및 필터 적용 로직 개선으로 더 정확한 큐레이션·추천 결과 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->