### PR TITLE
[FIX] FULL_FUNNEL 제목 fallback 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface HouseFurnitureRepositoryCustom {
     List<HouseFurniture> findAllByHouseIdWithFurniture(Long houseId);
+
+    List<HouseFurniture> findAllByHouseIdInWithFurniture(List<Long> houseIds);
 }

--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseFurnitureRepositoryImpl.java
@@ -30,4 +30,23 @@ public class HouseFurnitureRepositoryImpl implements HouseFurnitureRepositoryCus
                 .orderBy(houseFurniture.id.asc())
                 .fetch();
     }
+
+    @Override
+    public List<HouseFurniture> findAllByHouseIdInWithFurniture(List<Long> houseIds) {
+        if (houseIds == null || houseIds.isEmpty()) {
+            return List.of();
+        }
+
+        QHouseFurniture houseFurniture = QHouseFurniture.houseFurniture;
+        QFurniture furniture = QFurniture.furniture;
+        QFurnitureType furnitureType = QFurnitureType.furnitureType;
+
+        return queryFactory
+                .selectFrom(houseFurniture)
+                .join(houseFurniture.furniture, furniture).fetchJoin()
+                .join(furniture.furnitureType, furnitureType).fetchJoin()
+                .where(houseFurniture.house.id.in(houseIds))
+                .orderBy(houseFurniture.house.id.asc(), houseFurniture.id.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
@@ -4,6 +4,8 @@ import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -19,14 +21,16 @@ public class CarouselShuffleService {
 
     public List<Long> selectDisplayIds(CarouselCandidateBundle bundle, Long userId) {
         LinkedHashSet<Long> selectedIds = new LinkedHashSet<>();
-        OrderedBucket selectedBucket = new OrderedBucket(bundle.selectedFurnitureIds());
-        OrderedBucket furnitureBucket = new OrderedBucket(bundle.furnitureCategoryIds());
+        long epochDay = LocalDate.now(ZoneOffset.UTC).toEpochDay();
+        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 11L));
+        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 23L));
 
-        Map<SoozipCategory, OrderedBucket> otherBuckets = new LinkedHashMap<>();
+        Map<SoozipCategory, ShuffledBucket> otherBuckets = new LinkedHashMap<>();
+        long salt = 31L;
         for (Map.Entry<SoozipCategory, List<Long>> entry : bundle.otherCategoryIds().entrySet()) {
-            otherBuckets.put(entry.getKey(), new OrderedBucket(entry.getValue()));
+            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), epochDay, salt++)));
         }
-        List<OrderedBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
+        List<ShuffledBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
 
         while (selectedIds.size() < TARGET_SIZE && hasAnyRemaining(selectedBucket, furnitureBucket)) {
             addNext(selectedIds, selectedBucket);
@@ -42,7 +46,7 @@ public class CarouselShuffleService {
             otherIndex++;
         }
 
-        OrderedBucket fallbackBucket = new OrderedBucket(bundle.fallbackIds());
+        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 97L));
         while (selectedIds.size() < TARGET_SIZE && fallbackBucket.hasNext()) {
             addNext(selectedIds, fallbackBucket);
         }
@@ -50,15 +54,15 @@ public class CarouselShuffleService {
         return new ArrayList<>(selectedIds);
     }
 
