### PR TITLE
[CHORE] /api/v2/carousels 조회 로직을 100개 일괄 랜덤 노출 구조로 개편

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryCustom.java
@@ -1,6 +1,7 @@
 package or.sopt.houme.domain.furniture.repository;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -46,6 +47,21 @@ public interface CurationRawProductRepositoryCustom {
     List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserWithCursor(
             Long userId,
             Long cursor,
+            int size,
+            List<Long> excludedIds
+    );
+
+    List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserByCategory(
+            Long userId,
+            SoozipCategory category,
+            int size,
+            List<Long> excludedIds
+    );
+
+    List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+            Long userId,
+            List<Long> furnitureIds,
+            SoozipCategory category,
             int size,
             List<Long> excludedIds
     );

--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -14,6 +14,7 @@ import or.sopt.houme.domain.furniture.model.entity.QCurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QCurationRawProductFurnitureTag;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.model.entity.QFurniture;
 import or.sopt.houme.domain.furniture.model.entity.QFurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.QFurnitureType;
@@ -349,6 +350,62 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
     }
 
     @Override
+    public List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserByCategory(
+            Long userId,
+            SoozipCategory category,
+            int size,
+            List<Long> excludedIds
+    ) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        BooleanBuilder where = buildExposedRawProductBaseWhere(userId, excludedIds);
+        if (category != null) {
+            where.and(rawProduct.category.eq(category));
+        }
+
+        return queryFactory
+                .selectFrom(rawProduct)
+                .where(where)
+                .orderBy(rawProduct.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<CurationRawProduct> findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+            Long userId,
+            List<Long> furnitureIds,
+            SoozipCategory category,
+            int size,
+            List<Long> excludedIds
+    ) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
+            return List.of();
+        }
+
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        QCurationRawProductFurnitureTag mapping = QCurationRawProductFurnitureTag.curationRawProductFurnitureTag;
+        QFurnitureTag furnitureTag = QFurnitureTag.furnitureTag;
+        QFurniture furniture = QFurniture.furniture;
+
+        BooleanBuilder where = buildExposedRawProductBaseWhere(userId, excludedIds);
+        where.and(furniture.id.in(furnitureIds));
+        if (category != null) {
+            where.and(rawProduct.category.eq(category));
+        }
+
+        return queryFactory
+                .selectDistinct(rawProduct)
+                .from(rawProduct)
+                .join(rawProduct.furnitureTagMappings, mapping)
+                .join(mapping.furnitureTag, furnitureTag)
+                .join(furnitureTag.furniture, furniture)
+                .where(where)
+                .orderBy(rawProduct.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
     public List<CurationRawProduct> findAllSimilarByFurnitureTypeIds(
             List<Long> furnitureTypeIds,
             List<Long> excludeRawProductIds,
@@ -428,6 +485,33 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
+
+    private BooleanBuilder buildExposedRawProductBaseWhere(Long userId, List<Long> excludedIds) {
+        QCurationRawProduct rawProduct = QCurationRawProduct.curationRawProduct;
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(rawProduct.isExposed.isTrue().or(rawProduct.isExposed.isNull()));
+        where.and(notLikedByUser(userId, rawProduct));
+        if (excludedIds != null && !excludedIds.isEmpty()) {
+            where.and(rawProduct.id.notIn(excludedIds.stream().filter(Objects::nonNull).toList()));
+        }
+        return where;
+    }
+
+    private BooleanExpression notLikedByUser(Long userId, QCurationRawProduct rawProduct) {
+        QJjym jjym = QJjym.jjym;
+        QRecommendFurniture recommendFurniture = QRecommendFurniture.recommendFurniture;
+
+        return JPAExpressions
+                .selectOne()
+                .from(jjym)
+                .join(jjym.recommendFurniture, recommendFurniture)
+                .where(
+                        jjym.user.id.eq(userId),
+                        recommendFurniture.source.eq(CurationSource.RAW),
+                        recommendFurniture.furnitureProductId.eq(rawProduct.productId)
+                )
+                .notExists();
     }
 
     @Override

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
@@ -3,6 +3,8 @@ package or.sopt.houme.domain.house.presentation.carousel.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.service.carousel.CarouselLikeLogService;
@@ -12,11 +14,14 @@ import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarous
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
 import or.sopt.houme.global.api.handler.CarouselException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,9 +51,14 @@ public class CarouselController {
     @Operation(summary = "캐러셀 조회 API v2",
             description = "실제 상품을 응답합니다. 한 번 조회 시, 100개의 상품을 반환합니다.")
     public ResponseEntity<ApiResponse<GetCarouselV2ListResponseDTO>> getCarouselsV2(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "furnitureIds", required = false)
+            List<@NotNull(message = "furnitureIds에는 null이 포함될 수 없습니다.") Long> furnitureIds) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
+            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
+        }
 
-        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(userDetails.getUser());
+        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(userDetails.getUser(), furnitureIds);
 
         return ResponseEntity.ok(ApiResponse.ok(carousels));
     }

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
@@ -44,18 +44,11 @@ public class CarouselController {
 
     @GetMapping("/api/v2/carousels")
     @Operation(summary = "캐러셀 조회 API v2",
-            description = "실제 상품을 응답합니다. 한 번 조회 시, 10개의 상품을 반환합니다. <br><br>" +
-                    "cursor가 없으면 랜덤 시작점에서 조회하고, cursor가 있으면 해당 id 미만을 이어서 조회합니다.")
+            description = "실제 상품을 응답합니다. 한 번 조회 시, 100개의 상품을 반환합니다.")
     public ResponseEntity<ApiResponse<GetCarouselV2ListResponseDTO>> getCarouselsV2(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(value = "cursor", required = false)
-            @Min(value = 1, message = "cursor는 1 이상이어야 합니다.")
-            Long cursor) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(
-                cursor,
-                userDetails.getUser()
-        );
+        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(userDetails.getUser());
 
         return ResponseEntity.ok(ApiResponse.ok(carousels));
     }

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselResponseDTO.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselResponseDTO.java
@@ -3,12 +3,12 @@ package or.sopt.houme.domain.house.presentation.carousel.controller.dto;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
 
 public record GetCarouselResponseDTO(
-        Long carouselId,
+        Long rawProductId,
         String url
 )
 {
-    public static GetCarouselResponseDTO of(Long carouselId, String url) {
-        return new GetCarouselResponseDTO(carouselId, url);
+    public static GetCarouselResponseDTO of(Long rawProductId, String url) {
+        return new GetCarouselResponseDTO(rawProductId, url);
     }
 
     public static GetCarouselResponseDTO from(Carousel carousel) {

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselV2ListResponseDTO.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselV2ListResponseDTO.java
@@ -3,11 +3,10 @@ package or.sopt.houme.domain.house.presentation.carousel.controller.dto;
 import java.util.List;
 
 public record GetCarouselV2ListResponseDTO(
-        List<GetCarouselResponseDTO> carousels,
-        Long nextCursor
+        List<GetCarouselResponseDTO> carousels
 ) {
 
-    public static GetCarouselV2ListResponseDTO of(List<GetCarouselResponseDTO> carousels, Long nextCursor) {
-        return new GetCarouselV2ListResponseDTO(carousels, nextCursor);
+    public static GetCarouselV2ListResponseDTO of(List<GetCarouselResponseDTO> carousels) {
+        return new GetCarouselV2ListResponseDTO(carousels);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
@@ -1,24 +1,10 @@
 package or.sopt.houme.domain.house.repository;
 
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface HouseFurnitureRepository extends JpaRepository<HouseFurniture, Long> {
+public interface HouseFurnitureRepository extends JpaRepository<HouseFurniture, Long>, HouseFurnitureRepositoryCustom {
     void deleteByHouseId(Long houseId);
-
-    @Query("""
-            select houseFurniture
-            from HouseFurniture houseFurniture
-            join fetch houseFurniture.furniture furniture
-            join fetch furniture.furnitureType
-            where houseFurniture.house.id = :houseId
-            order by houseFurniture.id asc
-            """)
-    List<HouseFurniture> findAllByHouseIdWithFurniture(@Param("houseId") Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepository.java
@@ -1,10 +1,24 @@
 package or.sopt.houme.domain.house.repository;
 
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface HouseFurnitureRepository extends JpaRepository<HouseFurniture, Long> {
     void deleteByHouseId(Long houseId);
+
+    @Query("""
+            select houseFurniture
+            from HouseFurniture houseFurniture
+            join fetch houseFurniture.furniture furniture
+            join fetch furniture.furnitureType
+            where houseFurniture.house.id = :houseId
+            order by houseFurniture.id asc
+            """)
+    List<HouseFurniture> findAllByHouseIdWithFurniture(@Param("houseId") Long houseId);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryCustom.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.house.repository;
+
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+
+import java.util.List;
+
+public interface HouseFurnitureRepositoryCustom {
+    List<HouseFurniture> findAllByHouseIdWithFurniture(Long houseId);
+}

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryImpl.java
@@ -1,0 +1,33 @@
+package or.sopt.houme.domain.house.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.QFurniture;
+import or.sopt.houme.domain.furniture.model.entity.QFurnitureType;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+import or.sopt.houme.domain.house.model.entity.mapping.QHouseFurniture;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class HouseFurnitureRepositoryImpl implements HouseFurnitureRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<HouseFurniture> findAllByHouseIdWithFurniture(Long houseId) {
+        QHouseFurniture houseFurniture = QHouseFurniture.houseFurniture;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType furnitureType = QFurnitureType.furnitureType;
+
+        return queryFactory
+                .selectFrom(houseFurniture)
+                .join(houseFurniture.furniture, furniture).fetchJoin()
+                .join(furniture.furnitureType, furnitureType).fetchJoin()
+                .where(houseFurniture.house.id.eq(houseId))
+                .orderBy(houseFurniture.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidatePolicy.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidatePolicy.java
@@ -1,0 +1,24 @@
+package or.sopt.houme.domain.house.service.carousel;
+
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+import java.util.List;
+
+public final class CarouselCandidatePolicy {
+
+    public static final int SELECTED_FURNITURE_CANDIDATE_LIMIT = 160;
+    public static final int FURNITURE_CATEGORY_CANDIDATE_LIMIT = 160;
+    public static final int OTHER_CATEGORY_CANDIDATE_LIMIT = 60;
+    public static final int FALLBACK_CANDIDATE_LIMIT = 220;
+
+    public static final List<SoozipCategory> OTHER_CATEGORIES = List.of(
+            SoozipCategory.LIGHTING,
+            SoozipCategory.LIVING_GOODS,
+            SoozipCategory.HOME_FABRIC,
+            SoozipCategory.ACCESSORY,
+            SoozipCategory.MINI_ELECTRONICS
+    );
+
+    private CarouselCandidatePolicy() {
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -19,20 +19,6 @@ import java.util.Set;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CarouselCandidateService {
-
-    private static final int SELECTED_FURNITURE_CANDIDATE_LIMIT = 160;
-    private static final int FURNITURE_CATEGORY_CANDIDATE_LIMIT = 160;
-    private static final int OTHER_CATEGORY_CANDIDATE_LIMIT = 60;
-    private static final int FALLBACK_CANDIDATE_LIMIT = 220;
-
-    private static final List<SoozipCategory> OTHER_CATEGORIES = List.of(
-            SoozipCategory.LIGHTING,
-            SoozipCategory.LIVING_GOODS,
-            SoozipCategory.HOME_FABRIC,
-            SoozipCategory.ACCESSORY,
-            SoozipCategory.MINI_ELECTRONICS
-    );
-
     private final CurationRawProductRepository curationRawProductRepository;
 
     public CarouselCandidateBundle collectCandidates(Long userId, List<Long> requestFurnitureIds) {
@@ -44,7 +30,7 @@ public class CarouselCandidateService {
                         userId,
                         selectedFurnitureSourceIds,
                         SoozipCategory.FURNITURE,
-                        SELECTED_FURNITURE_CANDIDATE_LIMIT,
+                        CarouselCandidatePolicy.SELECTED_FURNITURE_CANDIDATE_LIMIT,
                         List.copyOf(excludedIds)
                 )
         );
@@ -54,18 +40,18 @@ public class CarouselCandidateService {
                 curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
                         userId,
                         SoozipCategory.FURNITURE,
-                        FURNITURE_CATEGORY_CANDIDATE_LIMIT,
+                        CarouselCandidatePolicy.FURNITURE_CATEGORY_CANDIDATE_LIMIT,
                         List.copyOf(excludedIds)
                 )
         );
         excludedIds.addAll(furnitureCategoryIds);
 
         Map<SoozipCategory, List<Long>> otherCategoryIds = new EnumMap<>(SoozipCategory.class);
-        for (SoozipCategory category : OTHER_CATEGORIES) {
+        for (SoozipCategory category : CarouselCandidatePolicy.OTHER_CATEGORIES) {
             List<Long> otherIds = mapIds(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
                     userId,
                     category,
-                    OTHER_CATEGORY_CANDIDATE_LIMIT,
+                    CarouselCandidatePolicy.OTHER_CATEGORY_CANDIDATE_LIMIT,
                     List.copyOf(excludedIds)
             ));
             otherCategoryIds.put(category, otherIds);
@@ -76,7 +62,7 @@ public class CarouselCandidateService {
                 curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
                         userId,
                         null,
-                        FALLBACK_CANDIDATE_LIMIT,
+                        CarouselCandidatePolicy.FALLBACK_CANDIDATE_LIMIT,
                         List.copyOf(excludedIds)
                 )
         );

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.EnumMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +37,7 @@ public class CarouselCandidateService {
 
     public CarouselCandidateBundle collectCandidates(Long userId, List<Long> requestFurnitureIds) {
         List<Long> selectedFurnitureSourceIds = normalizeFurnitureIds(requestFurnitureIds);
+        Set<Long> excludedIds = new LinkedHashSet<>();
 
         List<Long> selectedFurnitureIds = mapIds(
                 curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
@@ -42,30 +45,31 @@ public class CarouselCandidateService {
                         selectedFurnitureSourceIds,
                         SoozipCategory.FURNITURE,
                         SELECTED_FURNITURE_CANDIDATE_LIMIT,
-                        List.of()
+                        List.copyOf(excludedIds)
                 )
         );
+        excludedIds.addAll(selectedFurnitureIds);
 
         List<Long> furnitureCategoryIds = mapIds(
                 curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
                         userId,
                         SoozipCategory.FURNITURE,
                         FURNITURE_CATEGORY_CANDIDATE_LIMIT,
-                        List.of()
+                        List.copyOf(excludedIds)
                 )
         );
+        excludedIds.addAll(furnitureCategoryIds);
 
         Map<SoozipCategory, List<Long>> otherCategoryIds = new EnumMap<>(SoozipCategory.class);
         for (SoozipCategory category : OTHER_CATEGORIES) {
-            otherCategoryIds.put(
+            List<Long> otherIds = mapIds(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                    userId,
                     category,
-                    mapIds(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
-                            userId,
-                            category,
-                            OTHER_CATEGORY_CANDIDATE_LIMIT,
-                            List.of()
-                    ))
-            );
+                    OTHER_CATEGORY_CANDIDATE_LIMIT,
+                    List.copyOf(excludedIds)
+            ));
+            otherCategoryIds.put(category, otherIds);
+            excludedIds.addAll(otherIds);
         }
 
         List<Long> fallbackIds = mapIds(
@@ -73,7 +77,7 @@ public class CarouselCandidateService {
                         userId,
                         null,
                         FALLBACK_CANDIDATE_LIMIT,
-                        List.of()
+                        List.copyOf(excludedIds)
                 )
         );
 

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -1,0 +1,124 @@
+package or.sopt.houme.domain.house.service.carousel;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
+import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CarouselCandidateService {
+
+    private static final int SELECTED_FURNITURE_CANDIDATE_LIMIT = 160;
+    private static final int FURNITURE_CATEGORY_CANDIDATE_LIMIT = 160;
+    private static final int OTHER_CATEGORY_CANDIDATE_LIMIT = 60;
+    private static final int FALLBACK_CANDIDATE_LIMIT = 220;
+
+    private static final List<SoozipCategory> OTHER_CATEGORIES = List.of(
+            SoozipCategory.LIGHTING,
+            SoozipCategory.LIVING_GOODS,
+            SoozipCategory.HOME_FABRIC,
+            SoozipCategory.ACCESSORY,
+            SoozipCategory.MINI_ELECTRONICS
+    );
+
+    private final GenerateImageRepository generateImageRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
+    private final CurationRawProductRepository curationRawProductRepository;
+
+    public CarouselCandidateBundle collectCandidates(Long userId) {
+        Optional<GenerateImage> recentGenerateImage = generateImageRepository.findMostRecentByUserId(userId);
+        Long recentImageId = recentGenerateImage.map(GenerateImage::getId).orElse(null);
+        List<Long> recentFurnitureIds = resolveRecentSelectedFurnitureIds(recentGenerateImage);
+
+        List<Long> selectedFurnitureIds = mapIds(
+                curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+                        userId,
+                        recentFurnitureIds,
+                        SoozipCategory.FURNITURE,
+                        SELECTED_FURNITURE_CANDIDATE_LIMIT,
+                        List.of()
+                )
+        );
+
+        List<Long> furnitureCategoryIds = mapIds(
+                curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                        userId,
+                        SoozipCategory.FURNITURE,
+                        FURNITURE_CATEGORY_CANDIDATE_LIMIT,
+                        List.of()
+                )
+        );
+
+        Map<SoozipCategory, List<Long>> otherCategoryIds = new EnumMap<>(SoozipCategory.class);
+        for (SoozipCategory category : OTHER_CATEGORIES) {
+            otherCategoryIds.put(
+                    category,
+                    mapIds(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                            userId,
+                            category,
+                            OTHER_CATEGORY_CANDIDATE_LIMIT,
+                            List.of()
+                    ))
+            );
+        }
+
+        List<Long> fallbackIds = mapIds(
+                curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                        userId,
+                        null,
+                        FALLBACK_CANDIDATE_LIMIT,
+                        List.of()
+                )
+        );
+
+        return new CarouselCandidateBundle(
+                recentImageId,
+                selectedFurnitureIds,
+                furnitureCategoryIds,
+                otherCategoryIds,
+                fallbackIds
+        );
+    }
+
+    private List<Long> resolveRecentSelectedFurnitureIds(Optional<GenerateImage> recentGenerateImage) {
+        if (recentGenerateImage.isEmpty() || recentGenerateImage.get().getHouse() == null) {
+            return List.of();
+        }
+
+        Long houseId = recentGenerateImage.get().getHouse().getId();
+        if (houseId == null) {
+            return List.of();
+        }
+
+        return houseFurnitureRepository.findAllByHouseIdWithFurniture(houseId).stream()
+                .map(HouseFurniture::getFurniture)
+                .filter(Objects::nonNull)
+                .map(furniture -> furniture.getId())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<Long> mapIds(List<CurationRawProduct> rawProducts) {
+        return rawProducts.stream()
+                .map(CurationRawProduct::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -4,10 +4,6 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
-import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
-import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
-import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
-import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +12,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,19 +31,15 @@ public class CarouselCandidateService {
             SoozipCategory.MINI_ELECTRONICS
     );
 
-    private final GenerateImageRepository generateImageRepository;
-    private final HouseFurnitureRepository houseFurnitureRepository;
     private final CurationRawProductRepository curationRawProductRepository;
 
-    public CarouselCandidateBundle collectCandidates(Long userId) {
-        Optional<GenerateImage> recentGenerateImage = generateImageRepository.findMostRecentByUserId(userId);
-        Long recentImageId = recentGenerateImage.map(GenerateImage::getId).orElse(null);
-        List<Long> recentFurnitureIds = resolveRecentSelectedFurnitureIds(recentGenerateImage);
+    public CarouselCandidateBundle collectCandidates(Long userId, List<Long> requestFurnitureIds) {
+        List<Long> selectedFurnitureSourceIds = normalizeFurnitureIds(requestFurnitureIds);
 
         List<Long> selectedFurnitureIds = mapIds(
                 curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
                         userId,
-                        recentFurnitureIds,
+                        selectedFurnitureSourceIds,
                         SoozipCategory.FURNITURE,
                         SELECTED_FURNITURE_CANDIDATE_LIMIT,
                         List.of()
@@ -87,7 +78,7 @@ public class CarouselCandidateService {
         );
 
         return new CarouselCandidateBundle(
-                recentImageId,
+                null,
                 selectedFurnitureIds,
                 furnitureCategoryIds,
                 otherCategoryIds,
@@ -95,20 +86,12 @@ public class CarouselCandidateService {
         );
     }
 
-    private List<Long> resolveRecentSelectedFurnitureIds(Optional<GenerateImage> recentGenerateImage) {
-        if (recentGenerateImage.isEmpty() || recentGenerateImage.get().getHouse() == null) {
+    private List<Long> normalizeFurnitureIds(List<Long> furnitureIds) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
             return List.of();
         }
 
-        Long houseId = recentGenerateImage.get().getHouse().getId();
-        if (houseId == null) {
-            return List.of();
-        }
-
-        return houseFurnitureRepository.findAllByHouseIdWithFurniture(houseId).stream()
-                .map(HouseFurniture::getFurniture)
-                .filter(Objects::nonNull)
-                .map(furniture -> furniture.getId())
+        return furnitureIds.stream()
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
@@ -5,9 +5,11 @@ import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarous
 import or.sopt.houme.domain.user.model.entity.User;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 public interface CarouselService {
     GetCarouselListResponseDTO getCarousel(int page);
-    GetCarouselV2ListResponseDTO getCarouselV2(User user);
+    GetCarouselV2ListResponseDTO getCarouselV2(User user, List<Long> furnitureIds);
 
     @Transactional
     void likeCarousel(User user, Long carouselId);

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface CarouselService {
     GetCarouselListResponseDTO getCarousel(int page);
-    GetCarouselV2ListResponseDTO getCarouselV2(Long cursor, User user);
+    GetCarouselV2ListResponseDTO getCarouselV2(User user);
 
     @Transactional
     void likeCarousel(User user, Long carouselId);

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
@@ -57,8 +57,8 @@ public class CarouselServiceImpl implements CarouselService {
     }
 
     @Override
-    public GetCarouselV2ListResponseDTO getCarouselV2(User user) {
-        var candidateBundle = carouselCandidateService.collectCandidates(user.getId());
+    public GetCarouselV2ListResponseDTO getCarouselV2(User user, List<Long> furnitureIds) {
+        var candidateBundle = carouselCandidateService.collectCandidates(user.getId(), furnitureIds);
         List<Long> displayIds = carouselShuffleService.selectDisplayIds(candidateBundle, user.getId());
         if (displayIds.isEmpty()) {
             return GetCarouselV2ListResponseDTO.of(List.of());

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
@@ -2,17 +2,12 @@ package or.sopt.houme.domain.house.service.carousel;
 
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
-import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.JjymService;
-import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
-import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
-import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
-import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
 import or.sopt.houme.domain.preference.model.entity.CarouselPreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -24,20 +19,16 @@ import or.sopt.houme.global.api.handler.CarouselException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CarouselServiceImpl implements CarouselService {
-    private static final int CAROUSEL_V2_SIZE = 10;
-    private static final int PRIORITY_FURNITURE_MATCH_SIZE = 4;
-    private static final int RANDOM_SEGMENT_COUNT = 3;
-
     private final CarouselCacheService carouselCacheService;
     private final CarouselRepository carouselRepository;
     private final PreferenceRepository preferenceRepository;
@@ -45,8 +36,8 @@ public class CarouselServiceImpl implements CarouselService {
     private final CurationRawProductRepository curationRawProductRepository;
     private final JjymService jjymService;
     private final CarouselLikeLogService carouselLikeLogService;
-    private final GenerateImageRepository generateImageRepository;
-    private final HouseFurnitureRepository houseFurnitureRepository;
+    private final CarouselCandidateService carouselCandidateService;
+    private final CarouselShuffleService carouselShuffleService;
 
     @Override
     public GetCarouselListResponseDTO getCarousel(int page) {
@@ -66,36 +57,23 @@ public class CarouselServiceImpl implements CarouselService {
     }
 
     @Override
-    public GetCarouselV2ListResponseDTO getCarouselV2(Long cursor, User user) {
-        Long userId = user.getId();
-        if (cursor == null) {
-            List<CurationRawProduct> initialSelected = getInitialCarouselV2Selection(userId);
-            List<GetCarouselResponseDTO> initialResult = initialSelected.stream()
-                    .map(rawProduct -> GetCarouselResponseDTO.of(rawProduct.getId(), rawProduct.getProductImageUrl()))
-                    .toList();
-            Long nextCursor = initialSelected.size() < CAROUSEL_V2_SIZE
-                    ? null
-                    : initialSelected.get(initialSelected.size() - 1).getId();
-            return GetCarouselV2ListResponseDTO.of(initialResult, nextCursor);
+    public GetCarouselV2ListResponseDTO getCarouselV2(User user) {
+        var candidateBundle = carouselCandidateService.collectCandidates(user.getId());
+        List<Long> displayIds = carouselShuffleService.selectDisplayIds(candidateBundle, user.getId());
+        if (displayIds.isEmpty()) {
+            return GetCarouselV2ListResponseDTO.of(List.of());
         }
 
-        List<CurationRawProduct> selected = new ArrayList<>();
+        Map<Long, CurationRawProduct> rawProductById = curationRawProductRepository.findAllById(displayIds).stream()
+                .collect(Collectors.toMap(CurationRawProduct::getId, Function.identity()));
 
-        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                userId,
-                cursor,
-                CAROUSEL_V2_SIZE,
-                List.of()
-        ));
-
-        List<GetCarouselResponseDTO> result = selected.stream()
+        List<GetCarouselResponseDTO> result = displayIds.stream()
+                .map(rawProductById::get)
+                .filter(java.util.Objects::nonNull)
                 .map(rawProduct -> GetCarouselResponseDTO.of(rawProduct.getId(), rawProduct.getProductImageUrl()))
                 .toList();
-        Long nextCursor = selected.size() < CAROUSEL_V2_SIZE
-                ? null
-                : selected.get(selected.size() - 1).getId();
 
-        return GetCarouselV2ListResponseDTO.of(result, nextCursor);
+        return GetCarouselV2ListResponseDTO.of(result);
     }
 
     @Override
@@ -114,130 +92,6 @@ public class CarouselServiceImpl implements CarouselService {
     public void likeCarouselV2WithLog(User user, Long rawProductId) {
         jjymService.likeRawProduct(user.getId(), rawProductId);
         carouselLikeLogService.createLikeLog(user, rawProductId);
-    }
-
-    private List<CurationRawProduct> getInitialCarouselV2Selection(Long userId) {
-        Long maxId = curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(userId);
-        if (maxId == null) {
-            return List.of();
-        }
-
-        List<CurationRawProduct> selected = new ArrayList<>();
-        addPreferredFurnitureProducts(userId, selected);
-        addFurnitureCategoryProducts(userId, selected);
-        addDiversifiedRandomProducts(userId, maxId, selected);
-
-        return selected.size() > CAROUSEL_V2_SIZE
-                ? new ArrayList<>(selected.subList(0, CAROUSEL_V2_SIZE))
-                : selected;
-    }
-
-    private void addPreferredFurnitureProducts(Long userId, List<CurationRawProduct> selected) {
-        if (selected.size() >= CAROUSEL_V2_SIZE) {
-            return;
-        }
-
-        List<Long> preferredFurnitureIds = resolveRecentSelectedFurnitureIds(userId);
-        if (preferredFurnitureIds.isEmpty()) {
-            return;
-        }
-
-        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
-                userId,
-                preferredFurnitureIds,
-                SoozipCategory.FURNITURE,
-                Math.min(PRIORITY_FURNITURE_MATCH_SIZE, CAROUSEL_V2_SIZE - selected.size()),
-                extractRawProductIds(selected)
-        ));
-    }
-
-    private void addFurnitureCategoryProducts(Long userId, List<CurationRawProduct> selected) {
-        if (selected.size() >= CAROUSEL_V2_SIZE) {
-            return;
-        }
-
-        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
-                userId,
-                SoozipCategory.FURNITURE,
-                CAROUSEL_V2_SIZE - selected.size(),
-                extractRawProductIds(selected)
-        ));
-    }
-
-    private void addDiversifiedRandomProducts(Long userId, Long maxId, List<CurationRawProduct> selected) {
-        if (selected.size() >= CAROUSEL_V2_SIZE) {
-            return;
-        }
-
-        List<Long> anchors = resolveRandomStartIds(userId, maxId);
-        for (int index = 0; index < anchors.size() && selected.size() < CAROUSEL_V2_SIZE; index++) {
-            int remaining = CAROUSEL_V2_SIZE - selected.size();
-            int perSegmentSize = Math.max(1, (int) Math.ceil((double) remaining / (anchors.size() - index)));
-            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                    userId,
-                    anchors.get(index) + 1L,
-                    perSegmentSize,
-                    extractRawProductIds(selected)
-            ));
-        }
-
-        if (selected.size() < CAROUSEL_V2_SIZE) {
-            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                    userId,
-                    null,
-                    CAROUSEL_V2_SIZE - selected.size(),
-                    extractRawProductIds(selected)
-            ));
-        }
-    }
-
-    private List<Long> resolveRecentSelectedFurnitureIds(Long userId) {
-        Optional<GenerateImage> recentGenerateImage = generateImageRepository.findMostRecentByUserId(userId);
-        if (recentGenerateImage.isEmpty() || recentGenerateImage.get().getHouse() == null) {
-            return List.of();
-        }
-
-        Long houseId = recentGenerateImage.get().getHouse().getId();
-        if (houseId == null) {
-            return List.of();
-        }
-
-        return houseFurnitureRepository.findAllByHouseIdWithFurniture(houseId).stream()
-                .map(HouseFurniture::getFurniture)
-                .filter(java.util.Objects::nonNull)
-                .map(furniture -> furniture.getId())
-                .filter(java.util.Objects::nonNull)
-                .distinct()
-                .toList();
-    }
-
-    private List<Long> resolveRandomStartIds(Long userId, Long maxId) {
-        if (maxId == null || maxId < 1L) {
-            return List.of();
-        }
-
-        long firstAnchor = resolveRandomStartId(userId, maxId);
-        long segmentSpan = Math.max(1L, maxId / RANDOM_SEGMENT_COUNT);
-        Set<Long> anchors = new LinkedHashSet<>();
-        anchors.add(firstAnchor);
-        for (int index = 1; index < RANDOM_SEGMENT_COUNT; index++) {
-            anchors.add(((firstAnchor + (segmentSpan * index) - 1L) % maxId) + 1L);
-        }
-        return anchors.stream().toList();
-    }
-
-    private List<Long> extractRawProductIds(List<CurationRawProduct> selected) {
-        return selected.stream()
-                .map(CurationRawProduct::getId)
-                .filter(java.util.Objects::nonNull)
-                .distinct()
-                .toList();
-    }
-
-    private long resolveRandomStartId(Long userId, Long maxId) {
-        long seed = java.time.LocalDate.now().toEpochDay() ^ userId;
-        long positive = Math.abs(seed == Long.MIN_VALUE ? 0L : seed);
-        return (positive % maxId) + 1L;
     }
 
     private void updateLike(Long userId, Long carouselId, boolean isLike) {

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
@@ -2,12 +2,17 @@ package or.sopt.houme.domain.house.service.carousel;
 
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.JjymService;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
 import or.sopt.houme.domain.preference.model.entity.CarouselPreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -20,14 +25,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CarouselServiceImpl implements CarouselService {
     private static final int CAROUSEL_V2_SIZE = 10;
+    private static final int PRIORITY_FURNITURE_MATCH_SIZE = 4;
+    private static final int RANDOM_SEGMENT_COUNT = 3;
 
     private final CarouselCacheService carouselCacheService;
     private final CarouselRepository carouselRepository;
@@ -36,6 +45,8 @@ public class CarouselServiceImpl implements CarouselService {
     private final CurationRawProductRepository curationRawProductRepository;
     private final JjymService jjymService;
     private final CarouselLikeLogService carouselLikeLogService;
+    private final GenerateImageRepository generateImageRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
 
     @Override
     public GetCarouselListResponseDTO getCarousel(int page) {
@@ -57,34 +68,25 @@ public class CarouselServiceImpl implements CarouselService {
     @Override
     public GetCarouselV2ListResponseDTO getCarouselV2(Long cursor, User user) {
         Long userId = user.getId();
-        List<CurationRawProduct> selected = new ArrayList<>();
-
-        Long effectiveCursor = cursor;
-        if (effectiveCursor == null) {
-            Long maxId = curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(userId);
-            if (maxId == null) {
-                return GetCarouselV2ListResponseDTO.of(List.of(), null);
-            }
-            long randomStartId = resolveRandomStartId(userId, maxId);
-            effectiveCursor = randomStartId + 1L;
+        if (cursor == null) {
+            List<CurationRawProduct> initialSelected = getInitialCarouselV2Selection(userId);
+            List<GetCarouselResponseDTO> initialResult = initialSelected.stream()
+                    .map(rawProduct -> GetCarouselResponseDTO.of(rawProduct.getId(), rawProduct.getProductImageUrl()))
+                    .toList();
+            Long nextCursor = initialSelected.size() < CAROUSEL_V2_SIZE
+                    ? null
+                    : initialSelected.get(initialSelected.size() - 1).getId();
+            return GetCarouselV2ListResponseDTO.of(initialResult, nextCursor);
         }
+
+        List<CurationRawProduct> selected = new ArrayList<>();
 
         selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
                 userId,
-                effectiveCursor,
+                cursor,
                 CAROUSEL_V2_SIZE,
                 List.of()
         ));
-
-        if (cursor == null && selected.size() < CAROUSEL_V2_SIZE) {
-            List<Long> excludedIds = selected.stream().map(CurationRawProduct::getId).toList();
-            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                    userId,
-                    null,
-                    CAROUSEL_V2_SIZE - selected.size(),
-                    excludedIds
-            ));
-        }
 
         List<GetCarouselResponseDTO> result = selected.stream()
                 .map(rawProduct -> GetCarouselResponseDTO.of(rawProduct.getId(), rawProduct.getProductImageUrl()))
@@ -95,6 +97,7 @@ public class CarouselServiceImpl implements CarouselService {
 
         return GetCarouselV2ListResponseDTO.of(result, nextCursor);
     }
+
     @Override
     @Transactional
     public void likeCarousel(User user, Long carouselId) {
@@ -111,6 +114,124 @@ public class CarouselServiceImpl implements CarouselService {
     public void likeCarouselV2WithLog(User user, Long rawProductId) {
         jjymService.likeRawProduct(user.getId(), rawProductId);
         carouselLikeLogService.createLikeLog(user, rawProductId);
+    }
+
+    private List<CurationRawProduct> getInitialCarouselV2Selection(Long userId) {
+        Long maxId = curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(userId);
+        if (maxId == null) {
+            return List.of();
+        }
+
+        List<CurationRawProduct> selected = new ArrayList<>();
+        addPreferredFurnitureProducts(userId, selected);
+        addFurnitureCategoryProducts(userId, selected);
+        addDiversifiedRandomProducts(userId, maxId, selected);
+
+        return selected.size() > CAROUSEL_V2_SIZE
+                ? new ArrayList<>(selected.subList(0, CAROUSEL_V2_SIZE))
+                : selected;
+    }
+
+    private void addPreferredFurnitureProducts(Long userId, List<CurationRawProduct> selected) {
+        if (selected.size() >= CAROUSEL_V2_SIZE) {
+            return;
+        }
+
+        List<Long> preferredFurnitureIds = resolveRecentSelectedFurnitureIds(userId);
+        if (preferredFurnitureIds.isEmpty()) {
+            return;
+        }
+
+        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+                userId,
+                preferredFurnitureIds,
+                SoozipCategory.FURNITURE,
+                Math.min(PRIORITY_FURNITURE_MATCH_SIZE, CAROUSEL_V2_SIZE - selected.size()),
+                extractRawProductIds(selected)
+        ));
+    }
+
+    private void addFurnitureCategoryProducts(Long userId, List<CurationRawProduct> selected) {
+        if (selected.size() >= CAROUSEL_V2_SIZE) {
+            return;
+        }
+
+        selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                userId,
+                SoozipCategory.FURNITURE,
+                CAROUSEL_V2_SIZE - selected.size(),
+                extractRawProductIds(selected)
+        ));
+    }
+
+    private void addDiversifiedRandomProducts(Long userId, Long maxId, List<CurationRawProduct> selected) {
+        if (selected.size() >= CAROUSEL_V2_SIZE) {
+            return;
+        }
+
+        List<Long> anchors = resolveRandomStartIds(userId, maxId);
+        for (int index = 0; index < anchors.size() && selected.size() < CAROUSEL_V2_SIZE; index++) {
+            int remaining = CAROUSEL_V2_SIZE - selected.size();
+            int perSegmentSize = Math.max(1, (int) Math.ceil((double) remaining / (anchors.size() - index)));
+            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                    userId,
+                    anchors.get(index) + 1L,
+                    perSegmentSize,
+                    extractRawProductIds(selected)
+            ));
+        }
+
+        if (selected.size() < CAROUSEL_V2_SIZE) {
+            selected.addAll(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                    userId,
+                    null,
+                    CAROUSEL_V2_SIZE - selected.size(),
+                    extractRawProductIds(selected)
+            ));
+        }
+    }
+
+    private List<Long> resolveRecentSelectedFurnitureIds(Long userId) {
+        Optional<GenerateImage> recentGenerateImage = generateImageRepository.findMostRecentByUserId(userId);
+        if (recentGenerateImage.isEmpty() || recentGenerateImage.get().getHouse() == null) {
+            return List.of();
+        }
+
+        Long houseId = recentGenerateImage.get().getHouse().getId();
+        if (houseId == null) {
+            return List.of();
+        }
+
+        return houseFurnitureRepository.findAllByHouseIdWithFurniture(houseId).stream()
+                .map(HouseFurniture::getFurniture)
+                .filter(java.util.Objects::nonNull)
+                .map(furniture -> furniture.getId())
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<Long> resolveRandomStartIds(Long userId, Long maxId) {
+        if (maxId == null || maxId < 1L) {
+            return List.of();
+        }
+
+        long firstAnchor = resolveRandomStartId(userId, maxId);
+        long segmentSpan = Math.max(1L, maxId / RANDOM_SEGMENT_COUNT);
+        Set<Long> anchors = new LinkedHashSet<>();
+        anchors.add(firstAnchor);
+        for (int index = 1; index < RANDOM_SEGMENT_COUNT; index++) {
+            anchors.add(((firstAnchor + (segmentSpan * index) - 1L) % maxId) + 1L);
+        }
+        return anchors.stream().toList();
+    }
+
+    private List<Long> extractRawProductIds(List<CurationRawProduct> selected) {
+        return selected.stream()
+                .map(CurationRawProduct::getId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     private long resolveRandomStartId(Long userId, Long maxId) {

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
@@ -1,0 +1,134 @@
+package or.sopt.houme.domain.house.service.carousel;
+
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+public class CarouselShuffleService {
+
+    private static final int TARGET_SIZE = 100;
+
+    public List<Long> selectDisplayIds(CarouselCandidateBundle bundle, Long userId) {
+        LinkedHashSet<Long> selectedIds = new LinkedHashSet<>();
+        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), 11L));
+        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), 23L));
+
+        Map<SoozipCategory, ShuffledBucket> otherBuckets = new LinkedHashMap<>();
+        long salt = 31L;
+        for (Map.Entry<SoozipCategory, List<Long>> entry : bundle.otherCategoryIds().entrySet()) {
+            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), salt++)));
+        }
+        List<ShuffledBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
+
+        int otherIndex = 0;
+        while (selectedIds.size() < TARGET_SIZE && hasAnyRemaining(selectedBucket, furnitureBucket, rotatingOtherBuckets)) {
+            addNext(selectedIds, selectedBucket);
+            addNext(selectedIds, selectedBucket);
+            addNext(selectedIds, furnitureBucket);
+
+            if (!rotatingOtherBuckets.isEmpty()) {
+                addNext(selectedIds, rotatingOtherBuckets.get(otherIndex % rotatingOtherBuckets.size()));
+                otherIndex++;
+            }
+        }
+
+        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), 97L));
+        while (selectedIds.size() < TARGET_SIZE && fallbackBucket.hasNext()) {
+            addNext(selectedIds, fallbackBucket);
+        }
+
+        return new ArrayList<>(selectedIds);
+    }
+
+    private boolean hasAnyRemaining(ShuffledBucket selectedBucket, ShuffledBucket furnitureBucket, List<ShuffledBucket> otherBuckets) {
+        if (selectedBucket.hasNext() || furnitureBucket.hasNext()) {
+            return true;
+        }
+
+        return otherBuckets.stream().anyMatch(ShuffledBucket::hasNext);
+    }
+
+    private void addNext(Set<Long> selectedIds, ShuffledBucket bucket) {
+        while (bucket.hasNext()) {
+            Long nextId = bucket.next();
+            if (nextId != null && selectedIds.add(nextId)) {
+                return;
+            }
+        }
+    }
+
+    private long computeSeed(Long userId, Long recentImageId, long salt) {
+        long baseUserId = userId == null ? 0L : userId;
+        long baseImageId = recentImageId == null ? 0L : recentImageId;
+        long epochDay = LocalDate.now().toEpochDay();
+        return (baseUserId * 31L) ^ (baseImageId * 17L) ^ (epochDay * 13L) ^ salt;
+    }
+
+    private static final class ShuffledBucket {
+        private final List<Long> source;
+        private final int size;
+        private final int start;
+        private final int step;
+        private int attempts;
+
+        private ShuffledBucket(List<Long> candidateIds, long seed) {
+            this.source = candidateIds == null ? List.of() : candidateIds.stream()
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .toList();
+            this.size = this.source.size();
+            this.start = size == 0 ? 0 : Math.floorMod(seed, size);
+            this.step = size <= 1 ? 1 : resolveStep(seed, size);
+            this.attempts = 0;
+        }
+
+        private boolean hasNext() {
+            return attempts < size;
+        }
+
+        private Long next() {
+            if (!hasNext()) {
+                return null;
+            }
+
+            int index = size == 0 ? 0 : Math.floorMod(start + (attempts * step), size);
+            attempts++;
+            return source.get(index);
+        }
+
+        private int resolveStep(long seed, int size) {
+            int candidate = (int) Math.floorMod((seed * 7L) + 5L, size);
+            if (candidate == 0) {
+                candidate = 1;
+            }
+            while (gcd(candidate, size) != 1) {
+                candidate++;
+                if (candidate >= size) {
+                    candidate = 1;
+                }
+            }
+            return candidate;
+        }
+
+        private int gcd(int left, int right) {
+            int first = Math.abs(left);
+            int second = Math.abs(right);
+            while (second != 0) {
+                int remainder = first % second;
+                first = second;
+                second = remainder;
+            }
+            return first == 0 ? 1 : first;
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -20,13 +21,14 @@ public class CarouselShuffleService {
 
     public List<Long> selectDisplayIds(CarouselCandidateBundle bundle, Long userId) {
         LinkedHashSet<Long> selectedIds = new LinkedHashSet<>();
-        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), 11L));
-        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), 23L));
+        long epochDay = LocalDate.now(ZoneOffset.UTC).toEpochDay();
+        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 11L));
+        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 23L));
 
         Map<SoozipCategory, ShuffledBucket> otherBuckets = new LinkedHashMap<>();
         long salt = 31L;
         for (Map.Entry<SoozipCategory, List<Long>> entry : bundle.otherCategoryIds().entrySet()) {
-            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), salt++)));
+            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), epochDay, salt++)));
         }
         List<ShuffledBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
 
