### PR TITLE
[TEST] 캐러셀 셔플 테스트 랜덤 순서 검증 반영

### DIFF
--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
@@ -31,7 +31,8 @@ class CarouselShuffleServiceTest {
 
         List<Long> result = carouselShuffleService.selectDisplayIds(bundle, 1L);
 
-        assertThat(result).startsWith(1L, 2L, 3L, 4L, 101L);
-        assertThat(result).containsSubsequence(1001L, 1002L);
+        assertThat(result.subList(0, 5)).containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 101L);
+        assertThat(result.subList(5, 7)).containsExactlyInAnyOrder(1001L, 1002L);
+        assertThat(result.subList(7, 9)).containsExactlyInAnyOrder(2001L, 2002L);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #566

## 📝 Summary

- `CarouselShuffleServiceTest`의 고정 순서 검증을 제거했습니다.
- 캐러셀 셔플 로직의 시드 기반 랜덤 순서를 유지할 수 있도록 테스트를 구간별 포함 값 검증 방식으로 수정했습니다.
- 첫 구간은 `선택 가구 4개 + 일반 가구 1개`, 이후 구간은 기타 카테고리와 fallback으로 채워지는 정책만 검증하도록 정리했습니다.


## 🙏 Question & PR point

- 실제 서비스 로직은 버킷 내부 순서를 시드 기반으로 순환시키므로, 테스트가 특정 고정 순서를 기대하면 정책과 충돌합니다.
- 이번 변경은 로직을 수정하지 않고 테스트만 정책에 맞게 보정한 PR입니다.
- 검증 포인트는 “정확한 순서”가 아니라 “각 구간에 어떤 후보군이 배치되는가”입니다.


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Tests**
  * 캐러셀 디스플레이 ID 선택 기능의 검증 로직이 개선되었습니다. 구간별 검증으로 변경되어 카테고리별 ID 그룹이 더욱 정밀하게 검사됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->