-    private boolean hasAnyRemaining(OrderedBucket selectedBucket, OrderedBucket furnitureBucket) {
+    private boolean hasAnyRemaining(ShuffledBucket selectedBucket, ShuffledBucket furnitureBucket) {
         return selectedBucket.hasNext() || furnitureBucket.hasNext();
     }
 
-    private boolean hasAnyRemaining(List<OrderedBucket> buckets) {
-        return buckets.stream().anyMatch(OrderedBucket::hasNext);
+    private boolean hasAnyRemaining(List<ShuffledBucket> buckets) {
+        return buckets.stream().anyMatch(ShuffledBucket::hasNext);
     }
 
-    private void addNext(Set<Long> selectedIds, OrderedBucket bucket) {
+    private void addNext(Set<Long> selectedIds, ShuffledBucket bucket) {
         while (bucket.hasNext()) {
             Long nextId = bucket.next();
             if (nextId != null && selectedIds.add(nextId)) {
@@ -67,17 +71,27 @@ public class CarouselShuffleService {
         }
     }
 
-    private static final class OrderedBucket {
+    private long computeSeed(Long userId, Long recentImageId, long epochDay, long salt) {
+        long baseUserId = userId == null ? 0L : userId;
+        long baseImageId = recentImageId == null ? 0L : recentImageId;
+        return (baseUserId * 31L) ^ (baseImageId * 17L) ^ (epochDay * 13L) ^ salt;
+    }
+
+    private static final class ShuffledBucket {
         private final List<Long> source;
         private final int size;
+        private final int start;
+        private final int step;
         private int attempts;
 
-        private OrderedBucket(List<Long> candidateIds) {
+        private ShuffledBucket(List<Long> candidateIds, long seed) {
             this.source = candidateIds == null ? List.of() : candidateIds.stream()
                     .filter(Objects::nonNull)
                     .distinct()
                     .toList();
             this.size = this.source.size();
+            this.start = size == 0 ? 0 : Math.floorMod(seed, size);
+            this.step = size <= 1 ? 1 : resolveStep(seed, size);
             this.attempts = 0;
         }
 
@@ -90,7 +104,34 @@ public class CarouselShuffleService {
                 return null;
             }
 
-            return source.get(attempts++);
+            int index = size == 0 ? 0 : Math.floorMod(start + (attempts * step), size);
+            attempts++;
+            return source.get(index);
+        }
+
+        private int resolveStep(long seed, int size) {
+            int candidate = (int) Math.floorMod((seed * 7L) + 5L, size);
+            if (candidate == 0) {
+                candidate = 1;
+            }
+            while (gcd(candidate, size) != 1) {
+                candidate++;
+                if (candidate >= size) {
+                    candidate = 1;
+                }
+            }
+            return candidate;
+        }
+
+        private int gcd(int left, int right) {
+            int first = Math.abs(left);
+            int second = Math.abs(right);
+            while (second != 0) {
+                int remainder = first % second;
+                first = second;
+                second = remainder;
+            }
+            return first == 0 ? 1 : first;
         }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
@@ -4,8 +4,6 @@ import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -21,16 +19,14 @@ public class CarouselShuffleService {
 
     public List<Long> selectDisplayIds(CarouselCandidateBundle bundle, Long userId) {
         LinkedHashSet<Long> selectedIds = new LinkedHashSet<>();
-        long epochDay = LocalDate.now(ZoneOffset.UTC).toEpochDay();
-        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 11L));
-        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 23L));
+        OrderedBucket selectedBucket = new OrderedBucket(bundle.selectedFurnitureIds());
+        OrderedBucket furnitureBucket = new OrderedBucket(bundle.furnitureCategoryIds());
 
-        Map<SoozipCategory, ShuffledBucket> otherBuckets = new LinkedHashMap<>();
-        long salt = 31L;
+        Map<SoozipCategory, OrderedBucket> otherBuckets = new LinkedHashMap<>();
         for (Map.Entry<SoozipCategory, List<Long>> entry : bundle.otherCategoryIds().entrySet()) {
-            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), epochDay, salt++)));
+            otherBuckets.put(entry.getKey(), new OrderedBucket(entry.getValue()));
         }
-        List<ShuffledBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
+        List<OrderedBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
 
         while (selectedIds.size() < TARGET_SIZE && hasAnyRemaining(selectedBucket, furnitureBucket)) {
             addNext(selectedIds, selectedBucket);
@@ -46,7 +42,7 @@ public class CarouselShuffleService {
             otherIndex++;
         }
 
-        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 97L));
+        OrderedBucket fallbackBucket = new OrderedBucket(bundle.fallbackIds());
         while (selectedIds.size() < TARGET_SIZE && fallbackBucket.hasNext()) {
             addNext(selectedIds, fallbackBucket);
         }