@@ -42,7 +44,7 @@ public class CarouselShuffleService {
             }
         }
 
-        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), 97L));
+        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 97L));
         while (selectedIds.size() < TARGET_SIZE && fallbackBucket.hasNext()) {
             addNext(selectedIds, fallbackBucket);
         }
@@ -67,10 +69,9 @@ public class CarouselShuffleService {
         }
     }
 
-    private long computeSeed(Long userId, Long recentImageId, long salt) {
+    private long computeSeed(Long userId, Long recentImageId, long epochDay, long salt) {
         long baseUserId = userId == null ? 0L : userId;
         long baseImageId = recentImageId == null ? 0L : recentImageId;
-        long epochDay = LocalDate.now().toEpochDay();
         return (baseUserId * 31L) ^ (baseImageId * 17L) ^ (epochDay * 13L) ^ salt;
     }
 

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/dto/CarouselCandidateBundle.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/dto/CarouselCandidateBundle.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.domain.house.service.carousel.dto;
+
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+
+import java.util.List;
+import java.util.Map;
+
+public record CarouselCandidateBundle(
+        Long recentImageId,
+        List<Long> selectedFurnitureIds,
+        List<Long> furnitureCategoryIds,
+        Map<SoozipCategory, List<Long>> otherCategoryIds,
+        List<Long> fallbackIds
+) {
+}

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
@@ -104,9 +104,9 @@ class CarouselControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").exists())
                 .andExpect(jsonPath("$.data.carouselResponseDTOS", hasSize(2)))
-                .andExpect(jsonPath("$.data.carouselResponseDTOS[0].carouselId").value(1))
+                .andExpect(jsonPath("$.data.carouselResponseDTOS[0].rawProductId").value(1))
                 .andExpect(jsonPath("$.data.carouselResponseDTOS[0].url").value("url1"))
-                .andExpect(jsonPath("$.data.carouselResponseDTOS[1].carouselId").value(2))
+                .andExpect(jsonPath("$.data.carouselResponseDTOS[1].rawProductId").value(2))
                 .andExpect(jsonPath("$.data.carouselResponseDTOS[1].url").value("url2"));
     }
 
