### PR TITLE
[CHORE] 회원가입 시, 크레딧 수를 5개로 조정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionService.java
@@ -26,7 +26,7 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class UserNicknameTagTransactionService {
 
-    private static final int SIGN_UP_CREDIT_COUNT = 1;
+    private static final int SIGN_UP_CREDIT_COUNT = 5;
 
     private final UserRepository userRepository;
     private final CreditRepository creditRepository;

--- a/src/test/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserNicknameTagTransactionServiceTest.java
@@ -1,0 +1,68 @@
+package or.sopt.houme.domain.user.service;
+
+import or.sopt.houme.domain.credit.repository.CreditRepository;
+import or.sopt.houme.domain.user.model.entity.Gender;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.domain.user.model.entity.record.SignupSession;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class UserNicknameTagTransactionServiceTest {
+
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final CreditRepository creditRepository = mock(CreditRepository.class);
+    private final UserNicknameTagTransactionService service = new UserNicknameTagTransactionService(
+            userRepository,
+            creditRepository
+    );
+
+    @Test
+    @DisplayName("소셜 회원가입 v2는 가입 크레딧 5개를 생성한다")
+    void createSocialUserWithNicknameTag_createsFiveCredits() {
+        SignupSession signupSession = SignupSession.of(1L, "test@houme.kr", "카카오닉네임");
+        User savedUser = User.builder().id(1L).email("test@houme.kr").build();
+
+        given(userRepository.saveAndFlush(org.mockito.ArgumentMatchers.any(User.class))).willReturn(savedUser);
+
+        service.createSocialUserWithNicknameTag(
+                signupSession,
+                "새닉네임",
+                "새닉네임",
+                "#1234",
+                Gender.MALE,
+                LocalDate.of(2000, 1, 1)
+        );
+
+        verify(creditRepository, times(1))
+                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 5));
+    }
+
+    @Test
+    @DisplayName("자체 회원가입 v2 완료는 가입 크레딧 5개를 생성한다")
+    void completeUserSignUpV2_createsFiveCredits() {
+        User user = User.builder().id(1L).email("test@houme.kr").build();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.saveAndFlush(user)).willReturn(user);
+
+        service.completeUserSignUpV2(
+                1L,
+                "새닉네임",
+                "#1234",
+                Gender.MALE,
+                LocalDate.of(2000, 1, 1)
+        );
+
+        verify(creditRepository, times(1))
+                .saveAll(argThat(credits -> credits instanceof java.util.Collection<?> c && c.size() == 5));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #549 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 시, 크레딧 수를 5개로 조정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **신규 기능**
  * 회원가입 시 제공되는 크레딧이 1개에서 5개로 증가했습니다.

* **테스트**
  * 회원가입 프로세스 검증 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-HOUME/HOUME-SERVER/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->