@@ -54,15 +50,15 @@ public class CarouselShuffleService {
         return new ArrayList<>(selectedIds);
     }
 
-    private boolean hasAnyRemaining(ShuffledBucket selectedBucket, ShuffledBucket furnitureBucket) {
+    private boolean hasAnyRemaining(OrderedBucket selectedBucket, OrderedBucket furnitureBucket) {
         return selectedBucket.hasNext() || furnitureBucket.hasNext();
     }
 
-    private boolean hasAnyRemaining(List<ShuffledBucket> buckets) {
-        return buckets.stream().anyMatch(ShuffledBucket::hasNext);
+    private boolean hasAnyRemaining(List<OrderedBucket> buckets) {
+        return buckets.stream().anyMatch(OrderedBucket::hasNext);
     }
 
-    private void addNext(Set<Long> selectedIds, ShuffledBucket bucket) {
+    private void addNext(Set<Long> selectedIds, OrderedBucket bucket) {
         while (bucket.hasNext()) {
             Long nextId = bucket.next();
             if (nextId != null && selectedIds.add(nextId)) {
@@ -71,27 +67,17 @@ public class CarouselShuffleService {
         }
     }
 
-    private long computeSeed(Long userId, Long recentImageId, long epochDay, long salt) {
-        long baseUserId = userId == null ? 0L : userId;
-        long baseImageId = recentImageId == null ? 0L : recentImageId;
-        return (baseUserId * 31L) ^ (baseImageId * 17L) ^ (epochDay * 13L) ^ salt;
-    }
-
-    private static final class ShuffledBucket {
+    private static final class OrderedBucket {
         private final List<Long> source;
         private final int size;
-        private final int start;
-        private final int step;
         private int attempts;
 
-        private ShuffledBucket(List<Long> candidateIds, long seed) {
+        private OrderedBucket(List<Long> candidateIds) {
             this.source = candidateIds == null ? List.of() : candidateIds.stream()
                     .filter(Objects::nonNull)
                     .distinct()
                     .toList();
             this.size = this.source.size();
-            this.start = size == 0 ? 0 : Math.floorMod(seed, size);
-            this.step = size <= 1 ? 1 : resolveStep(seed, size);
             this.attempts = 0;
         }
 
@@ -104,34 +90,7 @@ public class CarouselShuffleService {
                 return null;
             }
 
-            int index = size == 0 ? 0 : Math.floorMod(start + (attempts * step), size);
-            attempts++;
-            return source.get(index);
-        }
-
-        private int resolveStep(long seed, int size) {
-            int candidate = (int) Math.floorMod((seed * 7L) + 5L, size);
-            if (candidate == 0) {
-                candidate = 1;
-            }
-            while (gcd(candidate, size) != 1) {
-                candidate++;
-                if (candidate >= size) {
-                    candidate = 1;
-                }
-            }
-            return candidate;
-        }
-
-        private int gcd(int left, int right) {
-            int first = Math.abs(left);
-            int second = Math.abs(right);
-            while (second != 0) {
-                int remainder = first % second;
-                first = second;
-                second = remainder;
-            }
-            return first == 0 ? 1 : first;
+            return source.get(attempts++);
         }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -175,7 +175,13 @@ public class UserServiceImpl implements UserService {
         Map<Long, List<String>> colorsByRawProductId = buildColorsByRawProductId(rawProductsByImageId);
         Map<Long, Boolean> jjymByRawProductId = buildJjymByRawProductId(findUser.getId(), rawProductsByImageId);
         Map<Long, Boolean> mirrorByHouseId = buildMirrorByHouseId(generateImages);
-        Map<Long, List<String>> selectedFurnitureNamesByHouseId = buildSelectedFurnitureNamesByHouseId(generateImages);
+        List<GenerateImage> fullFunnelImagesNeedingFallback = generateImages.stream()
+                .filter(generateImage -> generateImage.getResolvedGenerationType() == GenerateImageType.FULL_FUNNEL)
+                .filter(generateImage -> rawProductsByImageId.getOrDefault(generateImage.getId(), List.of()).isEmpty())
+                .toList();
+        Map<Long, List<String>> selectedFurnitureNamesByHouseId = fullFunnelImagesNeedingFallback.isEmpty()
+                ? Map.of()
+                : buildSelectedFurnitureNamesByHouseId(fullFunnelImagesNeedingFallback);
 
         Map<LocalDate, List<MyPageGeneratedImageV2Response.ItemResponse>> grouped = new LinkedHashMap<>();
         for (GenerateImage generateImage : generateImages) {

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.Jjym;
 import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductColorRepository;
@@ -23,9 +24,11 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
 import or.sopt.houme.domain.house.model.taste.entity.Tag;
 import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.house.repository.taste.tag.TagRepository;
 import or.sopt.houme.domain.preference.model.entity.Factor;
@@ -81,6 +84,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final HouseRepository houseRepository;
     private final HouseFloorPlanRepository houseFloorPlanRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
     private final TagRepository tagRepository;
     private final GenerateImageRepository generateImageRepository;
     private final CreditRepository creditRepository;
@@ -171,6 +175,7 @@ public class UserServiceImpl implements UserService {
         Map<Long, List<String>> colorsByRawProductId = buildColorsByRawProductId(rawProductsByImageId);
         Map<Long, Boolean> jjymByRawProductId = buildJjymByRawProductId(findUser.getId(), rawProductsByImageId);
         Map<Long, Boolean> mirrorByHouseId = buildMirrorByHouseId(generateImages);
+        Map<Long, List<String>> selectedFurnitureNamesByHouseId = buildSelectedFurnitureNamesByHouseId(generateImages);
 
         Map<LocalDate, List<MyPageGeneratedImageV2Response.ItemResponse>> grouped = new LinkedHashMap<>();
         for (GenerateImage generateImage : generateImages) {
@@ -191,13 +196,17 @@ public class UserServiceImpl implements UserService {
 
             GenerateImageType generationType = generateImage.getResolvedGenerationType();
             Banner banner = resolveBanner(generateImage, bannersById);
+            String productSummaryText = buildProductSummaryText(rawProducts);
+            if (productSummaryText == null && generationType == GenerateImageType.FULL_FUNNEL) {
+                productSummaryText = buildFullFunnelSummaryText(generateImage, selectedFurnitureNamesByHouseId);
+            }
             MyPageGeneratedImageV2Response.ItemResponse item = MyPageGeneratedImageV2Response.ItemResponse.of(
                     generateImage.getId(),
                     resolveMyPageViewType(generationType),
                     generateImage.getUrl(),
                     generateImage.getCreatedAt(),
                     banner != null ? banner.getBannerTitle() : null,
-                    buildProductSummaryText(rawProducts),
+                    productSummaryText,
                     resolveIsMirror(generateImage, mirrorByHouseId),
                     usedProducts
             );
@@ -645,6 +654,42 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
+     * FULL_FUNNEL 제목 fallback 생성을 위해 house에 연결된 선택 가구명을 미리 조회합니다.
+     */
+    private Map<Long, List<String>> buildSelectedFurnitureNamesByHouseId(List<GenerateImage> generateImages) {
+        List<Long> houseIds = generateImages.stream()
+                .map(GenerateImage::getHouse)
+                .filter(Objects::nonNull)
+                .map(House::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (houseIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return houseFurnitureRepository.findAllByHouseIdInWithFurniture(houseIds).stream()
+                .filter(mapping -> mapping.getHouse() != null && mapping.getHouse().getId() != null)
+                .filter(mapping -> mapping.getFurniture() != null)
+                .collect(Collectors.groupingBy(
+                        mapping -> mapping.getHouse().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(
+                                mapping -> resolveFurnitureSummaryName(mapping.getFurniture()),
+                                Collectors.toCollection(LinkedHashSet::new)
+                        )
+                ))
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> List.copyOf(entry.getValue()),
+                        (left, right) -> left,
+                        LinkedHashMap::new
+                ));
+    }
+
+    /**
      * 생성 이미지에 연결된 배너를 배너 맵 기준으로 보정하여 반환합니다.
      */
     private Banner resolveBanner(GenerateImage generateImage, Map<Long, Banner> bannersById) {
@@ -669,6 +714,35 @@ public class UserServiceImpl implements UserService {
             return firstName + "로 생성된 이미지";
         }
         return firstName + " 외 " + remainingCount + "개로 생성된 이미지";
+    }
+
+    private String buildFullFunnelSummaryText(
+            GenerateImage generateImage,
+            Map<Long, List<String>> selectedFurnitureNamesByHouseId
+    ) {
+        House house = generateImage.getHouse();
+        if (house == null || house.getId() == null) {
+            return null;
+        }
+
+        List<String> furnitureNames = selectedFurnitureNamesByHouseId.getOrDefault(house.getId(), List.of());
+        if (furnitureNames.isEmpty()) {
+            return null;
+        }
+
+        String firstName = furnitureNames.get(0);
+        int remainingCount = furnitureNames.size() - 1;
+        if (remainingCount <= 0) {
+            return firstName + " 기반으로 생성된 이미지";
+        }
+        return firstName + " 외 " + remainingCount + "개 가구로 생성된 이미지";
+    }
+
+    private String resolveFurnitureSummaryName(Furniture furniture) {
+        if (furniture.getFurnitureNameKr() != null && !furniture.getFurnitureNameKr().isBlank()) {
+            return furniture.getFurnitureNameKr();
+        }
+        return "가구";
     }
 
     private FloorPlan resolveFloorPlan(House house) {

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
@@ -31,7 +31,8 @@ class CarouselShuffleServiceTest {
 
         List<Long> result = carouselShuffleService.selectDisplayIds(bundle, 1L);
 
-        assertThat(result).startsWith(1L, 2L, 3L, 4L, 101L);
-        assertThat(result).containsSubsequence(1001L, 1002L);
+        assertThat(result.subList(0, 5)).containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 101L);
+        assertThat(result.subList(5, 7)).containsExactlyInAnyOrder(1001L, 1002L);
+        assertThat(result.subList(7, 9)).containsExactlyInAnyOrder(2001L, 2002L);
     }
 }

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -559,6 +559,150 @@ class UserServiceImplTest {
     }
 
     @Test
+    @DisplayName("FULL_FUNNEL에 raw product가 있으면 선택 가구 fallback 대신 raw product 제목을 사용한다")
+    void getUserGeneratedImageHistoryListV2_fullFunnelWithRawProducts_usesRawProducts() {
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        House fullFunnelHouse = House.builder()
+                .id(32L)
+                .user(user)
+                .isValid(true)
+                .build();
+
+        GenerateImage fullFunnelImage = GenerateImage.builder()
+                .id(302L)
+                .url("https://cdn.com/full-funnel-raw.png")
+                .house(fullFunnelHouse)
+                .generationType(GenerateImageType.FULL_FUNNEL)
+                .build();
+        ReflectionTestUtils.setField(fullFunnelImage, "createdAt", LocalDateTime.of(2026, 3, 25, 10, 0));
+
+        CurationRawProduct rawProduct = CurationRawProduct.builder()
+                .id(501L)
+                .source("soozip")
+                .category(SoozipCategory.FURNITURE)
+                .productId(2001L)
+                .productImageUrl("https://cdn.com/raw.png")
+                .productSiteUrl("https://mall/raw")
+                .productName("실제 상품")
+                .fetchedAt(LocalDateTime.of(2026, 3, 25, 8, 0))
+                .build();
+
+        Furniture desk = Furniture.builder()
+                .id(1L)
+                .furnitureNameKr("업무용 책상")
+                .build();
+
+        given(generateImageRepository.findAllByUserIdWithHouseAndBanner(user.getId()))
+                .willReturn(List.of(fullFunnelImage));
+        given(houseFloorPlanRepository.findAllByHouseIdIn(List.of(32L)))
+                .willReturn(List.of(HouseFloorPlan.builder().house(fullFunnelHouse).isReverse(false).build()));
+        given(generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(302L)))
+                .willReturn(List.of(GenerateImageRawProduct.of(fullFunnelImage, rawProduct, 1)));
+        given(curationRawProductColorRepository.findAllByCurationRawProductIdIn(List.of(501L)))
+                .willReturn(List.of());
+        given(recommendFurnitureRepository.findAllBySourceAndFurnitureProductIdIn(CurationSource.RAW, List.of(2001L)))
+                .willReturn(List.of());
+        given(houseFurnitureRepository.findAllByHouseIdInWithFurniture(anyList()))
+                .willReturn(List.of(HouseFurniture.builder().id(1L).house(fullFunnelHouse).furniture(desk).build()));
+
+        MyPageGeneratedImageV2Response response = userService.getUserGeneratedImageHistoryListV2(user);
+
+        MyPageGeneratedImageV2Response.ItemResponse item = response.groups().get(0).items().get(0);
+        assertThat(item.productSummaryText()).isEqualTo("실제 상품로 생성된 이미지");
+        then(houseFurnitureRepository).should(never()).findAllByHouseIdInWithFurniture(anyList());
+    }
+
+    @Test
+    @DisplayName("FULL_FUNNEL에 raw product도 선택 가구도 없으면 productSummaryText는 null이다")
+    void getUserGeneratedImageHistoryListV2_fullFunnelWithoutAnyProducts_returnsNullSummary() {
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        House fullFunnelHouse = House.builder()
+                .id(33L)
+                .user(user)
+                .isValid(true)
+                .build();
+
+        GenerateImage fullFunnelImage = GenerateImage.builder()
+                .id(303L)
+                .url("https://cdn.com/full-funnel-empty.png")
+                .house(fullFunnelHouse)
+                .generationType(GenerateImageType.FULL_FUNNEL)
+                .build();
+        ReflectionTestUtils.setField(fullFunnelImage, "createdAt", LocalDateTime.of(2026, 3, 25, 11, 0));
+
+        given(generateImageRepository.findAllByUserIdWithHouseAndBanner(user.getId()))
+                .willReturn(List.of(fullFunnelImage));
+        given(houseFloorPlanRepository.findAllByHouseIdIn(List.of(33L)))
+                .willReturn(List.of(HouseFloorPlan.builder().house(fullFunnelHouse).isReverse(false).build()));
+        given(generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(303L)))
+                .willReturn(List.of());
+        given(generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(303L)))
+                .willReturn(List.of());
+        given(houseFurnitureRepository.findAllByHouseIdInWithFurniture(List.of(33L)))
+                .willReturn(List.of());
+
+        MyPageGeneratedImageV2Response response = userService.getUserGeneratedImageHistoryListV2(user);
+
+        MyPageGeneratedImageV2Response.ItemResponse item = response.groups().get(0).items().get(0);
+        assertThat(item.productSummaryText()).isNull();
+    }
+
+    @Test
+    @DisplayName("FULL_FUNNEL fallback은 공백 이름을 가구로 대체하고 중복 가구명은 제거한다")
+    void getUserGeneratedImageHistoryListV2_fullFunnelFallback_deduplicatesAndUsesGenericName() {
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        House fullFunnelHouse = House.builder()
+                .id(34L)
+                .user(user)
+                .isValid(true)
+                .build();
+
+        GenerateImage fullFunnelImage = GenerateImage.builder()
+                .id(304L)
+                .url("https://cdn.com/full-funnel-dup.png")
+                .house(fullFunnelHouse)
+                .generationType(GenerateImageType.FULL_FUNNEL)
+                .build();
+        ReflectionTestUtils.setField(fullFunnelImage, "createdAt", LocalDateTime.of(2026, 3, 25, 12, 0));
+
+        Furniture blankNameFurniture = Furniture.builder()
+                .id(1L)
+                .furnitureNameKr(" ")
+                .build();
+        Furniture duplicateDesk1 = Furniture.builder()
+                .id(2L)
+                .furnitureNameKr("책상")
+                .build();
+        Furniture duplicateDesk2 = Furniture.builder()
+                .id(3L)
+                .furnitureNameKr("책상")
+                .build();
+
+        given(generateImageRepository.findAllByUserIdWithHouseAndBanner(user.getId()))
+                .willReturn(List.of(fullFunnelImage));
+        given(houseFloorPlanRepository.findAllByHouseIdIn(List.of(34L)))
+                .willReturn(List.of(HouseFloorPlan.builder().house(fullFunnelHouse).isReverse(false).build()));
+        given(generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(304L)))
+                .willReturn(List.of());
+        given(generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(304L)))
+                .willReturn(List.of());
+        given(houseFurnitureRepository.findAllByHouseIdInWithFurniture(List.of(34L)))
+                .willReturn(List.of(
+                        HouseFurniture.builder().id(1L).house(fullFunnelHouse).furniture(blankNameFurniture).build(),
+                        HouseFurniture.builder().id(2L).house(fullFunnelHouse).furniture(duplicateDesk1).build(),
+                        HouseFurniture.builder().id(3L).house(fullFunnelHouse).furniture(duplicateDesk2).build()
+                ));
+
+        MyPageGeneratedImageV2Response response = userService.getUserGeneratedImageHistoryListV2(user);
+
+        MyPageGeneratedImageV2Response.ItemResponse item = response.groups().get(0).items().get(0);
+        assertThat(item.productSummaryText()).isEqualTo("가구 외 1개 가구로 생성된 이미지");
+    }
+
+    @Test
     @DisplayName("성공적으로_유저정보를_업데이트한다")
     void updateUser_success() {
         // given

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -9,6 +9,7 @@ import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProductColor;
 import or.sopt.houme.domain.furniture.model.entity.CurationSource;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.Jjym;
 import or.sopt.houme.domain.furniture.model.entity.RecommendFurniture;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
@@ -23,11 +24,13 @@ import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageUsedProductRepository;
 import or.sopt.houme.domain.house.model.entity.House;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
 import or.sopt.houme.domain.house.model.entity.enums.Equilibrium;
 import or.sopt.houme.domain.house.model.entity.enums.Form;
 import or.sopt.houme.domain.house.model.entity.enums.Structure;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
 import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.preference.model.entity.GenerateImagePreference;
 import or.sopt.houme.domain.preference.model.entity.Preference;
@@ -67,6 +70,7 @@ class UserServiceImplTest {
     private final UserRepository userRepository = mock(UserRepository.class);
     private final HouseRepository houseRepository = mock(HouseRepository.class);
     private final HouseFloorPlanRepository houseFloorPlanRepository = mock(HouseFloorPlanRepository.class);
+    private final HouseFurnitureRepository houseFurnitureRepository = mock(HouseFurnitureRepository.class);
     private final TagRepository tagRepository = mock(TagRepository.class);
     private final GenerateImageRepository generateImageRepository = mock(GenerateImageRepository.class);
     private final CreditRepository creditRepository = mock(CreditRepository.class);
@@ -87,6 +91,7 @@ class UserServiceImplTest {
             userRepository,
             houseRepository,
             houseFloorPlanRepository,
+            houseFurnitureRepository,
             tagRepository,
             generateImageRepository,
             creditRepository,
@@ -499,6 +504,58 @@ class UserServiceImplTest {
         assertThat(secondItem.usedProducts()).hasSize(1);
         assertThat(secondItem.usedProducts().get(0).isJjym()).isTrue();
         assertThat(secondItem.usedProducts().get(0).colors()).containsExactly("우드");
+    }
+
+    @Test
+    @DisplayName("마이페이지 생성 이미지 이력 v2 조회 시 FULL_FUNNEL은 선택 가구 기반 fallback 제목을 반환한다")
+    void getUserGeneratedImageHistoryListV2_fullFunnelFallbackSummary_success() {
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        House fullFunnelHouse = House.builder()
+                .id(31L)
+                .user(user)
+                .isValid(true)
+                .build();
+
+        GenerateImage fullFunnelImage = GenerateImage.builder()
+                .id(301L)
+                .url("https://cdn.com/full-funnel-image.png")
+                .house(fullFunnelHouse)
+                .generationType(GenerateImageType.FULL_FUNNEL)
+                .build();
+        ReflectionTestUtils.setField(fullFunnelImage, "createdAt", LocalDateTime.of(2026, 3, 25, 9, 0));
+
+        Furniture desk = Furniture.builder()
+                .id(1L)
+                .furnitureNameKr("업무용 책상")
+                .build();
+        Furniture chair = Furniture.builder()
+                .id(2L)
+                .furnitureNameKr("의자")
+                .build();
+
+        given(generateImageRepository.findAllByUserIdWithHouseAndBanner(user.getId()))
+                .willReturn(List.of(fullFunnelImage));
+        given(houseFloorPlanRepository.findAllByHouseIdIn(List.of(31L)))
+                .willReturn(List.of(HouseFloorPlan.builder().house(fullFunnelHouse).isReverse(false).build()));
+        given(generateImageRawProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(301L)))
+                .willReturn(List.of());
+        given(generateImageUsedProductRepository.findAllByGenerateImageIdInWithRawProduct(List.of(301L)))
+                .willReturn(List.of());
+        given(houseFurnitureRepository.findAllByHouseIdInWithFurniture(List.of(31L)))
+                .willReturn(List.of(
+                        HouseFurniture.builder().id(1L).house(fullFunnelHouse).furniture(desk).build(),
+                        HouseFurniture.builder().id(2L).house(fullFunnelHouse).furniture(chair).build()
+                ));
+
+        MyPageGeneratedImageV2Response response = userService.getUserGeneratedImageHistoryListV2(user);
+
+        assertThat(response.groups()).hasSize(1);
+        MyPageGeneratedImageV2Response.ItemResponse item = response.groups().get(0).items().get(0);
+        assertThat(item.viewType()).isEqualTo(MyPageGeneratedImageV2Response.ViewType.FULL_FUNNEL);
+        assertThat(item.bannerTitle()).isNull();
+        assertThat(item.productSummaryText()).isEqualTo("업무용 책상 외 1개 가구로 생성된 이미지");
+        assertThat(item.usedProducts()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #564 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- funnel 작업 시, title 데이터가 제대로 내려가지 않는 문제를 수정하였습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 따로 큰 스키마 변경이나 클래스 추가 없이, 로직만 추가된 내용입니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 마이페이지 생성 이미지 목록의 요약 문구 생성 로직을 확장하여, 특정 생성 타입에서 선택된 가구 정보를 모아 대체 제목을 생성하도록 개선했습니다.
  * 다수의 집 정보를 한 번에 조회해 요약 생성에 활용할 수 있도록 조회 범위를 확장했습니다.

* **테스트**
  * FULL_FUNNEL 요약 동작을 검증하는 단위 테스트들을 추가 및 보완했습니다.
  * 캐러셀 관련 테스트의 검증 방식을 더 엄격하게 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->