@@ -131,9 +131,9 @@ class CarouselControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.msg").exists())
                 .andExpect(jsonPath("$.data.carousels", hasSize(2)))
-                .andExpect(jsonPath("$.data.carousels[0].carouselId").value(11))
+                .andExpect(jsonPath("$.data.carousels[0].rawProductId").value(11))
                 .andExpect(jsonPath("$.data.carousels[0].url").value("url11"))
-                .andExpect(jsonPath("$.data.carousels[1].carouselId").value(12))
+                .andExpect(jsonPath("$.data.carousels[1].rawProductId").value(12))
                 .andExpect(jsonPath("$.data.carousels[1].url").value("url12"));
     }
 

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
@@ -119,11 +119,12 @@ class CarouselControllerTest {
                 new GetCarouselResponseDTO(12L, "url12")
         );
         GetCarouselV2ListResponseDTO responseDTO = GetCarouselV2ListResponseDTO.of(mockList);
-        when(carouselService.getCarouselV2(any())).thenReturn(responseDTO);
+        when(carouselService.getCarouselV2(any(), eq(List.of(10L, 20L)))).thenReturn(responseDTO);
 
         setAuthentication(testUserDetails);
 
         mockMvc.perform(get("/api/v2/carousels")
+                        .param("furnitureIds", "10", "20")
                         .requestAttr("userDetails", testUserDetails)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -134,6 +135,18 @@ class CarouselControllerTest {
                 .andExpect(jsonPath("$.data.carousels[0].url").value("url11"))
                 .andExpect(jsonPath("$.data.carousels[1].carouselId").value(12))
                 .andExpect(jsonPath("$.data.carousels[1].url").value("url12"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/carousels 요청 시 furnitureIds가 없으면 400을 반환한다")
+    @WithMockUser()
+    void getCarouselsV2_returnsBadRequest_whenFurnitureIdsMissing() throws Exception {
+        setAuthentication(testUserDetails);
+
+        mockMvc.perform(get("/api/v2/carousels")
+                        .requestAttr("userDetails", testUserDetails)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
@@ -2,6 +2,7 @@ package or.sopt.houme.domain.house.presentation.carousel.controller;
 
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
+import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.house.service.carousel.CarouselLikeLogService;
 import or.sopt.houme.domain.house.service.carousel.facade.CarouselOptimisticLockFacade;
 import or.sopt.houme.domain.house.service.carousel.CarouselService;
@@ -107,6 +108,32 @@ class CarouselControllerTest {
                 .andExpect(jsonPath("$.data.carouselResponseDTOS[0].url").value("url1"))
                 .andExpect(jsonPath("$.data.carouselResponseDTOS[1].carouselId").value(2))
                 .andExpect(jsonPath("$.data.carouselResponseDTOS[1].url").value("url2"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/carousels 요청 시 100개 이하의 캐러셀 응답을 반환한다")
+    @WithMockUser()
+    void getCarouselsV2_returnsCarouselList() throws Exception {
+        List<GetCarouselResponseDTO> mockList = List.of(
+                new GetCarouselResponseDTO(11L, "url11"),
+                new GetCarouselResponseDTO(12L, "url12")
+        );
+        GetCarouselV2ListResponseDTO responseDTO = GetCarouselV2ListResponseDTO.of(mockList);
+        when(carouselService.getCarouselV2(any())).thenReturn(responseDTO);
+
+        setAuthentication(testUserDetails);
+
+        mockMvc.perform(get("/api/v2/carousels")
+                        .requestAttr("userDetails", testUserDetails)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").exists())
+                .andExpect(jsonPath("$.data.carousels", hasSize(2)))
+                .andExpect(jsonPath("$.data.carousels[0].carouselId").value(11))
+                .andExpect(jsonPath("$.data.carousels[0].url").value("url11"))
+                .andExpect(jsonPath("$.data.carousels[1].carouselId").value(12))
+                .andExpect(jsonPath("$.data.carousels[1].url").value("url12"));
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselListResponseDTOTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselListResponseDTOTest.java
@@ -22,7 +22,7 @@ class GetCarouselListResponseDTOTest {
 
         // then
         assertThat(result.carouselResponseDTOS()).hasSize(2);
-        assertThat(result.carouselResponseDTOS().get(0).carouselId()).isEqualTo(1L);
+        assertThat(result.carouselResponseDTOS().get(0).rawProductId()).isEqualTo(1L);
         assertThat(result.carouselResponseDTOS().get(1).url()).isEqualTo("https://example.com/image2.jpg");
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselResponseDTOTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/dto/GetCarouselResponseDTOTest.java
@@ -24,7 +24,7 @@ class GetCarouselResponseDTOTest {
         GetCarouselResponseDTO dto = GetCarouselResponseDTO.from(carousel);
 
         // then
-        assertThat(dto.carouselId()).isEqualTo(1L);
+        assertThat(dto.rawProductId()).isEqualTo(1L);
         assertThat(dto.url()).isEqualTo("https://example.com/image.jpg");
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
@@ -1,0 +1,97 @@
+package or.sopt.houme.domain.house.service.carousel;
+
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CarouselCandidateServiceTest {
+
+    @InjectMocks
+    private CarouselCandidateService carouselCandidateService;
+
+    @Mock
+    private CurationRawProductRepository curationRawProductRepository;
+
+    @Test
+    @DisplayName("후보군 조회 시 이전 버킷의 상품 ID를 excludedIds로 누적 전달한다")
+    void collectCandidates_accumulatesExcludedIdsAcrossBuckets() {
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+                1L,
+                List.of(10L, 20L),
+                SoozipCategory.FURNITURE,
+                160,
+                List.of()
+        )).thenReturn(List.of(rawProduct(101L)));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                1L,
+                SoozipCategory.FURNITURE,
+                160,
+                List.of(101L)
+        )).thenReturn(List.of(rawProduct(102L)));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.LIGHTING),
+                eq(60),
+                eq(List.of(101L, 102L))
+        )).thenReturn(List.of(rawProduct(103L)));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.LIVING_GOODS),
+                eq(60),
+                eq(List.of(101L, 102L, 103L))
+        )).thenReturn(List.of(rawProduct(104L)));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.HOME_FABRIC),
+                eq(60),
+                eq(List.of(101L, 102L, 103L, 104L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.ACCESSORY),
+                eq(60),
+                eq(List.of(101L, 102L, 103L, 104L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.MINI_ELECTRONICS),
+                eq(60),
+                eq(List.of(101L, 102L, 103L, 104L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                1L,
+                null,
+                220,
+                List.of(101L, 102L, 103L, 104L)
+        )).thenReturn(List.of(rawProduct(105L)));
+
+        CarouselCandidateBundle result = carouselCandidateService.collectCandidates(1L, List.of(10L, 20L));
+
+        assertThat(result.selectedFurnitureIds()).containsExactly(101L);
+        assertThat(result.furnitureCategoryIds()).containsExactly(102L);
+        assertThat(result.otherCategoryIds().get(SoozipCategory.LIGHTING)).containsExactly(103L);
+        assertThat(result.otherCategoryIds().get(SoozipCategory.LIVING_GOODS)).containsExactly(104L);
+        assertThat(result.fallbackIds()).containsExactly(105L);
+    }
+
+    private CurationRawProduct rawProduct(Long id) {
+        return CurationRawProduct.builder()
+                .id(id)
+                .productImageUrl("image-" + id)
+                .build();
+    }
+}

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -130,12 +130,12 @@ class CarouselServiceImplTest {
                 List.of(101L, 102L, 103L)
         );
 
-        when(carouselCandidateService.collectCandidates(1L)).thenReturn(candidateBundle);
+        when(carouselCandidateService.collectCandidates(1L, List.of(21L, 22L))).thenReturn(candidateBundle);
         when(carouselShuffleService.selectDisplayIds(candidateBundle, 1L)).thenReturn(List.of(103L, 101L, 102L));
         when(curationRawProductRepository.findAllById(List.of(103L, 101L, 102L)))
                 .thenReturn(List.of(rawProduct1, rawProduct2, rawProduct3));
 
-        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(user);
+        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(user, List.of(21L, 22L));
 
         assertThat(result.carousels()).hasSize(3);
         assertThat(result.carousels())

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -103,7 +103,7 @@ class CarouselServiceImplTest {
         // then
         assertThat(result.carouselResponseDTOS()).hasSize(2);
         assertThat(result.carouselResponseDTOS())
-                .extracting("carouselId")
+                .extracting("rawProductId")
                 .containsExactlyInAnyOrder(1L, 2L);
     }
 
@@ -139,7 +139,7 @@ class CarouselServiceImplTest {
 
         assertThat(result.carousels()).hasSize(3);
         assertThat(result.carousels())
-                .extracting("carouselId")
+                .extracting("rawProductId")
                 .containsExactly(103L, 101L, 102L);
         verifyNoInteractions(jjymService);
     }

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -1,22 +1,15 @@
 package or.sopt.houme.domain.house.service.carousel;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
-import or.sopt.houme.domain.furniture.model.entity.Furniture;
-import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
-import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.JjymService;
-import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
-import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
 import or.sopt.houme.domain.house.model.carousel.entity.CarouselType;
-import or.sopt.houme.domain.house.model.entity.House;
-import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
-import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
+import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import or.sopt.houme.domain.preference.model.entity.CarouselPreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
 import or.sopt.houme.domain.preference.repository.CarouselPreferenceRepository;
@@ -65,10 +58,10 @@ class CarouselServiceImplTest {
     private JjymService jjymService;
 
     @Mock
-    private GenerateImageRepository generateImageRepository;
+    private CarouselCandidateService carouselCandidateService;
 
     @Mock
-    private HouseFurnitureRepository houseFurnitureRepository;
+    private CarouselShuffleService carouselShuffleService;
 
     private User user;
     private Carousel carousel;
@@ -115,101 +108,40 @@ class CarouselServiceImplTest {
     }
 
     @Test
-    @DisplayName("getCarouselV2() 초기 조회는 선택 가구와 furniture 카테고리를 우선 노출한다")
+    @DisplayName("getCarouselV2()는 후보군 셔플 결과 순서대로 100개 캐러셀 응답을 조립한다")
     void getCarouselV2_returnsExposedRawProductsExcludingLikedProducts() {
-        CurationRawProduct preferredRawProduct = CurationRawProduct.builder()
+        CurationRawProduct rawProduct1 = CurationRawProduct.builder()
                 .id(101L)
                 .productImageUrl("image-101")
-                .category(SoozipCategory.FURNITURE)
                 .build();
-        CurationRawProduct furnitureRawProduct = CurationRawProduct.builder()
+        CurationRawProduct rawProduct2 = CurationRawProduct.builder()
                 .id(102L)
                 .productImageUrl("image-102")
-                .category(SoozipCategory.FURNITURE)
                 .build();
-        CurationRawProduct randomRawProduct = CurationRawProduct.builder()
+        CurationRawProduct rawProduct3 = CurationRawProduct.builder()
                 .id(103L)
                 .productImageUrl("image-103")
                 .build();
-        FurnitureType furnitureType = FurnitureType.builder()
-                .id(11L)
-                .nameKr("의자")
-                .nameEng("CHAIR")
-                .build();
-        Furniture furniture = Furniture.builder()
-                .id(21L)
-                .furnitureType(furnitureType)
-                .furnitureNameKr("의자")
-                .furnitureNameEng("CHAIR")
-                .build();
-        House house = House.builder()
-                .id(31L)
-                .build();
-        GenerateImage generateImage = GenerateImage.builder()
-                .house(house)
-                .build();
-        HouseFurniture houseFurniture = HouseFurniture.builder()
-                .id(41L)
-                .house(house)
-                .furniture(furniture)
-                .build();
+        CarouselCandidateBundle candidateBundle = new CarouselCandidateBundle(
+                500L,
+                List.of(1L, 2L),
+                List.of(3L, 4L),
+                java.util.Map.of(),
+                List.of(101L, 102L, 103L)
+        );
 
-        when(curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(1L)).thenReturn(200L);
-        when(generateImageRepository.findMostRecentByUserId(1L)).thenReturn(Optional.of(generateImage));
-        when(houseFurnitureRepository.findAllByHouseIdWithFurniture(31L)).thenReturn(List.of(houseFurniture));
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
-                eq(1L), eq(List.of(21L)), eq(SoozipCategory.FURNITURE), eq(4), eq(List.of())
-        )).thenReturn(List.of(preferredRawProduct));
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
-                eq(1L), eq(SoozipCategory.FURNITURE), eq(9), eq(List.of(101L))
-        )).thenReturn(List.of(furnitureRawProduct));
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                eq(1L), anyLong(), anyInt(), anyList()
-        )).thenReturn(List.of(randomRawProduct), List.of(), List.of());
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                eq(1L), isNull(), anyInt(), anyList()
-        )).thenReturn(List.of());
+        when(carouselCandidateService.collectCandidates(1L)).thenReturn(candidateBundle);
+        when(carouselShuffleService.selectDisplayIds(candidateBundle, 1L)).thenReturn(List.of(103L, 101L, 102L));
+        when(curationRawProductRepository.findAllById(List.of(103L, 101L, 102L)))
+                .thenReturn(List.of(rawProduct1, rawProduct2, rawProduct3));
 
