### PR TITLE
[CHORE] 이미지 생성 시, 가구 조합 순서 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -909,6 +909,7 @@ public class GenerateImageFacade {
 
         Long selectedChipRawProductId = selectedChip.curationRawProductId();
         if (selectedChipRawProductId != null) {
+            // 선택 칩 상품은 배너 기본 상품보다 먼저 주입해 모델에 더 강한 우선순위를 준다.
             CurationRawProduct selectedChipRawProduct = bannerRawProductsById.get(selectedChipRawProductId);
             if (selectedChipRawProduct == null) {
                 selectedChipRawProduct = curationRawProductRepository.findById(selectedChipRawProductId)
@@ -925,6 +926,7 @@ public class GenerateImageFacade {
         }
 
         bannerRawProductsById.values().forEach(rawProduct -> {
+            // 이미 앞에서 넣은 선택 칩 상품은 다시 추가하지 않아 순서를 고정한다.
             if (Objects.equals(rawProduct.getId(), selectedChipRawProductId)) {
                 return;
             }

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -900,33 +900,39 @@ public class GenerateImageFacade {
         if (floorPlanImageUrl != null && !floorPlanImageUrl.isBlank()) {
             urls.add(floorPlanImageUrl);
         }
-        if (banner.getBannerImageUrl() != null && !banner.getBannerImageUrl().isBlank()) {
-            urls.add(banner.getBannerImageUrl());
-        }
 
         Map<Long, CurationRawProduct> bannerRawProductsById = new LinkedHashMap<>();
         banner.getBannerRawProducts().stream()
                 .map(mapping -> mapping != null ? mapping.getCurationRawProduct() : null)
                 .filter(Objects::nonNull)
-                .forEach(rawProduct -> {
-                    bannerRawProductsById.put(rawProduct.getId(), rawProduct);
-                    if (rawProduct.getProductImageUrl() != null && !rawProduct.getProductImageUrl().isBlank()) {
-                        urls.add(rawProduct.getProductImageUrl());
-                    }
-                });
+                .forEach(rawProduct -> bannerRawProductsById.put(rawProduct.getId(), rawProduct));
 
-        if (selectedChip.curationRawProductId() != null) {
-            CurationRawProduct selectedChipRawProduct = bannerRawProductsById.get(selectedChip.curationRawProductId());
+        Long selectedChipRawProductId = selectedChip.curationRawProductId();
+        if (selectedChipRawProductId != null) {
+            CurationRawProduct selectedChipRawProduct = bannerRawProductsById.get(selectedChipRawProductId);
             if (selectedChipRawProduct == null) {
-                selectedChipRawProduct = curationRawProductRepository.findById(selectedChip.curationRawProductId())
+                selectedChipRawProduct = curationRawProductRepository.findById(selectedChipRawProductId)
                         .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_CURATION_RAW_PRODUCT));
             }
-            if (selectedChipRawProduct != null
-                    && selectedChipRawProduct.getProductImageUrl() != null
+            if (selectedChipRawProduct.getProductImageUrl() != null
                     && !selectedChipRawProduct.getProductImageUrl().isBlank()) {
                 urls.add(selectedChipRawProduct.getProductImageUrl());
             }
         }
+
+        if (banner.getBannerImageUrl() != null && !banner.getBannerImageUrl().isBlank()) {
+            urls.add(banner.getBannerImageUrl());
+        }
+
+        bannerRawProductsById.values().forEach(rawProduct -> {
+            if (Objects.equals(rawProduct.getId(), selectedChipRawProductId)) {
+                return;
+            }
+            if (rawProduct.getProductImageUrl() != null && !rawProduct.getProductImageUrl().isBlank()) {
+                urls.add(rawProduct.getProductImageUrl());
+            }
+        });
+
         return List.copyOf(urls);
     }
 

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -3,6 +3,7 @@ package or.sopt.houme.domain.generateImage.service.facade;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
 import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
@@ -65,6 +66,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -79,6 +81,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[FloorPlan Service Test]")
@@ -446,6 +449,111 @@ class GenerateImageFacadeTest {
                 any(),
                 eq(imageUploadResponseDTO)
         );
+    }
+
+    @Test
+    @DisplayName("배너 템플릿 이미지 생성 시 선택 칩 상품 이미지를 배너 기본 상품보다 먼저 reference에 넣는다")
+    void generateBannerImageByGemini_placesSelectedChipProductBeforeBannerProducts() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .name("test_user")
+                .build();
+
+        Credit lockedCredit = Credit.builder()
+                .id(10L)
+                .status(CreditStatus.PENDING)
+                .user(user)
+                .build();
+
+        CurationRawProduct selectedProduct = CurationRawProduct.builder()
+                .id(350L)
+                .source("desker")
+                .productId(501L)
+                .productImageUrl("https://selected-product-image")
+                .productSiteUrl("https://selected-product-site")
+                .productName("선택 칩 책상")
+                .fetchedAt(LocalDateTime.now())
+                .build();
+        CurationRawProduct otherProduct = CurationRawProduct.builder()
+                .id(365L)
+                .source("29cm")
+                .productId(516L)
+                .productImageUrl("https://other-product-image")
+                .productSiteUrl("https://other-product-site")
+                .productName("배너 기본 상품")
+                .fetchedAt(LocalDateTime.now())
+                .build();
+
+        Banner banner = Banner.builder()
+                .id(100L)
+                .bannerType(BannerType.BANNER)
+                .bannerImageUrl("https://banner-image")
+                .stylePrompt("배너 스타일 프롬프트")
+                .styleAnswerChipsJson("[{\"id\":2}]")
+                .bannerRawProducts(List.of(
+                        BannerCurationRawProduct.of(null, selectedProduct),
+                        BannerCurationRawProduct.of(null, otherProduct)
+                ))
+                .build();
+
+        FloorPlan floorPlan = FloorPlan.builder()
+                .id(11L)
+                .url("https://floorplan-default")
+                .floorPlanPrompt("도면 프롬프트")
+                .imagesJson("[]")
+                .build();
+
+        BannerGenerateImageRequest request = new BannerGenerateImageRequest(
+                100L,
+                2L,
+                11L,
+                null,
+                false
+        );
+
+        ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
+                "generated.webp",
+                "generated-original.webp",
+                "https://generated-image",
+                "image/webp"
+        );
+
+        when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
+        when(bannerRepository.findByIdWithRawProducts(100L, BannerType.BANNER, false)).thenReturn(Optional.of(banner));
+        when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
+        when(objectMapper.readValue(eq("[{\"id\":2}]"), any(TypeReference.class)))
+                .thenReturn(List.of(new BannerStyleAnswerChip(2L, 2, "답변", "선택 프롬프트", 350L)));
+        when(floorPlanImageJsonCodec.read("[]")).thenReturn(List.of());
+        when(geminiImageService.createImageWithReferences(any(), argThat(referenceImageUrls ->
+                referenceImageUrls.equals(List.of(
+                        "https://floorplan-default",
+                        "https://selected-product-image",
+                        "https://banner-image",
+                        "https://other-product-image"
+                ))
+        ))).thenReturn(imageUploadResponseDTO);
+        when(generateImageTransactionService.saveBannerImageAndConfirmCredit(
+                eq(user),
+                eq(lockedCredit),
+                eq(banner),
+                eq(11L),
+                eq(false),
+                any(),
+                eq(imageUploadResponseDTO)
+        )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
+
+        BannerGenerateImageResponse response = generateImageFacade.generateBannerImageByGemini(user, request);
+
+        assertThat(response.imageId()).isEqualTo(999L);
+        verify(geminiImageService, times(1)).createImageWithReferences(any(), argThat(referenceImageUrls ->
+                referenceImageUrls.equals(List.of(
+                        "https://floorplan-default",
+                        "https://selected-product-image",
+                        "https://banner-image",
+                        "https://other-product-image"
+                ))
+        ));
+        verify(curationRawProductRepository, never()).findById(anyLong());
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #557 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 이미지를 생성할때 가구가 조합되는 순서를 수정하였습니다.
- 문제 [스레드 링크입니다.](https://discord.com/channels/1383631178593996910/1511150997018382416)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

기존의 로직은 아래와 같았습니다.
```
1. floorPlanImageUrl 추가
2. bannerImageUrl 추가
3. bannerRawProducts를 순회하면서 기본 상품 이미지 전부 추가
4. 마지막에 selectedChip.curationRawProductId로 선택 칩 상품 이미지 추가
```

이때 curationRawProduct가 누락되는 문제를 해결하기 위해 TL님께서 말씀해주신 우선순위대로 이미지 소스를 주입하도록 로직을 수정하였습니다.
```
1. floorPlanImageUrl 추가
2. bannerRawProducts를 먼저 Map<Long, CurationRawProduct>로 모음
3. selectedChip.curationRawProductId가 있으면 그 상품을 먼저 찾아서 이미지 URL 추가
3-1. 배너 기본 상품 목록에 없으면 curationRawProductRepository.findById(...)로 fallback 조회
4. bannerImageUrl 추가
5. bannerRawProducts를 다시 순회하면서 선택 칩 상품은 제외하고 나머지 기본 상품 이미지만 추가
```

`공간 이미지 > 선택 칩 상품 이미지 > 그 외 배너 기본 상품 이미지 순` 으로 이미지가 조합되어 생성됩니다.
본탁님 @kbt82883 이 구현해주신 부분이라 변경된 로직을 이해하시기 쉽도록, 간단한 주석 몇 줄을 추가해두었습니다. 참고해주시면 감사하겠습니다!


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 배너 이미지 생성 시 선택된 상품 이미지를 우선 처리하도록 개선하여 이미지 순서 최적화 및 중복 방지

* **Tests**
  * 배너 이미지 생성 로직 검증을 위한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->