### PR TITLE
[CHORE] 최근 사용 도면 조회 시 최근 사용 뷰 표시

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -142,7 +142,30 @@ public class GenerateImageTransactionService {
             String finalPrompt,
             ImageUploadResponseDTO imageResponse
     ) {
-        House house = houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
+        return saveBannerImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                banner,
+                floorPlanId,
+                isMirror,
+                null,
+                finalPrompt,
+                imageResponse
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BannerGenerateImageResponse saveBannerImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Banner banner,
+            Long floorPlanId,
+            boolean isMirror,
+            String floorPlanView,
+            String finalPrompt,
+            ImageUploadResponseDTO imageResponse
+    ) {
+        House house = houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror, floorPlanView);
 
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
@@ -167,7 +190,34 @@ public class GenerateImageTransactionService {
             java.util.List<Long> furnitureIds,
             java.util.List<Long> moodBoardIds
     ) {
-        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror);
+        return saveV4ImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                floorPlanId,
+                isMirror,
+                null,
+                finalPrompt,
+                imageResponse,
+                activity,
+                furnitureIds,
+                moodBoardIds
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GenerateImageV4Response saveV4ImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Long floorPlanId,
+            boolean isMirror,
+            String floorPlanView,
+            String finalPrompt,
+            ImageUploadResponseDTO imageResponse,
+            Activity activity,
+            java.util.List<Long> furnitureIds,
+            java.util.List<Long> moodBoardIds
+    ) {
+        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror, floorPlanView);
         houseService.updateHouseActivity(house.getId(), activity);
 
         if (furnitureIds != null && !furnitureIds.isEmpty()) {
@@ -198,7 +248,30 @@ public class GenerateImageTransactionService {
             ImageUploadResponseDTO imageResponse,
             List<CurationRawProduct> selectedProducts
     ) {
-        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror);
+        return saveProductImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                floorPlanId,
+                isMirror,
+                null,
+                finalPrompt,
+                imageResponse,
+                selectedProducts
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GenerateImageV4Response saveProductImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            Long floorPlanId,
+            boolean isMirror,
+            String floorPlanView,
+            String finalPrompt,
+            ImageUploadResponseDTO imageResponse,
+            List<CurationRawProduct> selectedProducts
+    ) {
+        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror, floorPlanView);
 
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -402,6 +402,7 @@ public class GenerateImageFacade {
                     banner,
                     request.floorPlanId(),
                     request.isMirror(),
+                    request.floorPlanView(),
                     prompt,
                     imageUploadResponseDTO
             );
@@ -469,6 +470,7 @@ public class GenerateImageFacade {
                     style,
                     request.floorPlanId(),
                     request.isMirror(),
+                    request.floorPlanView(),
                     prompt,
                     imageUploadResponseDTO
             );