-        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(null, user);
+        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(user);
 
         assertThat(result.carousels()).hasSize(3);
         assertThat(result.carousels())
                 .extracting("carouselId")
-                .containsExactly(101L, 102L, 103L);
-        assertThat(result.nextCursor()).isNull();
-        verify(curationRawProductRepository, times(1))
-                .findExposedRawProductsExcludingLikedByUserByFurnitureIds(eq(1L), eq(List.of(21L)), eq(SoozipCategory.FURNITURE), eq(4), eq(List.of()));
-        verify(curationRawProductRepository, times(1))
-                .findExposedRawProductsExcludingLikedByUserByCategory(eq(1L), eq(SoozipCategory.FURNITURE), eq(9), eq(List.of(101L)));
+                .containsExactly(103L, 101L, 102L);
         verifyNoInteractions(jjymService);
-    }
-
-    @Test
-    @DisplayName("getCarouselV2() 커서 조회는 기존 커서 기준 연속 조회를 유지한다")
-    void getCarouselV2_withCursor_usesCursorQueryOnly() {
-        CurationRawProduct rawProduct1 = CurationRawProduct.builder()
-                .id(88L)
-                .productImageUrl("image-88")
-                .build();
-        CurationRawProduct rawProduct2 = CurationRawProduct.builder()
-                .id(77L)
-                .productImageUrl("image-77")
-                .build();
-
-        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                1L,
-                90L,
-                10,
-                List.of()
-        )).thenReturn(List.of(rawProduct1, rawProduct2));
-
-        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(90L, user);
-
-        assertThat(result.carousels())
-                .extracting("carouselId")
-                .containsExactly(88L, 77L);
-        assertThat(result.nextCursor()).isNull();
-        verifyNoInteractions(generateImageRepository, houseFurnitureRepository);
     }
 
 

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -1,13 +1,21 @@
 package or.sopt.houme.domain.house.service.carousel;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.service.JjymService;
