### PR TITLE
[FEAT] 어드민 이미지 자동 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,7 @@ jib {
         format = 'Docker'
     }
     // cwebp 실행파일을 도커 이미지에 포함 + 실행권한 부여
+    // cwebp 바이너리: EC2가 t3.small -> libwebp 1.5.0 linux-x86-64 (amd64 static-pie)
     extraDirectories {
         paths {
             path {

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,16 @@ jib {
         creationTime = "USE_CURRENT_TIMESTAMP"
         format = 'Docker'
     }
+    // cwebp 실행파일을 도커 이미지에 포함 + 실행권한 부여
+    extraDirectories {
+        paths {
+            path {
+                from = file('src/main/jib')
+                into = '/'
+            }
+        }
+        permissions = ['/app/bin/cwebp': '755']
+    }
 }
 
 jacoco {

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -172,6 +172,7 @@ public enum ErrorCode {
     IMAGE_DELETE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50006 ,"이미지 삭제에 실패하였습니다. 서버관리자에게 문의해주세요" ),
     IMAGE_DOWNLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50022, "이미지 다운로드 중, AWS 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     IMAGE_VARIANT_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50023, "최적화 이미지 업로드 중, 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
+    IMAGE_LIST_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50024, "이미지 목록 조회 중, AWS 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     HTTP_MEDIA_TYPE_NOT_ACCEPTABLE(HttpStatus.INTERNAL_SERVER_ERROR,50007,"HTTP 리퀘스트 타입에 오류가 발생하였습니다"),
     INCODING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50008 ,"인코딩 과정 중 예외가 발생하였습니다" ),
     CHAT_GPT_CALL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50009 ,"챗 gpt 호출 중 예외가 발생하였습니다" ),

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -170,6 +170,8 @@ public enum ErrorCode {
     IMAGE_UPLOAD_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "이미지 업로드 중, IO 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     IMAGE_STILL_EXIST(HttpStatus.INTERNAL_SERVER_ERROR,50005 ,"이미지가 삭제되지 않고 S3에 남아있습니다. 서버 관리자에게 문의해주세요" ),
     IMAGE_DELETE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50006 ,"이미지 삭제에 실패하였습니다. 서버관리자에게 문의해주세요" ),
+    IMAGE_DOWNLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50022, "이미지 다운로드 중, AWS 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
+    IMAGE_VARIANT_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 50023, "최적화 이미지 업로드 중, 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     HTTP_MEDIA_TYPE_NOT_ACCEPTABLE(HttpStatus.INTERNAL_SERVER_ERROR,50007,"HTTP 리퀘스트 타입에 오류가 발생하였습니다"),
     INCODING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50008 ,"인코딩 과정 중 예외가 발생하였습니다" ),
     CHAT_GPT_CALL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,50009 ,"챗 gpt 호출 중 예외가 발생하였습니다" ),