@@ -554,6 +556,7 @@ public class GenerateImageFacade {
                     lockedCredit,
                     request.floorPlanId(),
                     request.isMirror(),
+                    request.floorPlanView(),
                     prompt,
                     imageUploadResponseDTO,
                     activity,
@@ -621,6 +624,7 @@ public class GenerateImageFacade {
                     lockedCredit,
                     request.floorPlanId(),
                     request.isMirror(),
+                    request.floorPlanView(),
                     prompt,
                     imageUploadResponseDTO,
                     selectedProducts

--- a/src/main/java/or/sopt/houme/domain/house/model/entity/mapping/HouseFloorPlan.java
+++ b/src/main/java/or/sopt/houme/domain/house/model/entity/mapping/HouseFloorPlan.java
@@ -26,4 +26,7 @@ public class HouseFloorPlan {
 
     @Column(name = "is_reverse", nullable = false)
     private boolean isReverse;
+
+    @Column(name = "selected_view")
+    private String selectedView;
 }

--- a/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanItemResponse.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanItemResponse.java
@@ -1,0 +1,16 @@
+package or.sopt.houme.domain.house.presentation.floorPlan.dto.response;
+
+public record RecentFloorPlanItemResponse(
+        String imageUrl,
+        String view,
+        Boolean isRecentUsedView
+) {
+
+    public static RecentFloorPlanItemResponse of(
+            String imageUrl,
+            String view,
+            boolean isRecentUsedView
+    ) {
+        return new RecentFloorPlanItemResponse(imageUrl, view, isRecentUsedView);
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanResponse.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/floorPlan/dto/response/RecentFloorPlanResponse.java
@@ -7,14 +7,14 @@ public record RecentFloorPlanResponse(
         Long floorPlanId,
         String floorPlanName,
         String equilibrium,
-        List<ExploreHouseTemplateDetailItemResponse> floorPlans
+        List<RecentFloorPlanItemResponse> floorPlans
 ) {
 
     public static RecentFloorPlanResponse withRecent(
             Long floorPlanId,
             String floorPlanName,
             String equilibrium,
-            List<ExploreHouseTemplateDetailItemResponse> floorPlans
+            List<RecentFloorPlanItemResponse> floorPlans
     ) {
         return new RecentFloorPlanResponse(Boolean.TRUE, floorPlanId, floorPlanName, equilibrium, floorPlans);
     }

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseService.java
@@ -36,8 +36,12 @@ public interface HouseService {
     // 템플릿 기반 이미지 생성을 위한 house 저장
     House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror);
 
+    House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror, String selectedView);
+
     // houseId와 floorPlan 저장
     void saveHouseFloorPlan(House house, Long floorPlanId, boolean isMirror);
+
+    void saveHouseFloorPlan(House house, Long floorPlanId, boolean isMirror, String selectedView);
 
     // house와 furniture 저장
     void saveHouseFurniture(House house, List<Long> furnitureIds);

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
@@ -118,6 +118,12 @@ public class HouseServiceImpl implements HouseService {
     @Transactional
     @Override
     public House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror) {
+        return createTemplateHouse(user, banner, prompt, floorPlanId, isMirror, null);
+    }
+
+    @Transactional
+    @Override
+    public House createTemplateHouse(User user, Banner banner, String prompt, Long floorPlanId, boolean isMirror, String selectedView) {
         FloorPlan floorPlan = floorPlanRepository.findById(floorPlanId)
                 .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
 
@@ -130,7 +136,7 @@ public class HouseServiceImpl implements HouseService {
                 .build();
 
         House savedHouse = houseRepository.save(house);
-        saveHouseFloorPlan(savedHouse, floorPlanId, isMirror);
+        saveHouseFloorPlan(savedHouse, floorPlanId, isMirror, selectedView);
         return savedHouse;
     }
 
@@ -150,7 +156,12 @@ public class HouseServiceImpl implements HouseService {
     @Transactional
     @Override
     public void saveHouseFloorPlan(House house, Long floorPlanId, boolean isMirror) {
+        saveHouseFloorPlan(house, floorPlanId, isMirror, null);
+    }
 
+    @Transactional
+    @Override
+    public void saveHouseFloorPlan(House house, Long floorPlanId, boolean isMirror, String selectedView) {
         FloorPlan floorPlan = floorPlanRepository.findById(floorPlanId)
                 .orElseThrow(() -> new HouseException(ErrorCode.NOT_FOUND_FLOOR_PLAN));
 
@@ -158,6 +169,7 @@ public class HouseServiceImpl implements HouseService {
                 .house(house)
                 .floorPlan(floorPlan)
                 .isReverse(isMirror)
+                .selectedView(selectedView)
                 .build();
 
         houseFloorPlanRepository.save(houseFloorPlan);

--- a/src/main/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImpl.java
@@ -11,6 +11,7 @@ import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHou
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHouseTemplateDetailResponse;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHouseTemplateItemResponse;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.ExploreHouseTemplateListResponse;
+import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.RecentFloorPlanItemResponse;
 import or.sopt.houme.domain.house.presentation.floorPlan.dto.response.RecentFloorPlanResponse;
 import or.sopt.houme.domain.house.model.entity.mapping.HouseFloorPlan;
 import or.sopt.houme.domain.house.model.floorPlan.entity.FloorPlan;
@@ -78,18 +79,23 @@ public class FloorPlanServiceImpl implements FloorPlanService {
             return RecentFloorPlanResponse.noRecent();
         }
 
-        FloorPlan floorPlan = recentGenerateImage.get().getHouse().getHouseFloorPlans().stream()
+        HouseFloorPlan recentHouseFloorPlan = recentGenerateImage.get().getHouse().getHouseFloorPlans().stream()
                 .sorted((left, right) -> Long.compare(safeHouseFloorPlanId(left), safeHouseFloorPlanId(right)))
-                .map(HouseFloorPlan::getFloorPlan)
-                .filter(java.util.Objects::nonNull)
+                .filter(mapping -> mapping != null && mapping.getFloorPlan() != null)
                 .findFirst()
                 .orElse(null);
-        if (floorPlan == null) {
+        if (recentHouseFloorPlan == null) {
             return RecentFloorPlanResponse.noRecent();
         }
+        FloorPlan floorPlan = recentHouseFloorPlan.getFloorPlan();
+        String selectedView = normalizeView(recentHouseFloorPlan.getSelectedView());
 
-        List<ExploreHouseTemplateDetailItemResponse> floorPlans = resolveFloorPlanImages(floorPlan).stream()
-                .map(image -> ExploreHouseTemplateDetailItemResponse.of(image.url(), image.view()))
+        List<RecentFloorPlanItemResponse> floorPlans = resolveFloorPlanImages(floorPlan).stream()
+                .map(image -> RecentFloorPlanItemResponse.of(
+                        image.url(),
+                        image.view(),
+                        isRecentUsedView(image.view(), selectedView)
+                ))
                 .toList();
 
         return RecentFloorPlanResponse.withRecent(
@@ -162,6 +168,23 @@ public class FloorPlanServiceImpl implements FloorPlanService {
             return Long.MAX_VALUE;
         }
         return mapping.getId();
+    }
+
+    private boolean isRecentUsedView(String view, String selectedView) {
+        if (selectedView == null) {
+            return false;
+        }
+        String normalizedView = normalizeView(view);
+        return normalizedView != null && selectedView.equalsIgnoreCase(normalizedView);
+    }
+
+    private String normalizeView(String view) {
+        if (view == null) {
+            return null;
+        }
+
+        String normalized = view.trim();
+        return normalized.isEmpty() ? null : normalized;
     }
 
     private List<FloorPlanImageItem> resolveFloorPlanImages(FloorPlan floorPlan) {

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionServiceTest.java
@@ -83,7 +83,7 @@ class GenerateImageTransactionServiceTest {
                 .build();
 
         when(banner.getBannerType()).thenReturn(BannerType.BANNER);
-        when(houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror))
+        when(houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror, null))
                 .thenReturn(house);
         when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenReturn(generateImage);
@@ -101,7 +101,7 @@ class GenerateImageTransactionServiceTest {
         assertThat(response.imageId()).isEqualTo(101L);
         assertThat(response.imageUrl()).isEqualTo("https://cdn.example.com/file.jpg");
         assertThat(response.isMirror()).isTrue();
-        verify(houseService).createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror);
+        verify(houseService).createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror, null);
         verify(generateImageService).createGenerateImage(imageResponse, house, GenerateImageType.BANNER);
         verify(creditService).commitCreditDeletion(lockedCredit);
         verify(userService).updateHasGeneratedImage(user);
@@ -122,7 +122,7 @@ class GenerateImageTransactionServiceTest {
         );
 
         when(banner.getBannerType()).thenReturn(BannerType.BANNER);
-        when(houseService.createTemplateHouse(user, banner, "prompt", 1L, false)).thenReturn(house);
+        when(houseService.createTemplateHouse(user, banner, "prompt", 1L, false, null)).thenReturn(house);
         when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenThrow(new RuntimeException("image save failed"));
 
@@ -160,7 +160,7 @@ class GenerateImageTransactionServiceTest {
                 .generationType(GenerateImageType.LIST)
                 .build();
 
-        when(houseService.createTemplateHouse(user, banner, "prompt", 2L, true)).thenReturn(house);
+        when(houseService.createTemplateHouse(user, banner, "prompt", 2L, true, null)).thenReturn(house);
         when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.BANNER))
                 .thenReturn(generateImage);
         doThrow(new RuntimeException("credit commit failed"))
@@ -195,7 +195,7 @@ class GenerateImageTransactionServiceTest {
                 .generationType(GenerateImageType.FULL_FUNNEL)
                 .build();
 
-        when(houseService.createTemplateHouse(user, null, "prompt", 3L, false)).thenReturn(house);
+        when(houseService.createTemplateHouse(user, null, "prompt", 3L, false, null)).thenReturn(house);
         when(houseService.updateHouseActivity(anyLong(), eq(Activity.REMOTE_WORK))).thenReturn(house);
         when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.FULL_FUNNEL))
                 .thenReturn(generateImage);
@@ -238,7 +238,7 @@ class GenerateImageTransactionServiceTest {
                 .generationType(GenerateImageType.PRODUCT)
                 .build();
 
-        when(houseService.createTemplateHouse(user, null, "prompt", 1L, false)).thenReturn(house);
+        when(houseService.createTemplateHouse(user, null, "prompt", 1L, false, null)).thenReturn(house);
         when(generateImageService.createGenerateImage(imageResponse, house, GenerateImageType.PRODUCT))
                 .thenReturn(generateImage);
 

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -432,6 +432,7 @@ class GenerateImageFacadeTest {
                 eq(11L),
                 eq(false),
                 any(),
+                any(),
                 eq(imageUploadResponseDTO)
         )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
 
@@ -446,6 +447,7 @@ class GenerateImageFacadeTest {
                 eq(banner),
                 eq(11L),
                 eq(false),
+                any(),
                 any(),
                 eq(imageUploadResponseDTO)
         );
@@ -538,6 +540,7 @@ class GenerateImageFacadeTest {
                 eq(banner),
                 eq(11L),
                 eq(false),
+                any(),
                 any(),
                 eq(imageUploadResponseDTO)
         )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
@@ -644,6 +647,7 @@ class GenerateImageFacadeTest {
                 eq(11L),
                 eq(true),
                 any(),
+                any(),
                 eq(imageUploadResponseDTO),
                 eq(Activity.REMOTE_WORK),
                 eq(List.of(7L, 8L)),
@@ -667,6 +671,7 @@ class GenerateImageFacadeTest {
                 eq(lockedCredit),
                 eq(11L),
                 eq(true),
+                any(),
                 any(),
                 eq(imageUploadResponseDTO),
                 eq(Activity.REMOTE_WORK),
@@ -793,7 +798,7 @@ class GenerateImageFacadeTest {
                 .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
         when(geminiImageService.createImageWithReferences(any(), any())).thenReturn(imageUploadResponseDTO);
         when(generateImageTransactionService.saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
         )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
 
         GenerateImageV4Response response = generateImageFacade.generateImageByProducts(user, request);
@@ -810,7 +815,7 @@ class GenerateImageFacadeTest {
                         && urls.contains("https://p3"))
         );
         verify(generateImageTransactionService).saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
+                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
         );
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleServiceTest.java
@@ -31,7 +31,8 @@ class CarouselShuffleServiceTest {
 
         List<Long> result = carouselShuffleService.selectDisplayIds(bundle, 1L);
 
-        assertThat(result).startsWith(1L, 2L, 3L, 4L, 101L);
-        assertThat(result).containsSubsequence(1001L, 1002L);
+        assertThat(result.subList(0, 5)).containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 101L);
+        assertThat(result.subList(5, 7)).containsExactlyInAnyOrder(1001L, 1002L);
+        assertThat(result.subList(7, 9)).containsExactlyInAnyOrder(2001L, 2002L);
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/floorPlan/FloorPlanServiceImplTest.java
@@ -91,6 +91,7 @@ class FloorPlanServiceImplTest {
         HouseFloorPlan houseFloorPlan = HouseFloorPlan.builder()
                 .id(100L)
                 .floorPlan(floorPlan)
+                .selectedView("SIDE_VIEW")
                 .build();
         House house = House.builder()
                 .houseFloorPlans(List.of(houseFloorPlan))
@@ -112,10 +113,10 @@ class FloorPlanServiceImplTest {
         assertThat(response.floorPlanName()).isEqualTo("복층 오피스텔");
         assertThat(response.equilibrium()).isEqualTo(Equilibrium.BETWEEN_6_10.getDescription());
         assertThat(response.floorPlans())
-                .extracting("imageUrl", "view")
+                .extracting("imageUrl", "view", "isRecentUsedView")
                 .containsExactly(
-                        tuple("https://image-1", "TOP_VIEW"),
-                        tuple("https://image-2", "SIDE_VIEW")
+                        tuple("https://image-1", "TOP_VIEW", false),
+                        tuple("https://image-2", "SIDE_VIEW", true)
                 );
     }
 


### PR DESCRIPTION
## 📣 Related Issue
- close #561

## 📝 Summary
- `/api/v2/recent-floor-plan` 응답에 최근 사용한 뷰 여부를 표시하는 값을 추가했습니다.
- 최근 사용 도면의 각 뷰 응답 항목에 `isRecentUsedView` 필드를 내려주도록 수정했습니다.
- 배너/스타일/V4/상품 기반 이미지 생성 api에서 선택한 `floorPlanView`를 houseFloorPlan 테이블에 저장하도록 필드를 추가했습니다.

## 🙏 Question & PR point
- 기존에는 최근 사용 도면 조회 시 여러 뷰를 함께 내려주더라도, 어떤 뷰가 실제 최근 사용 뷰인지 식별할 수 없었습니다.
- 이를 위해 `HouseFloorPlan`에 `selected_view` nullable 컬럼을 추가했고, `floorPlanView`를 받는 이미지 생성 경로에서 해당 값을 저장하도록 처리했습니다.
- 기존 데이터나 뷰 정보가 없는 생성 이력은 `selected_view`가 없을 수 있으므로, 이 경우 `isRecentUsedView`는 모두 `false`로 응답합니다.

```json
// 최근 생성이력 있는 경우
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "hasRecentImage": true,
    "floorPlanId": 1,
    "floorPlanName": "다용도실이 있는 원룸",
    "equilibrium": "10평대",
    "floorPlans": [
      {
        "imageUrl": "https://google.com/top-view",
        "view": "탑 뷰",
        "isRecentUsedView": false
      },
      {
        "imageUrl": "https://google.com/window-view",
        "view": "창가 뷰",
        "isRecentUsedView": true
      },
      {
        "imageUrl": "https://google.com/side-view",
        "view": "측면 뷰",
        "isRecentUsedView": false
      }
    ]
  }
}

// 최근 생성이력 없는 경우
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "hasRecentImage": false,
    "floorPlanId": null,
    "floorPlanName": null,
    "equilibrium": null,
    "floorPlans": []
  }
}
```


## 📬 Postman
- 해당 없음