+import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselResponseDTO;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselV2ListResponseDTO;
 import or.sopt.houme.domain.house.model.carousel.entity.Carousel;
 import or.sopt.houme.domain.house.model.carousel.entity.CarouselType;
+import or.sopt.houme.domain.house.model.entity.House;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.carousel.CarouselRepository;
 import or.sopt.houme.domain.preference.model.entity.CarouselPreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -56,6 +64,12 @@ class CarouselServiceImplTest {
     @Mock
     private JjymService jjymService;
 
+    @Mock
+    private GenerateImageRepository generateImageRepository;
+
+    @Mock
+    private HouseFurnitureRepository houseFurnitureRepository;
+
     private User user;
     private Carousel carousel;
 
@@ -101,31 +115,101 @@ class CarouselServiceImplTest {
     }
 
     @Test
-    @DisplayName("getCarouselV2()는 사용자 찜 제외를 DB 쿼리에서 처리한 결과를 반환한다")
+    @DisplayName("getCarouselV2() 초기 조회는 선택 가구와 furniture 카테고리를 우선 노출한다")
     void getCarouselV2_returnsExposedRawProductsExcludingLikedProducts() {
-        CurationRawProduct rawProduct1 = CurationRawProduct.builder()
+        CurationRawProduct preferredRawProduct = CurationRawProduct.builder()
                 .id(101L)
                 .productImageUrl("image-101")
+                .category(SoozipCategory.FURNITURE)
                 .build();
-        CurationRawProduct rawProduct2 = CurationRawProduct.builder()
+        CurationRawProduct furnitureRawProduct = CurationRawProduct.builder()
                 .id(102L)
                 .productImageUrl("image-102")
+                .category(SoozipCategory.FURNITURE)
+                .build();
+        CurationRawProduct randomRawProduct = CurationRawProduct.builder()
+                .id(103L)
+                .productImageUrl("image-103")
+                .build();
+        FurnitureType furnitureType = FurnitureType.builder()
+                .id(11L)
+                .nameKr("의자")
+                .nameEng("CHAIR")
+                .build();
+        Furniture furniture = Furniture.builder()
+                .id(21L)
+                .furnitureType(furnitureType)
+                .furnitureNameKr("의자")
+                .furnitureNameEng("CHAIR")
+                .build();
+        House house = House.builder()
+                .id(31L)
+                .build();
+        GenerateImage generateImage = GenerateImage.builder()
+                .house(house)
+                .build();
+        HouseFurniture houseFurniture = HouseFurniture.builder()
+                .id(41L)
+                .house(house)
+                .furniture(furniture)
                 .build();
 
         when(curationRawProductRepository.findMaxExposedRawProductIdExcludingLikedByUser(1L)).thenReturn(200L);
+        when(generateImageRepository.findMostRecentByUserId(1L)).thenReturn(Optional.of(generateImage));
+        when(houseFurnitureRepository.findAllByHouseIdWithFurniture(31L)).thenReturn(List.of(houseFurniture));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+                eq(1L), eq(List.of(21L)), eq(SoozipCategory.FURNITURE), eq(4), eq(List.of())
+        )).thenReturn(List.of(preferredRawProduct));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L), eq(SoozipCategory.FURNITURE), eq(9), eq(List.of(101L))
+        )).thenReturn(List.of(furnitureRawProduct));
         when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