--- a/src/main/java/or/sopt/houme/global/image/ImageOptimizationException.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageOptimizationException.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.global.image;
+
+/**
+ * 이미지 최적화(리사이즈/WebP 변환) 과정에서 발생하는 예외
+ */
+public class ImageOptimizationException extends RuntimeException {
+
+    public ImageOptimizationException(String message) {
+        super(message);
+    }
+
+    public ImageOptimizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
@@ -4,10 +4,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 
 /**
  * 원본 이미지(byte[])를 cwebp로 리사이즈 + WebP 변환하는 유틸
@@ -44,30 +50,37 @@ public class ImageOptimizer {
     public byte[] toResizedWebp(byte[] source, int width) {
         Path input = null;
         Path output = null;
+        Path processLog = null;
         try {
             input = Files.createTempFile("houme-img-src-", ".bin");
             output = Files.createTempFile("houme-img-out-", ".webp");
+            processLog = Files.createTempFile("houme-img-log-", ".txt");
             Files.write(input, source);
 
+            // cwebp 진단 출력을 파이프 대신 임시 파일로 보냄
+            // -> waitFor()를 먼저 해도 파이프 버퍼가 차서 자식 프로세스가 멈추는 deadlock이 없음
             Process process = new ProcessBuilder(
                     cwebpPath, "-quiet",
                     "-resize", String.valueOf(width), "0",
                     input.toString(), "-o", output.toString())
                     .redirectErrorStream(true)
+                    .redirectOutput(processLog.toFile())
                     .start();
 
             boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                // 강제 종료가 실제로 끝날 때까지 대기 (프로세스/FD 정리)
+                process.waitFor(5, TimeUnit.SECONDS);
                 throw new ImageOptimizationException(
                         "cwebp 변환이 " + processTimeoutSeconds + "초 내에 완료되지 않았습니다. width=" + width);
             }
 
             int exitCode = process.exitValue();
             if (exitCode != 0) {
-                String processLog = new String(process.getInputStream().readAllBytes()).trim();
+                String diagnostics = Files.readString(processLog).trim();
                 throw new ImageOptimizationException(
-                        "cwebp 변환 실패. exitCode=" + exitCode + ", width=" + width + ", log=" + processLog);
+                        "cwebp 변환 실패. exitCode=" + exitCode + ", width=" + width + ", log=" + diagnostics);
             }
 
             byte[] result = Files.readAllBytes(output);
@@ -84,7 +97,34 @@ public class ImageOptimizer {
         } finally {
             deleteQuietly(input);
             deleteQuietly(output);
+            deleteQuietly(processLog);
         }
+    }
+
+    /**
+     * 원본 이미지의 픽셀 크기(가로, 세로)를 헤더에서만 읽어 반환
+     * 형식을 못 읽으면 null을 반환
+     */
+    public ImageSize readSize(byte[] source) {
+        try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(source))) {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+            if (!readers.hasNext()) {
+                return null;
+            }
+            ImageReader reader = readers.next();
+            try {
+                reader.setInput(iis);
+                return new ImageSize(reader.getWidth(0), reader.getHeight(0));
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /** 이미지 픽셀 크기 (가로, 세로) */
+    public record ImageSize(int width, int height) {
     }
 
     private void deleteQuietly(Path path) {

--- a/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * 원본 이미지(byte[])를 cwebp로 리사이즈 + WebP 변환하는 유틸
  *
- * cwebp는 도커 이미지에 포함된 정적 바이너리({@code /app/bin/cwebp})를 실행하므로,
+ * cwebp는 도커 이미지에 포함된 정적 바이너리(/app/bin/cwebp)를 실행하므로,
  * 디코딩/리사이즈/인코딩이 JVM heap이 아닌 별도 프로세스(native 메모리)에서 수행됨
  * => 서버의 고정 heap 제약 영향 X, 대용량 이미지로 인한 JVM OOM 위험 X
  *
@@ -32,7 +32,7 @@ public class ImageOptimizer {
 
     /**
      * 원본 이미지를 지정한 가로 너비로 리사이즈하고 WebP로 변환
-     * 세로 높이는 원본 비율에 맞춰 자동 계산(cwebp {@code -resize width 0}).
+     * 세로 높이는 원본 비율에 맞춰 자동 계산(cwebp -resize width 0).
      *
      * @param source 원본 이미지 바이트 (jpg/png 등)
      * @param width  변환 결과의 가로 픽셀 너비

--- a/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
@@ -22,12 +22,14 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class ImageOptimizer {
 
-    private static final long PROCESS_TIMEOUT_SECONDS = 30L;
-
     private final String cwebpPath;
+    private final long processTimeoutSeconds;
 
-    public ImageOptimizer(@Value("${image.cwebp.path:/app/bin/cwebp}") String cwebpPath) {
+    public ImageOptimizer(
+            @Value("${image.cwebp.path:/app/bin/cwebp}") String cwebpPath,
+            @Value("${image.cwebp.timeout-seconds:30}") long processTimeoutSeconds) {
         this.cwebpPath = cwebpPath;
+        this.processTimeoutSeconds = processTimeoutSeconds;
     }
 
     /**
@@ -54,11 +56,11 @@ public class ImageOptimizer {
                     .redirectErrorStream(true)
                     .start();
 
-            boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
                 throw new ImageOptimizationException(
-                        "cwebp 변환이 " + PROCESS_TIMEOUT_SECONDS + "초 내에 완료되지 않았습니다. width=" + width);
+                        "cwebp 변환이 " + processTimeoutSeconds + "초 내에 완료되지 않았습니다. width=" + width);
             }
 
             int exitCode = process.exitValue();

--- a/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageOptimizer.java
@@ -1,0 +1,98 @@
+package or.sopt.houme.global.image;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 원본 이미지(byte[])를 cwebp로 리사이즈 + WebP 변환하는 유틸
+ *
+ * cwebp는 도커 이미지에 포함된 정적 바이너리({@code /app/bin/cwebp})를 실행하므로,
+ * 디코딩/리사이즈/인코딩이 JVM heap이 아닌 별도 프로세스(native 메모리)에서 수행됨
+ * => 서버의 고정 heap 제약 영향 X, 대용량 이미지로 인한 JVM OOM 위험 X
+ *
+ * 단, native 메모리는 컨테이너 메모리를 사용하므로 동시 실행 개수는 호출 측에서 제한 필요
+ */
+@Component
+@Slf4j
+public class ImageOptimizer {
+
+    private static final long PROCESS_TIMEOUT_SECONDS = 30L;
+
+    private final String cwebpPath;
+
+    public ImageOptimizer(@Value("${image.cwebp.path:/app/bin/cwebp}") String cwebpPath) {
+        this.cwebpPath = cwebpPath;
+    }
+
+    /**
+     * 원본 이미지를 지정한 가로 너비로 리사이즈하고 WebP로 변환
+     * 세로 높이는 원본 비율에 맞춰 자동 계산(cwebp {@code -resize width 0}).
+     *
+     * @param source 원본 이미지 바이트 (jpg/png 등)
+     * @param width  변환 결과의 가로 픽셀 너비
+     * @return WebP로 변환된 이미지 바이트
+     * @throws ImageOptimizationException 변환에 실패한 경우 (원본은 호출 측에서 보존)
+     */
+    public byte[] toResizedWebp(byte[] source, int width) {
+        Path input = null;
+        Path output = null;
+        try {
+            input = Files.createTempFile("houme-img-src-", ".bin");
+            output = Files.createTempFile("houme-img-out-", ".webp");
+            Files.write(input, source);
+
+            Process process = new ProcessBuilder(
+                    cwebpPath, "-quiet",
+                    "-resize", String.valueOf(width), "0",
+                    input.toString(), "-o", output.toString())
+                    .redirectErrorStream(true)
+                    .start();
+
+            boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new ImageOptimizationException(
+                        "cwebp 변환이 " + PROCESS_TIMEOUT_SECONDS + "초 내에 완료되지 않았습니다. width=" + width);
+            }
+
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                String processLog = new String(process.getInputStream().readAllBytes()).trim();
+                throw new ImageOptimizationException(
+                        "cwebp 변환 실패. exitCode=" + exitCode + ", width=" + width + ", log=" + processLog);
+            }
+
+            byte[] result = Files.readAllBytes(output);
+            if (result.length == 0) {
+                throw new ImageOptimizationException("cwebp 변환 결과가 비어 있습니다. width=" + width);
+            }
+            return result;
+
+        } catch (IOException e) {
+            throw new ImageOptimizationException("이미지 변환 중 IO 오류가 발생했습니다. width=" + width, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ImageOptimizationException("이미지 변환이 중단되었습니다. width=" + width, e);
+        } finally {
+            deleteQuietly(input);
+            deleteQuietly(output);
+        }
+    }
+
+    private void deleteQuietly(Path path) {
+        if (path == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            log.warn("임시 파일 삭제 실패: {}", path, e);
+        }
+    }
+}

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
@@ -1,0 +1,31 @@
+package or.sopt.houme.global.image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 어드민 이미지 최적화 sweep을 주기적으로 실행하는 스케줄러입니다.
+ *
+ * fixedDelay(기본 12시간) 간격으로 sweep을 실행합니다.
+ * image.sweep.enabled=false 로 비활성화할 수 있습니다(테스트/로컬 환경).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(prefix = "image.sweep", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ImageSweepScheduler {
+
+    private final ImageSweepService imageSweepService;
+
+    @Scheduled(
+            // 서버 시작 60초 후 첫 sweep 돌리기
+            initialDelayString = "${image.sweep.initial-delay-ms:60000}",
+            fixedDelayString = "${image.sweep.fixed-delay-ms:43200000}"
+    )
+    public void runSweep() {
+        imageSweepService.sweep();
+    }
+}

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 /**
  * 어드민 이미지 최적화 sweep을 주기적으로 실행하는 스케줄러입니다.
  *
- * fixedDelay(기본 12시간) 간격으로 sweep을 실행합니다.
+ * 매일 새벽 4시(KST)에 sweep을 실행합니다. (트래픽이 적은 시간대 + 24시간 주기)
  * image.sweep.enabled=false 로 비활성화할 수 있습니다(테스트/로컬 환경).
  */
 @Component
@@ -20,12 +20,14 @@ public class ImageSweepScheduler {
 
     private final ImageSweepService imageSweepService;
 
-    @Scheduled(
-            // 서버 시작 60초 후 첫 sweep 돌리기
-            initialDelayString = "${image.sweep.initial-delay-ms:60000}",
-            fixedDelayString = "${image.sweep.fixed-delay-ms:43200000}"
-    )
+    // 매일 새벽 4시(KST) 실행. cron 형식: 초 분 시 일 월 요일
+    @Scheduled(cron = "${image.sweep.cron:0 0 4 * * *}", zone = "Asia/Seoul")
     public void runSweep() {
-        imageSweepService.sweep();
+        // 예기치 못한 Throwable(Error 포함)이 스케줄러를 조용히 멈추지 않도록 최상위 가드
+        try {
+            imageSweepService.sweep();
+        } catch (Throwable t) {
+            log.error("이미지 최적화 sweep 실행 중 예외 발생. 다음 주기에 재시도합니다.", t);
+        }
     }
 }

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
@@ -11,10 +11,6 @@ import org.springframework.stereotype.Component;
  *
  * fixedDelay(기본 12시간) 간격으로 sweep을 실행합니다.
  * image.sweep.enabled=false 로 비활성화할 수 있습니다(테스트/로컬 환경).
- *
- * 주의: fixedDelay는 단일 JVM 안에서만 실행 겹침을 막으므로, 서버를 여러 대로 운영하면
- * 각 인스턴스가 같은 prefix를 중복 sweep합니다(멱등 key라 데이터는 안전하나 자원 낭비).
- * 다중 인스턴스 시 image.sweep.enabled로 한 인스턴스에서만 켜거나 분산 락을 두세요.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepScheduler.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
  *
  * fixedDelay(기본 12시간) 간격으로 sweep을 실행합니다.
  * image.sweep.enabled=false 로 비활성화할 수 있습니다(테스트/로컬 환경).
+ *
+ * 주의: fixedDelay는 단일 JVM 안에서만 실행 겹침을 막으므로, 서버를 여러 대로 운영하면
+ * 각 인스턴스가 같은 prefix를 중복 sweep합니다(멱등 key라 데이터는 안전하나 자원 낭비).
+ * 다중 인스턴스 시 image.sweep.enabled로 한 인스턴스에서만 켜거나 분산 락을 두세요.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -1,0 +1,101 @@
+package or.sopt.houme.global.image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.global.util.S3Util;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 어드민 이미지 폴더(S3 prefix)를 훑어 variant가 없는 원본을 찾아 리사이즈+WebP 변환합니다.
+ *
+ * - 멱등: 이미 모든 너비의 variant가 있으면 건너뜁니다.
+ * - 예외 격리: prefix 단위/이미지 단위로 try-catch해 일부 실패가 전체를 중단시키지 않습니다.
+ * - 원본 불변: 변환 실패 시 원본은 그대로 두고 해당 이미지만 건너뜁니다(프론트는 원본으로 폴백).
+ *
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageSweepService {
+
+    /** 어드민이 업로드하는 이미지가 저장되는 S3 prefix들 (AI 생성/상품 이미지는 포함되지 않음) */
+    private static final List<String> ADMIN_IMAGE_PREFIXES = List.of(
+            "floorplan/", "furniture/", "moodboard/", "banner/", "style/", "landing/"
+    );
+
+    /** 변환 대상 원본 확장자 (이미 webp인 이미지나 variant는 제외) */
+    private static final Set<String> TARGET_EXTENSIONS = Set.of("jpg", "jpeg", "png");
+
+    private final S3Util s3Util;
+    private final ImageOptimizer imageOptimizer;
+    private final VariantKeyResolver variantKeyResolver;
+
+    /**
+     * 모든 어드민 prefix를 훑어 variant가 없는 원본을 변환합니다.
+     */
+    public void sweep() {
+        log.info("이미지 최적화 sweep 시작");
+        int convertedTotal = 0;
+        for (String prefix : ADMIN_IMAGE_PREFIXES) {
+            try {
+                convertedTotal += sweepPrefix(prefix);
+            } catch (Exception e) {
+                log.error("prefix sweep 실패: {} — 건너뜀", prefix, e);
+            }
+        }
+        log.info("이미지 최적화 sweep 종료. 신규 변환 원본 수={}", convertedTotal);
+    }
+
+    private int sweepPrefix(String prefix) {
+        List<String> keys = s3Util.listKeys(prefix);
+        // 한 번의 목록 조회로 원본 + variant를 모두 받아 메모리에서 존재 여부를 비교 (객체별 추가 조회 불필요)
+        Set<String> existingKeys = new HashSet<>(keys);
+
+        List<String> originals = keys.stream()
+                .filter(key -> !variantKeyResolver.isVariantKey(key))
+                .filter(this::isTargetOriginal)
+                .toList();
+
+        int converted = 0;
+        for (String originalKey : originals) {
+            boolean allVariantsExist = variantKeyResolver.variantKeysFor(originalKey).stream()
+                    .allMatch(existingKeys::contains);
+            if (allVariantsExist) {
+                continue;
+            }
+            try {
+                convertMissingVariants(originalKey, existingKeys);
+                converted++;
+            } catch (Exception e) {
+                log.error("원본 변환 실패: {} — 원본 보존 후 건너뜀", originalKey, e);
+            }
+        }
+        return converted;
+    }
+
+    private void convertMissingVariants(String originalKey, Set<String> existingKeys) {
+        byte[] source = s3Util.download(originalKey);
+        for (int width : VariantKeyResolver.VARIANT_WIDTHS) {
+            String variantKey = variantKeyResolver.toVariantKey(originalKey, width);
+            if (existingKeys.contains(variantKey)) {
+                continue;
+            }
+            byte[] webp = imageOptimizer.toResizedWebp(source, width);
+            s3Util.uploadWebpVariant(variantKey, webp);
+            log.info("variant 생성: {} ({} bytes)", variantKey, webp.length);
+        }
+    }
+
+    private boolean isTargetOriginal(String key) {
+        int lastDot = key.lastIndexOf('.');
+        if (lastDot < 0) {
+            return false;
+        }
+        String extension = key.substring(lastDot + 1).toLowerCase();
+        return TARGET_EXTENSIONS.contains(extension);
+    }
+}

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -30,6 +30,9 @@ public class ImageSweepService {
     /** 변환 대상 원본 확장자 (이미 webp인 이미지나 variant는 제외) */
     private static final Set<String> TARGET_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
+    /** 디코딩 시 메모리를 과도하게 쓰는 큰 이미지를 거르기 위한 픽셀 수 상한 (약 50MP) */
+    private static final long MAX_PIXELS = 50_000_000L;
+
     private final S3Util s3Util;
     private final ImageOptimizer imageOptimizer;
     private final VariantKeyResolver variantKeyResolver;
@@ -81,7 +84,18 @@ public class ImageSweepService {
 
     private void convertVariants(String originalKey, List<Integer> widths) {
         byte[] source = s3Util.download(originalKey);
+
+        ImageOptimizer.ImageSize size = imageOptimizer.readSize(source);
+        if (size != null && (long) size.width() * size.height() > MAX_PIXELS) {
+            log.warn("초대형 이미지라 변환을 건너뜀: {} ({}x{})", originalKey, size.width(), size.height());
+            return;
+        }
+
         for (int width : widths) {
+            // 원본보다 큰 너비는 업스케일이라 만들지 않음 (프론트는 원본 이미지로 폴백)
+            if (size != null && width >= size.width()) {
+                continue;
+            }
             String variantKey = variantKeyResolver.toVariantKey(originalKey, width);
             byte[] webp = imageOptimizer.toResizedWebp(source, width);
             s3Util.uploadWebpVariant(variantKey, webp);

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -73,8 +73,9 @@ public class ImageSweepService {
                 continue;
             }
             try {
-                convertVariants(originalKey, missingWidths);
-                converted++;
+                if (convertVariants(originalKey, missingWidths) > 0) {
+                    converted++;
+                }
             } catch (Exception e) {
                 log.error("원본 변환 실패: {} — 원본 보존 후 건너뜀", originalKey, e);
             }
@@ -82,25 +83,28 @@ public class ImageSweepService {
         return converted;
     }
 
-    private void convertVariants(String originalKey, List<Integer> widths) {
+    private int convertVariants(String originalKey, List<Integer> widths) {
         byte[] source = s3Util.download(originalKey);
 
         ImageOptimizer.ImageSize size = imageOptimizer.readSize(source);
         if (size != null && (long) size.width() * size.height() > MAX_PIXELS) {
             log.warn("크기가 큰 이미지라 변환을 건너뜀: {} ({}x{})", originalKey, size.width(), size.height());
-            return;
+            return 0;
         }
 
+        int uploaded = 0;
         for (int width : widths) {
-            // 원본보다 큰 너비는 업스케일이라 만들지 않음 (프론트는 원본 이미지로 폴백)
-            if (size != null && width >= size.width()) {
+            // 원본보다 큰 variant 너비는 원본보다 업스케일이므로 skip (같은 너비는 variant 생성, 없으면 프론트가 원본으로 폴백)
+            if (size != null && width > size.width()) {
                 continue;
             }
             String variantKey = variantKeyResolver.toVariantKey(originalKey, width);
             byte[] webp = imageOptimizer.toResizedWebp(source, width);
             s3Util.uploadWebpVariant(variantKey, webp);
             log.info("variant 생성: {} ({} bytes)", variantKey, webp.length);
+            uploaded++;
         }
+        return uploaded;
     }
 
     private boolean isTargetOriginal(String key) {

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -62,13 +62,15 @@ public class ImageSweepService {
 
         int converted = 0;
         for (String originalKey : originals) {
-            boolean allVariantsExist = variantKeyResolver.variantKeysFor(originalKey).stream()
-                    .allMatch(existingKeys::contains);
-            if (allVariantsExist) {
+            // variant가 없는 너비만 추려냄
+            List<Integer> missingWidths = VariantKeyResolver.VARIANT_WIDTHS.stream()
+                    .filter(width -> !existingKeys.contains(variantKeyResolver.toVariantKey(originalKey, width)))
+                    .toList();
+            if (missingWidths.isEmpty()) {
                 continue;
             }
             try {
-                convertMissingVariants(originalKey, existingKeys);
+                convertVariants(originalKey, missingWidths);
                 converted++;
             } catch (Exception e) {
                 log.error("원본 변환 실패: {} — 원본 보존 후 건너뜀", originalKey, e);
@@ -77,13 +79,10 @@ public class ImageSweepService {
         return converted;
     }
 
-    private void convertMissingVariants(String originalKey, Set<String> existingKeys) {
+    private void convertVariants(String originalKey, List<Integer> widths) {
         byte[] source = s3Util.download(originalKey);
-        for (int width : VariantKeyResolver.VARIANT_WIDTHS) {
+        for (int width : widths) {
             String variantKey = variantKeyResolver.toVariantKey(originalKey, width);
-            if (existingKeys.contains(variantKey)) {
-                continue;
-            }
             byte[] webp = imageOptimizer.toResizedWebp(source, width);
             s3Util.uploadWebpVariant(variantKey, webp);
             log.info("variant 생성: {} ({} bytes)", variantKey, webp.length);

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -87,7 +87,7 @@ public class ImageSweepService {
 
         ImageOptimizer.ImageSize size = imageOptimizer.readSize(source);
         if (size != null && (long) size.width() * size.height() > MAX_PIXELS) {
-            log.warn("초대형 이미지라 변환을 건너뜀: {} ({}x{})", originalKey, size.width(), size.height());
+            log.warn("크기가 큰 이미지라 변환을 건너뜀: {} ({}x{})", originalKey, size.width(), size.height());
             return;
         }
 

--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -5,8 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.util.S3Util;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -93,15 +95,17 @@ public class ImageSweepService {
         }
 
         int uploaded = 0;
-        for (int width : widths) {
-            // 원본보다 큰 variant 너비는 원본보다 업스케일이므로 skip (같은 너비는 variant 생성, 없으면 프론트가 원본으로 폴백)
-            if (size != null && width > size.width()) {
-                continue;
-            }
-            String variantKey = variantKeyResolver.toVariantKey(originalKey, width);
-            byte[] webp = imageOptimizer.toResizedWebp(source, width);
+        // 원본이 작아 여러 목표 너비(400/800/1280)가 같은 너비(원본의 너비)로 클램프되는 경우, 같은 너비를 두 번 인코딩하지 않도록 캐시
+        Map<Integer, byte[]> encodedByWidth = new HashMap<>();
+        for (int targetWidth : widths) {
+            // targetWidth는 만들 variant의 목표 너비. 원본보다 targetWidth가 크면
+            // 원본을 업스케일하는 대신 원본 너비로 줄여서 variant를 만들어 항상 WebP를 생성한다.
+            int resizeWidth = (size != null) ? Math.min(targetWidth, size.width()) : targetWidth;
+            byte[] webp = encodedByWidth.computeIfAbsent(resizeWidth,
+                    width -> imageOptimizer.toResizedWebp(source, width));
+            String variantKey = variantKeyResolver.toVariantKey(originalKey, targetWidth);
             s3Util.uploadWebpVariant(variantKey, webp);
-            log.info("variant 생성: {} ({} bytes)", variantKey, webp.length);
+            log.info("variant 생성: {} ({} bytes, 실제너비={}px)", variantKey, webp.length, resizeWidth);
             uploaded++;
         }
         return uploaded;

--- a/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
+++ b/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
@@ -39,15 +39,6 @@ public class VariantKeyResolver {
     }
 
     /**
-     * 원본 하나에 대한 모든 너비의 variant key 목록을 반환합니다.
-     */
-    public List<String> variantKeysFor(String originalKey) {
-        return VARIANT_WIDTHS.stream()
-                .map(width -> toVariantKey(originalKey, width))
-                .toList();
-    }
-
-    /**
      * 주어진 key가 variant(최적화로 생성된 webp)인지 판별합니다.
      * 호출 측에서 variant를 걸러낼 때 사용합니다. (variant를 다시 변환하는 일 방지)
      */

--- a/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
+++ b/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
@@ -16,8 +16,9 @@ import java.util.regex.Pattern;
 public class VariantKeyResolver {
 
     /**
-     * 생성할 variant 너비
+     * 생성할 variant 너비 (각 값은 만들 variant의 목표 너비)
      * 프론트 렌더에 필요한 크기 기반(그리드 썸네일 ~200px, 최대너비/상세이미지 ~440px)에 DPR 2~3을 반영한 값.
+     * 원본이 목표 너비보다 작으면 업스케일하지 않고 원본 너비로 줄여서 생성하므로, 모든 원본이 세 너비의 variant를 모두 가집니다.
      * 웹의 srcset이 페이지별로 필요한 이미지 1개만 다운로드하므로, 모든 이미지에 3가지 width를 적용해도 대역폭 낭비가 없습니다.
      */
     public static final List<Integer> VARIANT_WIDTHS = List.of(400, 800, 1280);

--- a/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
+++ b/src/main/java/or/sopt/houme/global/image/VariantKeyResolver.java
@@ -1,0 +1,69 @@
+package or.sopt.houme.global.image;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * 원본 이미지 key와 최적화 variant key 사이의 네이밍 규칙을 정의합니다.
+ * 이 규칙은 서버와 웹이 동일하게 공유해야 합니다.
+ *
+ * 규칙: {원본 key에서 확장자 제거}__w{너비}.webp
+ * 예) floorplan/1712_ab12cd34.png → floorplan/1712_ab12cd34__w400.webp
+ */
+@Component
+public class VariantKeyResolver {
+
+    /**
+     * 생성할 variant 너비
+     * 프론트 렌더에 필요한 크기 기반(그리드 썸네일 ~200px, 최대너비/상세이미지 ~440px)에 DPR 2~3을 반영한 값.
+     * 웹의 srcset이 페이지별로 필요한 이미지 1개만 다운로드하므로, 모든 이미지에 3가지 width를 적용해도 대역폭 낭비가 없습니다.
+     */
+    public static final List<Integer> VARIANT_WIDTHS = List.of(400, 800, 1280);
+
+    private static final String VARIANT_MARKER = "__w";
+    private static final String WEBP_EXTENSION = ".webp";
+    // variant key 판별용: "..__w{숫자}.webp" 로 끝나는 key
+    private static final Pattern VARIANT_KEY_PATTERN = Pattern.compile(".*__w\\d+\\.webp$");
+
+    /**
+     * 원본 key와 너비로 variant key를 만듭니다.
+     *
+     * @param originalKey 원본 S3 key (예: floorplan/1712_ab.png)
+     * @param width       variant 가로 너비
+     * @return variant key (예: floorplan/1712_ab__w400.webp)
+     */
+    public String toVariantKey(String originalKey, int width) {
+        return stripExtension(originalKey) + VARIANT_MARKER + width + WEBP_EXTENSION;
+    }
+
+    /**
+     * 원본 하나에 대한 모든 너비의 variant key 목록을 반환합니다.
+     */
+    public List<String> variantKeysFor(String originalKey) {
+        return VARIANT_WIDTHS.stream()
+                .map(width -> toVariantKey(originalKey, width))
+                .toList();
+    }
+
+    /**
+     * 주어진 key가 variant(최적화로 생성된 webp)인지 판별합니다.
+     * 호출 측에서 variant를 걸러낼 때 사용합니다. (variant를 다시 변환하는 일 방지)
+     */
+    public boolean isVariantKey(String key) {
+        return key != null && VARIANT_KEY_PATTERN.matcher(key).matches();
+    }
+
+    /**
+     * key에서 파일 확장자를 제거합니다. 디렉토리 경로에 '.'이 있는 경우를 방어합니다.
+     */
+    private String stripExtension(String key) {
+        int lastDot = key.lastIndexOf('.');
+        int lastSlash = key.lastIndexOf('/');
+        if (lastDot > lastSlash) {
+            return key.substring(0, lastDot);
+        }
+        return key;
+    }
+}

--- a/src/main/java/or/sopt/houme/global/util/S3Util.java
+++ b/src/main/java/or/sopt/houme/global/util/S3Util.java
@@ -3,6 +3,8 @@ package or.sopt.houme.global.util;
 import or.sopt.houme.global.dto.ImageUploadResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface S3Util {
 
     ImageUploadResponseDTO upload(String dirName, MultipartFile file);
@@ -12,6 +14,8 @@ public interface S3Util {
     byte[] download(String key);
 
     void uploadWebpVariant(String key, byte[] webpBytes);
+
+    List<String> listKeys(String prefix);
 
     void delete(String fileUrl);
 }

--- a/src/main/java/or/sopt/houme/global/util/S3Util.java
+++ b/src/main/java/or/sopt/houme/global/util/S3Util.java
@@ -9,5 +9,9 @@ public interface S3Util {
 
     ImageUploadResponseDTO uploadByByte(String dirName, byte[] imageBytes);
 
+    byte[] download(String key);
+
+    void uploadWebpVariant(String key, byte[] webpBytes);
+
     void delete(String fileUrl);
 }

--- a/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
+++ b/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
@@ -39,6 +39,10 @@ public class S3UtilImpl implements S3Util {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    // 다운로드 시 heap에 올릴 원본 바이트 상한 (이 크기를 넘으면 다운로드 전에 차단)
+    @Value("${image.sweep.max-source-bytes:26214400}")
+    private long maxSourceBytes;
+
     private final AmazonS3 amazonS3;
 
     private static final String CONTENT_TYPE_WEBP = "image/webp";
@@ -182,6 +186,13 @@ public class S3UtilImpl implements S3Util {
     public byte[] download(String key) {
         try (S3Object s3Object = amazonS3.getObject(bucket, key);
              InputStream content = s3Object.getObjectContent()) {
+            // 이미지를 heap에 올리기 전에 Content-Length로 크기를 먼저 검사 (대용량 파일 OOM 방지)
+            long contentLength = s3Object.getObjectMetadata().getContentLength();
+            if (contentLength > maxSourceBytes) {
+                log.warn("S3 download skipped (too large). bucket={}, key={}, contentLength={}, limit={}",
+                        bucket, key, contentLength, maxSourceBytes);
+                throw new S3Exception(ErrorCode.IMAGE_DOWNLOAD_EXCEPTION);
+            }
             return content.readAllBytes();
         } catch (AmazonServiceException e) {
             log.error(

--- a/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
+++ b/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
@@ -3,9 +3,12 @@ package or.sopt.houme.global.util;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.api.ErrorCode;
@@ -20,6 +23,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static or.sopt.houme.global.util.constant.S3ExtensionConstant.EXTENSION_PNG;
@@ -168,7 +173,7 @@ public class S3UtilImpl implements S3Util {
 
 
     /**
-     * S3에서 key에 해당하는 객체를 바이트로 다운로드합니다. (어드민 이미지 최적화 sweep에서 원본을 읽을 때 사용)
+     * S3에서 key에 해당하는 객체를 바이트로 다운로드합니다.
      *
      * @param key S3 객체 key
      * @return 객체 바이트
@@ -220,6 +225,40 @@ public class S3UtilImpl implements S3Util {
             log.error("S3 variant upload failed (client). bucket={}, key={}, message={}", bucket, key, e.getMessage(), e);
             throw new S3Exception(ErrorCode.IMAGE_VARIANT_UPLOAD_EXCEPTION);
         }
+    }
+
+    /**
+     * S3에서, 지정한 prefix 아래의 모든 객체 key를 반환합니다.
+     *
+     * @param prefix S3 prefix (예: "floorplan/")
+     * @return prefix 아래 객체 key 목록
+     */
+    @Override
+    public List<String> listKeys(String prefix) {
+        List<String> keys = new ArrayList<>();
+        try {
+            ListObjectsV2Request request = new ListObjectsV2Request()
+                    .withBucketName(bucket)
+                    .withPrefix(prefix);
+            ListObjectsV2Result result;
+            do {
+                result = amazonS3.listObjectsV2(request);
+                for (S3ObjectSummary summary : result.getObjectSummaries()) {
+                    keys.add(summary.getKey());
+                }
+                request.setContinuationToken(result.getNextContinuationToken());
+            } while (result.isTruncated());
+        } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 list failed (service). bucket={}, prefix={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket, prefix, e.getStatusCode(), e.getErrorCode(), e.getRequestId(), e.getErrorMessage(), e
+            );
+            throw new S3Exception(ErrorCode.IMAGE_LIST_EXCEPTION);
+        } catch (SdkClientException e) {
+            log.error("S3 list failed (client). bucket={}, prefix={}, message={}", bucket, prefix, e.getMessage(), e);
+            throw new S3Exception(ErrorCode.IMAGE_LIST_EXCEPTION);
+        }
+        return keys;
     }
 
     /**

--- a/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
+++ b/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
@@ -39,8 +39,8 @@ public class S3UtilImpl implements S3Util {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    // 다운로드 시 heap에 올릴 원본 바이트 상한 (이 크기를 넘으면 다운로드 전에 차단)
-    @Value("${image.sweep.max-source-bytes:26214400}")
+    // 다운로드 시 heap에 올릴 원본 바이트 상한 (약 20MB, 초과 시 다운로드 전에 차단)
+    @Value("${image.sweep.max-source-bytes:20971520}")
     private long maxSourceBytes;
 
     private final AmazonS3 amazonS3;

--- a/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
+++ b/src/main/java/or/sopt/houme/global/util/S3UtilImpl.java
@@ -5,6 +5,7 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.api.ErrorCode;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 
 import static or.sopt.houme.global.util.constant.S3ExtensionConstant.EXTENSION_PNG;
@@ -33,6 +35,10 @@ public class S3UtilImpl implements S3Util {
     private String bucket;
 
     private final AmazonS3 amazonS3;
+
+    private static final String CONTENT_TYPE_WEBP = "image/webp";
+    // 최적화 이미지(variant)는 내용이 바뀌지 않으므로 장기 캐싱 (원본은 Cache-Control 미설정 → 재방문 시 재다운로드 발생)
+    private static final String CACHE_CONTROL_IMMUTABLE = "public, max-age=31536000, immutable";
 
 
     /**
@@ -160,6 +166,61 @@ public class S3UtilImpl implements S3Util {
 
 
 
+
+    /**
+     * S3에서 key에 해당하는 객체를 바이트로 다운로드합니다. (어드민 이미지 최적화 sweep에서 원본을 읽을 때 사용)
+     *
+     * @param key S3 객체 key
+     * @return 객체 바이트
+     */
+    @Override
+    public byte[] download(String key) {
+        try (S3Object s3Object = amazonS3.getObject(bucket, key);
+             InputStream content = s3Object.getObjectContent()) {
+            return content.readAllBytes();
+        } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 download failed (service). bucket={}, key={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket, key, e.getStatusCode(), e.getErrorCode(), e.getRequestId(), e.getErrorMessage(), e
+            );
+            throw new S3Exception(ErrorCode.IMAGE_DOWNLOAD_EXCEPTION);
+        } catch (SdkClientException e) {
+            log.error("S3 download failed (client). bucket={}, key={}, message={}", bucket, key, e.getMessage(), e);
+            throw new S3Exception(ErrorCode.IMAGE_DOWNLOAD_EXCEPTION);
+        } catch (IOException e) {
+            log.error("S3 download failed (io). bucket={}, key={}, message={}", bucket, key, e.getMessage(), e);
+            throw new S3Exception(ErrorCode.IMAGE_DOWNLOAD_EXCEPTION);
+        }
+    }
+
+    /**
+     * WebP 변환본(variant)을 지정한 key에 업로드합니다.
+     * content-type은 image/webp, Cache-Control은 장기 캐싱(immutable)으로 설정합니다.
+     *
+     * @param key       variant를 저장할 S3 key (네이밍 규칙으로 결정된 key)
+     * @param webpBytes WebP 변환 결과 바이트
+     */
+    @Override
+    public void uploadWebpVariant(String key, byte[] webpBytes) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(webpBytes.length);
+        metadata.setContentType(CONTENT_TYPE_WEBP);
+        metadata.setCacheControl(CACHE_CONTROL_IMMUTABLE);
+
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(webpBytes);
+            amazonS3.putObject(new PutObjectRequest(bucket, key, inputStream, metadata));
+        } catch (AmazonServiceException e) {
+            log.error(
+                    "S3 variant upload failed (service). bucket={}, key={}, statusCode={}, errorCode={}, requestId={}, message={}",
+                    bucket, key, e.getStatusCode(), e.getErrorCode(), e.getRequestId(), e.getErrorMessage(), e
+            );
+            throw new S3Exception(ErrorCode.IMAGE_VARIANT_UPLOAD_EXCEPTION);
+        } catch (SdkClientException e) {
+            log.error("S3 variant upload failed (client). bucket={}, key={}, message={}", bucket, key, e.getMessage(), e);
+            throw new S3Exception(ErrorCode.IMAGE_VARIANT_UPLOAD_EXCEPTION);
+        }
+    }
 
     /**
      * key 기반으로 이미지를 삭제하는 메서드입니다.


### PR DESCRIPTION
## 📣 Related Issue

- close #560

## 📝 Summary

어드민 템플릿 이미지를 **클라 렌더 크기로 리사이즈 + WebP 변환**하는 서버측 자동화를 추가했습니다. 기존 이미지 업로드 흐름은 그대로 유지됩니다(코드 수정 X)

### 문제 상황

- 어드민 템플릿 이미지(도면/배너/스타일/무드보드/가구/랜딩)가 리사이즈·포맷 최적화 없이 S3에 저장돼 클라로 전달됨
- 웹 LCP에 경고 발생, LCP breakdown에서 이미지 **Resource Load Duration이 LCP의 약 75~90%** → 이미지 바이트 자체가 렌더 병목

⇒ 서버에서 어드민 이미지를 최적화해 대역폭/LCP를 개선할 수 있도록 로직을 구현함

### 작업 내용

- 어드민 이미지를 400 / 800 / 1280px로 리사이징하고 WebP로 변환해 S3에 variant(최적화된 이미지)로 변환 (원본 이미지도 S3에 보존)
- 기존에 S3에 등록되어있는 어드민 이미지: 별도 스크립트 없이 첫 sweep 실행이 일괄 변환
- 앞으로 새로 업로드되는 어드민 이미지: 24시간 주기로 `sweep`이 자동 변환
- cwebp 실행파일(WebP 변환 압축 도구)을 Jib `extraDirectories`로 도커 이미지에 포함

**⇒ 어드민 이미지 크기를 95~99%정도 줄일 수 있을 것으로 예상됨**

### 전체 동작 흐름

```
[이미지 업로드 — 기존 그대로, 미수정]
어드민 → presigned 발급 → S3에 원본 PUT → 엔티티 저장

[추가된 것 — 서버 내부 스케줄러]
12시간마다: 
S3 prefix 6개(/moodboard, /floorplan 등) 훑기(sweep)
→ variant 없는 원본(jpg/png) 탐지 
→ 서버에 이미지 다운로드 
→ cwebp로 리사이즈+WebP변환 
→ variant key로 최적화된 이미지를 S3에 업로드
```

### 핵심 설계 결정

<details>
<summary><b>1. 이미지 최적화 처리 위치 — AWS Lambda 도입 대신 기존 서버에서 처리하는 방식 선택</b></summary>

- 어드민 이미지 업로드 빈도가 낮음 → 서버 CPU 부담 미미 → Lambda의 강점(offloading/auto-scale)이 큰 의미 없음
- Lambda는 관리 포인트(인프라/배포/IAM/S3이벤트)가 늘어남 → 서버 전체로 보면 유지보수 요소 증가
- 서버 처리는 로직이 서버 코드에 모여 에러/로그/재시도/폴백을 기존 체계로 일관 처리 가능
- 별도 RDS 네트워크 설정 불필요(서버에서 바로 DB 접근)

처음엔 Lambda가 정석적인 이미지 처리 방식이라 고려했지만, 업로드 빈도가 낮은 현 상황에선 **EC2 여유 CPU로 충분**하고 굳이 관리 포인트를 늘릴 이유가 없다고 판단 ⇒ **서버 처리 채택**

+) AWS Lambda로 처리한다면 S3 ObjectCreated 이벤트 + Lambda(Node+sharp) 조합으로 이벤트를 감지하고 이미지를 최적화하는 방식 고려 가능
</details>

<details>
<summary><b>2. 인코더 — cwebp (Java 라이브러리 대신 외부 바이너리 사용)</b></summary>

- 서버 JVM heap이 `Xmx512m`로 고정돼 있음
- Scrimage 같은 **Java 라이브러리**는 원본을 heap에 디코딩 → 큰 이미지면 **공유 서버 전체가 OOM**으로 죽을 위험
- **cwebp는 외부 프로세스**라 이미지 디코딩/리사이징/인코딩을 **JVM heap 밖**(native 메모리 == 도커 컨테이너의 메모리)에서 처리함 → 원본을 heap에 푸는 Scrimage와 달리 heap 메모리를 과하게 사용할 위험이 적음

**도커에 cwebp를 넣은 방식**: 하우미 서버는 Jib(Dockerfile 없이 도커 이미지를 빌드하는 방식)라 `apt install`을 못 함 → cwebp **static 바이너리를 `extraDirectories`로 이미지에 포함**(`/app/bin/cwebp`). 의존성 0인 static-pie 바이너리라 base 도커 이미지 변경 없이 동작 가능

```tsx
build.gradle

// cwebp 실행파일을 도커 이미지에 포함 + 실행권한 부여
extraDirectories {
    paths {
        path {
            from = file('src/main/jib')
            into = '/'
        }
    }
    permissions = ['/app/bin/cwebp': '755']
}
```

</details>

<details>
<summary><b>3. 이미지 최적화 트리거 — sweep 방식 </b></summary>

처음에는 어드민 클라가 이미지 업로드를 끝낸 직후 서버에 알리는 완료 API를 추가하는 방식을 고려했지만,

- 어드민 이미지 업로드 방식이 2가지
    - 도면/배너/스타일: presigned url 발급 → 클라가 S3에 PUT → 별도의 이미지 등록 API가 따로 호출되어 DB에 저장
    - 무드보드/가구: 한 API가 presigned url 발급 + DB 저장을 한꺼번에 → 그 다음 클라가 PUT. url 발급과 이미지 저장이 결합되어 있음
    
    ⇒ 두 방식 모두 고려해서 완료 API를 구현하려면 **어드민 웹 코드까지 수정**해야 함
    
- 완료 API가 정상적으로 동작하려면 클라가 ‘방금 올린 S3 key’를 넘겨야 하는데, 무드보드/가구 API 응답에는 key가 없음

**sweep**은 서버가 주기적으로 S3를 훑어 variant(최적화된 이미지) 없는 원본을 변환 → 클라 신호도, key 전달도 불필요.

즉 sweep은 **기존 이미지 업로드 코드/응답/어드민 웹 코드를 하나도 건드리지 않아도 되므로**, 코드 리뷰 부담과 회귀 위험을 최소화할 수 있음.

+) 어드민에서 실제로 이미지가 업로드되지 않음에도 12시간마다 반복적으로 sweep하는건 서버 자원 낭비처럼 느껴질 수 있지만, 어드민 버킷이 작아(~100장) sweep 1회당 S3 prefix별 ListObjects 몇 번 + 메모리 비교로 끝나므로 비용은 월 100원 이하, idle CPU는 수 ms 수준일 것으로 예상됨. 또한 variant가 늦게 생겨 원본 이미지밖에 없는 경우에는, 웹에서 **원본 이미지로 폴백**하도록 구현할 예정이며, 어드민 이미지 등록은 그렇게 자주 발생하는 이벤트 X
⇒ 그래서 sweep 주기는 '비용'이 아닌 '최적화 반영까지 허용 가능한 지연'을 기준으로 잡았고, 즉시성이 필요 없는 어드민 이미지 특성상 12시간으로 설정함
</details>

<details>
<summary><b>4. 최적화된 이미지(variant) 위치 규칙</b></summary>

variant의 S3에서의 위치(key)는 원본 key + 네이밍 규칙으로 언제든 계산할 수 있음. 따라서 DB에 variant의 주소를 저장하면 DB에 저장된 key값과 실제 S3에서의 해당 variant의 주소가 어긋날 위험성 + key 중복 문제(variant의 key는 원본 key로부터 계산 가능한 값이므로 DB 입장에서는 같은 정보를 두 번 가짐) 발생

⇒ DB에 저장하지 않고 프론트와 서버가 원본 이미지의 URL에 같은 규칙을 적용해 그때그때 variant의 주소 유도 ⇒ **스키마 변경 0!**

**variant 네이밍 규칙**

- `{원본 key에서 확장자 제거}__w{너비}.webp` (ex: `floorplan/1712_ab.png` → `floorplan/1712_ab__w400.webp`)
- 서버(`VariantKeyResolver`)와 프론트가 **같은 규칙**을 공유해야 최적화된 이미지를 S3에서 성공적으로 가져올 수 있음
        
- 실제로 웹 페이지에서 렌더링되어야하는 도면/무드보드/배너/스타일 이미지 사이즈(width `~200px`, maxWidth `~440px` 수준)와 DPR(Device Pixel Ratio) 2~3배를 고려해, S3에 저장되는 최적화된 이미지 크기는 400/800/1280 으로 결정함.

</details>

<details>
<summary><b>5. 메모리 / 동시성 / 에러 / 멱등성 고려</b></summary>

- **메모리**
    - cwebp는 heap 밖에서 이미지 리사이징/webp 변환을 처리함
    - 크기가 큰 이미지(약 50MP 초과) 변환은 skip하도록 가드로직 적용
    - 순차 처리로 동시성 제한
- **동시성**
    - `@Scheduled fixedDelay`: 한 서버(JVM) 안에서 직전 sweep이 끝나야 다음 sweep이 시작되므로, sweep끼리 동시에 겹쳐 도는 일이 없음
- **에러 격리**: S3의 prefix 단위·이미지 단위로 try/catch문 내에서 이미지 최적화 적용 → 일부 이미지에서 이미지 최적화가 실패하더라도 전체 sweep을 중단시키지 않음. 변환 실패 시 **원본은 보존**되며, 프론트는 최적화된 이미지를 얻을 수 없을 시 원본 이미지로 폴백함.
- **멱등**: 이미 variant가 있으면 skip, 즉 sweep이 반복적으로 실행되더라도 이미 원본에 대해 최적화된 이미지가 있다면 최적화를 skip함.

</details>

<details>
<summary><b>6. 이미지 리사이징 기준</b></summary>

웹에서 실제로 렌더링되는 이미지 width에 DPR 2~3를 고려해, 그
2~3배인 **400 / 800 / 1280px** 세 너비로 변환본(variant)을 생성한다.

목표 너비가 원본 너비보다 크면 업스케일링으로 화질이 떨어지므로, 업스케일하지 않고 **원본 너비로 줄여서(클램프)** 생성한다. => 작은 원본도 최적화에서 누락되지 않고, 모든 원본이 세 variant(`__w400` / `__w800` / `__w1280`)를 빠짐없이 가진다.

| 원본 너비 | 생성되는 variant (실제 너비) | 결과 |
| --- | --- | --- |
| 8192px (스타일) | 400 / 800 / 1280 | 3개, 전부 목표 너비 |
| 2752px (도면) | 400 / 800 / 1280 | 3개 |
| 1131px (배너) | 400 / 800 / 1131 | 3개 (1280 → 원본 1131로 클램프) |
| 719px (무드보드) | 400 / 719 / 719 | 3개 (800·1280 → 719로 클램프) |
| 375px (랜딩) | 375 / 375 / 375 | 3개 (전부 375로 클램프) |

variant key는 항상 `__w400` / `__w800` / `__w1280`이고, 위 "실제 너비"는 클램프된 변환 결과의 가로 픽셀이다. 작은 원본은 여러 목표 너비가 같은 결과로 클램프되므로 한 번만 인코딩해 재사용한다.

</details>

### 코드 구조

`global/image/` 패키지에 모았습니다(특정 도메인이 아닌 cross-cutting 인프라). 단일 책임으로 계층 분리:

| 클래스 | 책임 |
| --- | --- |
| `ImageSweepScheduler` | 이미지 최적화 트리거 — @Scheduled로 주기적(12시간)으로 실행됨 |
| `ImageSweepService` | 오케스트레이션 — sweep→최적화되지 않은 이미지 탐지→해당 이미지 변환 위임 |
| `ImageOptimizer` | cwebp 래퍼 — 리사이즈+WebP 변환 담당 |
| `VariantKeyResolver` | 이미지 원본↔variant key 네이밍 규칙(서버/프론트가 공유해야하는 규칙) |
| `S3Util`(기존 S3Util 확장) | `download` / `uploadWebpVariant` / `listKeys` 추가 |

트리거 → 오케스트레이션 → 저수준 유틸로 나눠, 각 단계가 독립적으로 교체/테스트 가능하게 구현했습니다.

## **🙏 Question & PR point**

- 런타임 검증: 외부 엔드포인트가 없어 dev 배포 후 로그(variant 생성)와 S3의 `__w400.webp` 생성으로 확인 예정입니다.
- 후속작업(프론트): 별도 client 이슈에서 `getImageVariantUrl`로 동일 규칙을 적용해 `<img srcset />` + ‘variant 요청 → 원본 요청 → static 폴백’ 폴백 컴포넌트를 붙일 예정입니다. variant가 없을 시에는 원본 이미지로 폴백하므로 이 서버 PR을 먼저 배포해도 안전합니다.
- 최적화된 이미지의 너비(400/800/1280)/sweep 주기/크기가 큰 이미지 MP값 상한선은 `VariantKeyResolver.VARIANT_WIDTHS` / `image.sweep.*` / `MAX_PIXELS`로 조정 가능합니다.
- DB와 S3의 정합성을 체크할 수 있도록 로깅도 적용하면 좋을 것 같은데, Sentry/… 등 서버에서 어떤 모니터링 방식을 선호하는지 몰라 우선 audit은 제외했슨ㅂ니다
- 이 PR은 최적화 이미지(variant)를 생성/저장하는 서버측 작업이며, 실질적인 브라우저 LCP 개선은 웹에서 srcset으로 variant를 적용하는 후속 작업에서 진행할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이미지 최적화 도입: 업로드된 이미지를 WebP로 변환하고 여러 너비로 자동 리사이즈
  * 자동 스윕(주기적 검사)으로 누락된 이미지 변형을 찾아 생성·업로드

* **Chores**
  * 이미지 처리 파이프라인 및 S3 연동 확장
  * 컨테이너 이미지에 변환 도구 추가 및 실행 권한 부여
<!-- end of auto-generated comment: release notes by coderabbit.ai -->