### PR TITLE
[FIX] 이미지 선호도 API 지연 로딩 예외 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryCustom.java
@@ -9,6 +9,8 @@ import java.util.Set;
 
 public interface GenerateImageRepositoryCustom {
 
+    Optional<GenerateImage> findByIdWithHouseAndUser(Long imageId);
+
     Optional<GenerateImage> findByHouseId(Long houseId);
 
     // 가장 최근 생성된 GenerateImage 1개 가져오기

--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRepositoryImpl.java
@@ -11,6 +11,7 @@ import or.sopt.houme.domain.generateImage.model.entity.QGenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.QGenerateImageRawProduct;
 import or.sopt.houme.domain.banner.model.entity.QBanner;
 import or.sopt.houme.domain.house.model.entity.QHouse;
+import or.sopt.houme.domain.user.model.entity.QUser;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -24,6 +25,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GenerateImageRepositoryImpl implements GenerateImageRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<GenerateImage> findByIdWithHouseAndUser(Long imageId) {
+        QGenerateImage generateImage = QGenerateImage.generateImage;
+        QHouse house = QHouse.house;
+        QUser user = QUser.user;
+
+        return Optional.ofNullable(queryFactory
+                .selectFrom(generateImage)
+                .join(generateImage.house, house).fetchJoin()
+                .join(house.user, user).fetchJoin()
+                .where(generateImage.id.eq(imageId))
+                .fetchOne());
+    }
 
     @Override
     public Optional<GenerateImage> findByHouseId(Long houseId) {

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImpl.java
@@ -39,7 +39,7 @@ public class GenerateImageServiceImpl implements GenerateImageService {
     @Override
     public GenerateImage findGenerateImage(Long imageId) {
 
-        return generateImageRepository.findById(imageId)
+        return generateImageRepository.findByIdWithHouseAndUser(imageId)
                 .orElseThrow(() -> new GenerateImageException(ErrorCode.NOT_FOUND_GENERATE_IMAGE_ENTITY));
     }
 

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageServiceImplTest.java
@@ -100,6 +100,7 @@ class GenerateImageServiceImplTest {
                 .originalFilename(originalFilename)
                 .url(imageLink)
                 .fileExtension(contentType)
+                .house(savedHouse)
                 .build();
 
         GenerateImage saveImage = generateImageRepository.save(generateImage);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #553 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
-  이미지 선호도 API 지연 로딩 예외 수정

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

#### 기존 로직의 문제점
- facade에서 트랜잭션을 시작하지 않음
- 그래서 위의 isLike()에서 회원을 조회하고 트랜잭션에 닫히면 -> 다음 메서드에서 회원을 조회할 시, Lazy 500이 터짐
- `open-in-view=true`로 설정값을 변경하거나 Facade에서 트랜잭션을 시작하도록 로직을 수저앟면 쉽게 해결 할 수 있음.
- 전자는 커넥션이 불필요하게 오래 잡히고, 전역 설정이기에 이미지 생성 시 커넥션 부족 발생 위험
- Facade에서 시작하도록 하는건 좋은 것 같은데 팀원들과 논의된 부분이 아님. 어느 방향으로든 통일해야하는 부분이긴 함

결국 해결한 방법은 회원 조회 시, fetch join으로 프록시가 아닌 실제 객체를 가져와서 조회하도록 로직 변경

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **최적화**
  * 생성된 이미지 조회 시 주택 및 사용자 정보를 함께 로드하도록 개선했습니다. 전체 데이터 로딩 과정을 최적화하여 조회 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->