-                eq(1L), anyLong(), eq(10), eq(List.of())
-        )).thenReturn(List.of(rawProduct1, rawProduct2));
+                eq(1L), anyLong(), anyInt(), anyList()
+        )).thenReturn(List.of(randomRawProduct), List.of(), List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                eq(1L), isNull(), anyInt(), anyList()
+        )).thenReturn(List.of());
 
         GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(null, user);
 
-        assertThat(result.carousels()).hasSize(2);
-        assertThat(result.carousels().get(0).carouselId()).isEqualTo(101L);
-        assertThat(result.carousels().get(1).carouselId()).isEqualTo(102L);
+        assertThat(result.carousels()).hasSize(3);
+        assertThat(result.carousels())
+                .extracting("carouselId")
+                .containsExactly(101L, 102L, 103L);
         assertThat(result.nextCursor()).isNull();
         verify(curationRawProductRepository, times(1))
-                .findExposedRawProductsExcludingLikedByUserWithCursor(eq(1L), anyLong(), eq(10), eq(List.of()));
+                .findExposedRawProductsExcludingLikedByUserByFurnitureIds(eq(1L), eq(List.of(21L)), eq(SoozipCategory.FURNITURE), eq(4), eq(List.of()));
+        verify(curationRawProductRepository, times(1))
+                .findExposedRawProductsExcludingLikedByUserByCategory(eq(1L), eq(SoozipCategory.FURNITURE), eq(9), eq(List.of(101L)));
         verifyNoInteractions(jjymService);
+    }
+
+    @Test
+    @DisplayName("getCarouselV2() 커서 조회는 기존 커서 기준 연속 조회를 유지한다")
+    void getCarouselV2_withCursor_usesCursorQueryOnly() {
+        CurationRawProduct rawProduct1 = CurationRawProduct.builder()
+                .id(88L)
+                .productImageUrl("image-88")
+                .build();
+        CurationRawProduct rawProduct2 = CurationRawProduct.builder()
+                .id(77L)
+                .productImageUrl("image-77")
+                .build();
+
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserWithCursor(
+                1L,
+                90L,
+                10,
+                List.of()
+        )).thenReturn(List.of(rawProduct1, rawProduct2));
+
+        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(90L, user);
+
+        assertThat(result.carousels())
+                .extracting("carouselId")
+                .containsExactly(88L, 77L);
+        assertThat(result.nextCursor()).isNull();
+        verifyNoInteractions(generateImageRepository, houseFurnitureRepository);
     }
 
 


### PR DESCRIPTION
## 📣 Related Issue
- close #551

## 📝 Summary
- `/api/v2/carousels` 조회 방식을 기존 cursor 기반 10개 조회에서, 한 번에 100개를 내려주는 구조로 변경했습니다.
- 캐러셀 후보군을 `선택 가구 기반 상품`, `furniture 카테고리 상품`, `기타 카테고리 상품`, `fallback 상품`으로 나누고, 이를 조합해 우선순위와 다양성을 함께 반영하도록 개선했습니다.
- 버킷 내부 순서는 후보 리스트 기준의 이중 해싱 모방 셔플 방식으로 구성해, 연속 id 조회에서 발생하던 상품 지역성 문제를 줄였습니다.
- `/api/v2/carousels` 요청 시 `furnitureIds`를 필수값으로 받아, 현재 생성 중인 이미지에서 선택한 가구 기준으로 후보군이 구성되도록 변경했습니다.
- 캐러셀 응답 DTO의 식별자 필드명을 `carouselId`에서 `rawProductId`로 변경해, 실제 의미가 원상품 id임을 명확히 했습니다.

## 🙏 Question & PR point
- 이제 `/api/v2/carousels`는 `cursor` 없이 동작하며, `furnitureIds`를 필수로 전달해야 합니다.
- 응답 json 아래와 같이 변경되었습니다.
```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "carousels": [
      {
        "rawProductId": 24,
        "url": "https://google.com/selected-1"
      },
      {
        "rawProductId": 23,
        "url": "https://placehold.co/1024x1024/png?text=raw-23"
      },
      {
        "rawProductId": 22,
        "url": "https://placehold.co/1024x1024/png?text=raw-22"
      },
      {
        "rawProductId": 21,
        "url": "https://placehold.co/1024x1024/png?text=raw-21"
      },
      {
        "rawProductId": 20,
        "url": "https://placehold.co/1024x1024/png?text=raw-20"
      }
    ]
  }
}
```


## 📬 Postman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 캐러셀 V2가 커서 기반에서 가구 ID 기반 조회로 변경되어, 요청한 가구에 맞춘 추천을 제공합니다.
  * 카테고리별 필터링 및 사용자 좋아요 제외 로직 강화로 관련성 높은 상품을 노출합니다.
  * 한 번에 조회 가능한 캐러셀 수가 확대되어 최대 100개까지 반환됩니다.

* **Behavior Changes**
  * 응답 항목 식별자가 carouselId에서 rawProductId로 변경되었습니다.
  * V2 요청에 furnitureIds가 없으면 400 Bad Request를 반환합니다.

* **Tests**
  * 캐러셀 관련 테스트들이 새로운 입력/출력 규격에 맞게 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->