### PR TITLE
[CHORE] 이미지 생성 house 선저장 및 캐러셀 정합성 개선

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/GenerateImageTransactionService.java
@@ -165,8 +165,60 @@ public class GenerateImageTransactionService {
             String finalPrompt,
             ImageUploadResponseDTO imageResponse
     ) {
-        House house = houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror, floorPlanView);
+        House house = createTemplateHouseBeforeImageGeneration(
+                user,
+                banner,
+                floorPlanId,
+                isMirror,
+                floorPlanView,
+                finalPrompt,
+                null,
+                null,
+                null
+        );
 
+        return saveBannerImageAndConfirmCredit(
+                user,
+                lockedCredit,
+                house,
+                banner,
+                imageResponse,
+                isMirror
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public House createTemplateHouseBeforeImageGeneration(
+            User user,
+            Banner banner,
+            Long floorPlanId,
+            boolean isMirror,
+            String floorPlanView,
+            String finalPrompt,
+            Activity activity,
+            List<Long> furnitureIds,
+            List<Long> moodBoardIds
+    ) {
+        House house = houseService.createTemplateHouse(user, banner, finalPrompt, floorPlanId, isMirror, floorPlanView);
+        if (activity != null) {
+            houseService.updateHouseActivity(house.getId(), activity);
+        }
+        houseService.saveHouseFurniture(house, furnitureIds);
+        if (moodBoardIds != null && !moodBoardIds.isEmpty()) {
+            houseService.saveHouseTaste(house, moodBoardIds);
+        }
+        return house;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BannerGenerateImageResponse saveBannerImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            House house,
+            Banner banner,
+            ImageUploadResponseDTO imageResponse,
+            boolean isMirror
+    ) {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
@@ -217,16 +269,29 @@ public class GenerateImageTransactionService {
             java.util.List<Long> furnitureIds,
             java.util.List<Long> moodBoardIds
     ) {
-        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror, floorPlanView);
-        houseService.updateHouseActivity(house.getId(), activity);
+        House house = createTemplateHouseBeforeImageGeneration(
+                user,
+                null,
+                floorPlanId,
+                isMirror,
+                floorPlanView,
+                finalPrompt,
+                activity,
+                furnitureIds,
+                moodBoardIds
+        );
 
-        if (furnitureIds != null && !furnitureIds.isEmpty()) {
-            houseService.saveHouseFurniture(house, furnitureIds);
-        }
-        if (moodBoardIds != null && !moodBoardIds.isEmpty()) {
-            houseService.saveHouseTaste(house, moodBoardIds);
-        }
+        return saveV4ImageAndConfirmCredit(user, lockedCredit, house, imageResponse, isMirror);
+    }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GenerateImageV4Response saveV4ImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            House house,
+            ImageUploadResponseDTO imageResponse,
+            boolean isMirror
+    ) {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,
@@ -271,8 +336,30 @@ public class GenerateImageTransactionService {
             ImageUploadResponseDTO imageResponse,
             List<CurationRawProduct> selectedProducts
     ) {
-        House house = houseService.createTemplateHouse(user, null, finalPrompt, floorPlanId, isMirror, floorPlanView);
+        House house = createTemplateHouseBeforeImageGeneration(
+                user,
+                null,
+                floorPlanId,
+                isMirror,
+                floorPlanView,
+                finalPrompt,
+                null,
+                null,
+                null
+        );
 
+        return saveProductImageAndConfirmCredit(user, lockedCredit, house, imageResponse, selectedProducts, isMirror);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GenerateImageV4Response saveProductImageAndConfirmCredit(
+            User user,
+            Credit lockedCredit,
+            House house,
+            ImageUploadResponseDTO imageResponse,
+            List<CurationRawProduct> selectedProducts,
+            boolean isMirror
+    ) {
         GenerateImage generateImage = generateImageService.createGenerateImage(
                 imageResponse,
                 house,

--- a/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacade.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.domain.banner.model.entity.Banner;
+import or.sopt.houme.domain.banner.model.entity.BannerCurationRawProduct;
 import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.banner.model.vo.BannerStyleAnswerChip;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
@@ -13,10 +14,12 @@ import or.sopt.houme.domain.credit.model.entity.Credit;
 import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import or.sopt.houme.domain.credit.service.CreditService;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.CurationRawProductFurniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.model.entity.ActivityFurniture;
 import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
@@ -96,6 +99,7 @@ public class GenerateImageFacade {
     private final FurnitureTagRepository furnitureTagRepository;
     private final ActivityFurnitureRepository activityFurnitureRepository;
     private final CurationRawProductRepository curationRawProductRepository;
+    private final CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
     private final FloorPlanImageJsonCodec floorPlanImageJsonCodec;
     private final ObjectMapper objectMapper;
 
@@ -378,6 +382,17 @@ public class GenerateImageFacade {
             String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildReferenceImageUrls(banner, selectedChip, floorPlanImageUrl);
             String prompt = buildBannerPrompt(banner, selectedChip, floorPlan);
+            House house = generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                    user,
+                    banner,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    request.floorPlanView(),
+                    prompt,
+                    null,
+                    extractFurnitureIdsFromRawProducts(resolveBannerRawProductsForCarousel(banner, selectedChip)),
+                    null
+            );
             log.info(
                     "배너 템플릿 이미지 생성 프롬프트/참고이미지 bannerId={}, answerId={}, prompt={}, referenceImageUrls={}",
                     banner.getId(),
@@ -399,12 +414,10 @@ public class GenerateImageFacade {
             BannerGenerateImageResponse response = generateImageTransactionService.saveBannerImageAndConfirmCredit(
                     user,
                     lockedCredit,
+                    house,
                     banner,
-                    request.floorPlanId(),
-                    request.isMirror(),
-                    request.floorPlanView(),
-                    prompt,
-                    imageUploadResponseDTO
+                    imageUploadResponseDTO,
+                    request.isMirror()
             );
             log.info("배너 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());
             return response;
@@ -447,6 +460,17 @@ public class GenerateImageFacade {
             String floorPlanImageUrl = resolveFloorPlanImageUrl(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildStyleReferenceImageUrls(style, floorPlanImageUrl);
             String prompt = buildStylePrompt(style, floorPlan);
+            House house = generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                    user,
+                    style,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    request.floorPlanView(),
+                    prompt,
+                    null,
+                    extractFurnitureIdsFromRawProducts(extractBannerRawProducts(style)),
+                    null
+            );
             log.info(
                     "스타일 템플릿 이미지 생성 프롬프트/참고이미지 bannerId={}, prompt={}, referenceImageUrls={}",
                     style.getId(),
@@ -467,12 +491,10 @@ public class GenerateImageFacade {
             BannerGenerateImageResponse response = generateImageTransactionService.saveBannerImageAndConfirmCredit(
                     user,
                     lockedCredit,
+                    house,
                     style,
-                    request.floorPlanId(),
-                    request.isMirror(),
-                    request.floorPlanView(),
-                    prompt,
-                    imageUploadResponseDTO
+                    imageUploadResponseDTO,
+                    request.isMirror()
             );
             log.info("스타일 템플릿 기반 인테리어 이미지 생성 저장 완료 imageId={}", response.imageId());
             return OtherStyleGenerateImageResponse.of(response.imageId(), response.imageUrl(), response.isMirror());
@@ -535,6 +557,17 @@ public class GenerateImageFacade {
             String floorPlanImageUrl = resolveFloorPlanImageUrlStrict(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildV4ReferenceImageUrls(floorPlanImageUrl, matchedFurnitureTags);
             String prompt = buildV4Prompt(floorPlan, selectedTag, matchedFurnitureTags);
+            House house = generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                    user,
+                    null,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    request.floorPlanView(),
+                    prompt,
+                    activity,
+                    combinedFurnitureIds,
+                    request.moodBoardIds()
+            );
 
             log.info(
                     "V4 이미지 생성 프롬프트/참고이미지 tagId={}, prompt={}, referenceImageCount={}",
@@ -554,14 +587,9 @@ public class GenerateImageFacade {
             return generateImageTransactionService.saveV4ImageAndConfirmCredit(
                     user,
                     lockedCredit,
-                    request.floorPlanId(),
-                    request.isMirror(),
-                    request.floorPlanView(),
-                    prompt,
+                    house,
                     imageUploadResponseDTO,
-                    activity,
-                    combinedFurnitureIds,
-                    request.moodBoardIds()
+                    request.isMirror()
             );
         } catch (ValidException validException) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
@@ -611,6 +639,17 @@ public class GenerateImageFacade {
             String floorPlanImageUrl = resolveFloorPlanImageUrlStrict(floorPlan, request.floorPlanView());
             List<String> referenceImageUrls = buildProductReferenceImageUrls(floorPlanImageUrl, selectedProducts);
             String prompt = buildProductBasedPrompt(floorPlan, selectedProducts);
+            House house = generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                    user,
+                    null,
+                    request.floorPlanId(),
+                    request.isMirror(),
+                    request.floorPlanView(),
+                    prompt,
+                    null,
+                    extractFurnitureIdsFromRawProducts(selectedProducts),
+                    null
+            );
 
             ImageUploadResponseDTO imageUploadResponseDTO =
                     geminiImageService.createImageWithReferences(prompt, referenceImageUrls);
@@ -622,12 +661,10 @@ public class GenerateImageFacade {
             return generateImageTransactionService.saveProductImageAndConfirmCredit(
                     user,
                     lockedCredit,
-                    request.floorPlanId(),
-                    request.isMirror(),
-                    request.floorPlanView(),
-                    prompt,
+                    house,
                     imageUploadResponseDTO,
-                    selectedProducts
+                    selectedProducts,
+                    request.isMirror()
             );
         } catch (ValidException validException) {
             if (lockedCredit != null && lockedCredit.getStatus() == CreditStatus.PENDING) {
@@ -849,6 +886,64 @@ public class GenerateImageFacade {
         } catch (JsonProcessingException e) {
             throw new GeneralException(ErrorCode.OBJECTMAPPER_EXCEPTION);
         }
+    }
+
+    private List<CurationRawProduct> resolveBannerRawProductsForCarousel(
+            Banner banner,
+            BannerStyleAnswerChip selectedChip
+    ) {
+        Map<Long, CurationRawProduct> rawProductById = new LinkedHashMap<>();
+        extractBannerRawProducts(banner).forEach(rawProduct -> rawProductById.put(rawProduct.getId(), rawProduct));
+
+        Long selectedChipRawProductId = selectedChip.curationRawProductId();
+        if (selectedChipRawProductId != null && !rawProductById.containsKey(selectedChipRawProductId)) {
+            curationRawProductRepository.findById(selectedChipRawProductId)
+                    .ifPresent(rawProduct -> rawProductById.put(rawProduct.getId(), rawProduct));
+        }
+        return List.copyOf(rawProductById.values());
+    }
+
+    private List<CurationRawProduct> extractBannerRawProducts(Banner banner) {
+        if (banner == null || banner.getBannerRawProducts() == null) {
+            return List.of();
+        }
+
+        return banner.getBannerRawProducts().stream()
+                .map(BannerCurationRawProduct::getCurationRawProduct)
+                .filter(Objects::nonNull)
+                .filter(rawProduct -> rawProduct.getId() != null)
+                .toList();
+    }
+
+    private List<Long> extractFurnitureIdsFromRawProducts(List<CurationRawProduct> rawProducts) {
+        List<Long> rawProductIds = rawProducts == null ? List.of() : rawProducts.stream()
+                .filter(Objects::nonNull)
+                .map(CurationRawProduct::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (rawProductIds.isEmpty()) {
+            return List.of();
+        }
+
+        LinkedHashSet<Long> furnitureIds = new LinkedHashSet<>();
+        curationRawProductRepository.findAllByIdWithFurnitureTags(rawProductIds).stream()
+                .filter(Objects::nonNull)
+                .flatMap(rawProduct -> rawProduct.getFurnitureTagMappings().stream())
+                .map(mapping -> mapping.getFurnitureTag() != null ? mapping.getFurnitureTag().getFurniture() : null)
+                .filter(Objects::nonNull)
+                .map(Furniture::getId)
+                .filter(Objects::nonNull)
+                .forEach(furnitureIds::add);
+
+        curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(rawProductIds).stream()
+                .map(CurationRawProductFurniture::getFurniture)
+                .filter(Objects::nonNull)
+                .map(Furniture::getId)
+                .filter(Objects::nonNull)
+                .forEach(furnitureIds::add);
+
+        return List.copyOf(furnitureIds);
     }
 
     private String resolveFloorPlanImageUrl(FloorPlan floorPlan, String floorPlanView) {

--- a/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
+++ b/src/main/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselController.java
@@ -3,8 +3,6 @@ package or.sopt.houme.domain.house.presentation.carousel.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarouselListResponseDTO;
 import or.sopt.houme.domain.house.service.carousel.CarouselLikeLogService;
@@ -14,14 +12,11 @@ import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarous
 import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
 import or.sopt.houme.global.api.ApiResponse;
 import or.sopt.houme.global.api.ErrorCode;
-import or.sopt.houme.global.api.GeneralException;
 import or.sopt.houme.global.api.handler.CarouselException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,14 +46,8 @@ public class CarouselController {
     @Operation(summary = "캐러셀 조회 API v2",
             description = "실제 상품을 응답합니다. 한 번 조회 시, 100개의 상품을 반환합니다.")
     public ResponseEntity<ApiResponse<GetCarouselV2ListResponseDTO>> getCarouselsV2(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(value = "furnitureIds", required = false)
-            List<@NotNull(message = "furnitureIds에는 null이 포함될 수 없습니다.") Long> furnitureIds) {
-        if (furnitureIds == null || furnitureIds.isEmpty()) {
-            throw new GeneralException(ErrorCode.NOT_VALID_EXCEPTION);
-        }
-
-        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(userDetails.getUser(), furnitureIds);
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        GetCarouselV2ListResponseDTO carousels = carouselService.getCarouselV2(userDetails.getUser());
 
         return ResponseEntity.ok(ApiResponse.ok(carousels));
     }

--- a/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/HouseServiceImpl.java
@@ -185,6 +185,9 @@ public class HouseServiceImpl implements HouseService {
     @Transactional
     @Override
     public void saveHouseFurniture(House house, List<Long> furnitureIds) {
+        if (furnitureIds == null || furnitureIds.isEmpty()) {
+            return;
+        }
 
         List<Furniture> furnitures = furnitureRepository.findAllById(furnitureIds);
 

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -2,9 +2,14 @@ package or.sopt.houme.domain.house.service.carousel;
 
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.house.model.entity.House;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
+import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
+import or.sopt.houme.domain.user.model.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +25,23 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class CarouselCandidateService {
     private final CurationRawProductRepository curationRawProductRepository;
+    private final HouseRepository houseRepository;
+    private final HouseFurnitureRepository houseFurnitureRepository;
+
+    public CarouselCandidateBundle collectCandidates(User user) {
+        House latestHouse = houseRepository.findLatestHouse(user);
+        List<Long> furnitureIds = latestHouse == null
+                ? List.of()
+                : houseFurnitureRepository.findAllByHouseIdWithFurniture(latestHouse.getId()).stream()
+                .map(HouseFurniture::getFurniture)
+                .filter(Objects::nonNull)
+                .map(or.sopt.houme.domain.furniture.model.entity.Furniture::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        return collectCandidates(user.getId(), furnitureIds);
+    }
 
     public CarouselCandidateBundle collectCandidates(Long userId, List<Long> requestFurnitureIds) {
         List<Long> selectedFurnitureSourceIds = normalizeFurnitureIds(requestFurnitureIds);

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateService.java
@@ -40,10 +40,10 @@ public class CarouselCandidateService {
                 .distinct()
                 .toList();
 
-        return collectCandidates(user.getId(), furnitureIds);
+        return collectCandidates(user.getId(), latestHouse == null ? null : latestHouse.getId(), furnitureIds);
     }
 
-    public CarouselCandidateBundle collectCandidates(Long userId, List<Long> requestFurnitureIds) {
+    public CarouselCandidateBundle collectCandidates(Long userId, Long houseId, List<Long> requestFurnitureIds) {
         List<Long> selectedFurnitureSourceIds = normalizeFurnitureIds(requestFurnitureIds);
         Set<Long> excludedIds = new LinkedHashSet<>();
 
@@ -90,7 +90,7 @@ public class CarouselCandidateService {
         );
 
         return new CarouselCandidateBundle(
-                null,
+                houseId,
                 selectedFurnitureIds,
                 furnitureCategoryIds,
                 otherCategoryIds,

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselService.java
@@ -5,11 +5,9 @@ import or.sopt.houme.domain.house.presentation.carousel.controller.dto.GetCarous
 import or.sopt.houme.domain.user.model.entity.User;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 public interface CarouselService {
     GetCarouselListResponseDTO getCarousel(int page);
-    GetCarouselV2ListResponseDTO getCarouselV2(User user, List<Long> furnitureIds);
+    GetCarouselV2ListResponseDTO getCarouselV2(User user);
 
     @Transactional
     void likeCarousel(User user, Long carouselId);

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImpl.java
@@ -57,8 +57,8 @@ public class CarouselServiceImpl implements CarouselService {
     }
 
     @Override
-    public GetCarouselV2ListResponseDTO getCarouselV2(User user, List<Long> furnitureIds) {
-        var candidateBundle = carouselCandidateService.collectCandidates(user.getId(), furnitureIds);
+    public GetCarouselV2ListResponseDTO getCarouselV2(User user) {
+        var candidateBundle = carouselCandidateService.collectCandidates(user);
         List<Long> displayIds = carouselShuffleService.selectDisplayIds(candidateBundle, user.getId());
         if (displayIds.isEmpty()) {
             return GetCarouselV2ListResponseDTO.of(List.of());

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/CarouselShuffleService.java
@@ -4,8 +4,8 @@ import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -18,17 +18,18 @@ import java.util.Set;
 public class CarouselShuffleService {
 
     private static final int TARGET_SIZE = 100;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     public List<Long> selectDisplayIds(CarouselCandidateBundle bundle, Long userId) {
         LinkedHashSet<Long> selectedIds = new LinkedHashSet<>();
-        long epochDay = LocalDate.now(ZoneOffset.UTC).toEpochDay();
-        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 11L));
-        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 23L));
+        long epochSecond = ZonedDateTime.now(KST).toEpochSecond();
+        ShuffledBucket selectedBucket = new ShuffledBucket(bundle.selectedFurnitureIds(), computeSeed(userId, bundle.houseId(), epochSecond, 11L));
+        ShuffledBucket furnitureBucket = new ShuffledBucket(bundle.furnitureCategoryIds(), computeSeed(userId, bundle.houseId(), epochSecond, 23L));
 
         Map<SoozipCategory, ShuffledBucket> otherBuckets = new LinkedHashMap<>();
         long salt = 31L;
         for (Map.Entry<SoozipCategory, List<Long>> entry : bundle.otherCategoryIds().entrySet()) {
-            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.recentImageId(), epochDay, salt++)));
+            otherBuckets.put(entry.getKey(), new ShuffledBucket(entry.getValue(), computeSeed(userId, bundle.houseId(), epochSecond, salt++)));
         }
         List<ShuffledBucket> rotatingOtherBuckets = new ArrayList<>(otherBuckets.values());
 
@@ -46,7 +47,7 @@ public class CarouselShuffleService {
             otherIndex++;
         }
 
-        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.recentImageId(), epochDay, 97L));
+        ShuffledBucket fallbackBucket = new ShuffledBucket(bundle.fallbackIds(), computeSeed(userId, bundle.houseId(), epochSecond, 97L));
         while (selectedIds.size() < TARGET_SIZE && fallbackBucket.hasNext()) {
             addNext(selectedIds, fallbackBucket);
         }
@@ -71,10 +72,10 @@ public class CarouselShuffleService {
         }
     }
 
-    private long computeSeed(Long userId, Long recentImageId, long epochDay, long salt) {
+    private long computeSeed(Long userId, Long houseId, long epochSecond, long salt) {
         long baseUserId = userId == null ? 0L : userId;
-        long baseImageId = recentImageId == null ? 0L : recentImageId;
-        return (baseUserId * 31L) ^ (baseImageId * 17L) ^ (epochDay * 13L) ^ salt;
+        long baseHouseId = houseId == null ? 0L : houseId;
+        return (baseUserId * 31L) ^ (baseHouseId * 17L) ^ (epochSecond * 13L) ^ salt;
     }
 
     private static final class ShuffledBucket {

--- a/src/main/java/or/sopt/houme/domain/house/service/carousel/dto/CarouselCandidateBundle.java
+++ b/src/main/java/or/sopt/houme/domain/house/service/carousel/dto/CarouselCandidateBundle.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 public record CarouselCandidateBundle(
-        Long recentImageId,
+        Long houseId,
         List<Long> selectedFurnitureIds,
         List<Long> furnitureCategoryIds,
         Map<SoozipCategory, List<Long>> otherCategoryIds,

--- a/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
+++ b/src/test/java/or/sopt/houme/domain/generateImage/service/facade/GenerateImageFacadeTest.java
@@ -16,6 +16,7 @@ import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.FurnitureTag;
 import or.sopt.houme.domain.furniture.repository.ActivityFurnitureRepository;
 import or.sopt.houme.domain.furniture.service.FurnitureService;
+import or.sopt.houme.domain.furniture.repository.CurationRawProductFurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTagRepository;
 import or.sopt.houme.domain.generateImage.infrastructure.gemini.service.GeminiImageService;
@@ -107,6 +108,9 @@ class GenerateImageFacadeTest {
 
     @Mock
     CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    CurationRawProductFurnitureRepository curationRawProductFurnitureRepository;
 
     @Mock
     FurnitureTagRepository furnitureTagRepository;
@@ -394,6 +398,7 @@ class GenerateImageFacadeTest {
                 .styleAnswerChipsJson("[{\"id\":1}]")
                 .bannerRawProducts(List.of())
                 .build();
+        House house = House.builder().id(900L).build();
 
         FloorPlan floorPlan = FloorPlan.builder()
                 .id(11L)
@@ -423,17 +428,26 @@ class GenerateImageFacadeTest {
         when(objectMapper.readValue(eq("[{\"id\":1}]"), any(TypeReference.class)))
                 .thenReturn(List.of(new BannerStyleAnswerChip(1L, 1, "답변", "선택 프롬프트", null)));
         when(floorPlanImageJsonCodec.read("[]")).thenReturn(List.of());
+        when(generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                eq(user),
+                eq(banner),
+                eq(11L),
+                eq(false),
+                eq("TOP"),
+                any(),
+                eq(null),
+                eq(List.of()),
+                eq(null)
+        )).thenReturn(house);
         when(geminiImageService.createImageWithReferences(any(), any()))
                 .thenReturn(imageUploadResponseDTO);
         when(generateImageTransactionService.saveBannerImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
+                eq(house),
                 eq(banner),
-                eq(11L),
-                eq(false),
-                any(),
-                any(),
-                eq(imageUploadResponseDTO)
+                eq(imageUploadResponseDTO),
+                eq(false)
         )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
 
         BannerGenerateImageResponse response = generateImageFacade.generateBannerImageByGemini(user, request);
@@ -444,12 +458,10 @@ class GenerateImageFacadeTest {
         verify(generateImageTransactionService).saveBannerImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
+                eq(house),
                 eq(banner),
-                eq(11L),
-                eq(false),
-                any(),
-                any(),
-                eq(imageUploadResponseDTO)
+                eq(imageUploadResponseDTO),
+                eq(false)
         );
     }
 
@@ -497,6 +509,7 @@ class GenerateImageFacadeTest {
                         BannerCurationRawProduct.of(null, otherProduct)
                 ))
                 .build();
+        House house = House.builder().id(901L).build();
 
         FloorPlan floorPlan = FloorPlan.builder()
                 .id(11L)
@@ -526,6 +539,20 @@ class GenerateImageFacadeTest {
         when(objectMapper.readValue(eq("[{\"id\":2}]"), any(TypeReference.class)))
                 .thenReturn(List.of(new BannerStyleAnswerChip(2L, 2, "답변", "선택 프롬프트", 350L)));
         when(floorPlanImageJsonCodec.read("[]")).thenReturn(List.of());
+        when(curationRawProductRepository.findAllByIdWithFurnitureTags(List.of(350L, 365L))).thenReturn(List.of());
+        when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(List.of(350L, 365L)))
+                .thenReturn(List.of());
+        when(generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                eq(user),
+                eq(banner),
+                eq(11L),
+                eq(false),
+                eq(null),
+                any(),
+                eq(null),
+                eq(List.of()),
+                eq(null)
+        )).thenReturn(house);
         when(geminiImageService.createImageWithReferences(any(), argThat(referenceImageUrls ->
                 referenceImageUrls.equals(List.of(
                         "https://floorplan-default",
@@ -537,12 +564,10 @@ class GenerateImageFacadeTest {
         when(generateImageTransactionService.saveBannerImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
+                eq(house),
                 eq(banner),
-                eq(11L),
-                eq(false),
-                any(),
-                any(),
-                eq(imageUploadResponseDTO)
+                eq(imageUploadResponseDTO),
+                eq(false)
         )).thenReturn(BannerGenerateImageResponse.of(999L, "https://generated-image", false));
 
         BannerGenerateImageResponse response = generateImageFacade.generateBannerImageByGemini(user, request);
@@ -622,6 +647,7 @@ class GenerateImageFacadeTest {
                 .priority(2)
                 .searchKeyword("k2")
                 .build();
+        House house = House.builder().id(902L).build();
 
         ImageUploadResponseDTO imageUploadResponseDTO = ImageUploadResponseDTO.from(
                 "generated.webp",
@@ -639,19 +665,25 @@ class GenerateImageFacadeTest {
                 .thenReturn(List.of(selectedFurnitureTag, activityFurnitureTag));
         when(floorPlanImageJsonCodec.read("[]"))
                 .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
+        when(generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                eq(user),
+                eq(null),
+                eq(11L),
+                eq(true),
+                eq("창가 뷰"),
+                any(),
+                eq(Activity.REMOTE_WORK),
+                eq(List.of(7L, 8L)),
+                eq(List.of(1L, 2L))
+        )).thenReturn(house);
         when(geminiImageService.createImageWithReferences(any(), any()))
                 .thenReturn(imageUploadResponseDTO);
         when(generateImageTransactionService.saveV4ImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
-                eq(11L),
-                eq(true),
-                any(),
-                any(),
+                eq(house),
                 eq(imageUploadResponseDTO),
-                eq(Activity.REMOTE_WORK),
-                eq(List.of(7L, 8L)),
-                eq(List.of(1L, 2L))
+                eq(true)
         )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
 
         GenerateImageV4Response response = generateImageFacade.generateImageV4ByGemini(user, request);
@@ -669,14 +701,9 @@ class GenerateImageFacadeTest {
         verify(generateImageTransactionService).saveV4ImageAndConfirmCredit(
                 eq(user),
                 eq(lockedCredit),
-                eq(11L),
-                eq(true),
-                any(),
-                any(),
+                eq(house),
                 eq(imageUploadResponseDTO),
-                eq(Activity.REMOTE_WORK),
-                eq(List.of(7L, 8L)),
-                eq(List.of(1L, 2L))
+                eq(true)
         );
     }
 
@@ -779,6 +806,7 @@ class GenerateImageFacadeTest {
                 .floorPlanPrompt("도면 프롬프트")
                 .imagesJson("[]")
                 .build();
+        House house = House.builder().id(903L).build();
 
         CurationRawProduct p1 = CurationRawProduct.builder().id(1L).productName("소파").productImageUrl("https://p1").build();
         CurationRawProduct p2 = CurationRawProduct.builder().id(2L).productName("책상").productImageUrl("https://p2").build();
@@ -794,11 +822,25 @@ class GenerateImageFacadeTest {
         when(creditService.tryLockAndGetCredit(user)).thenReturn(lockedCredit);
         when(floorPlanRepository.findById(11L)).thenReturn(Optional.of(floorPlan));
         when(curationRawProductRepository.findAllById(List.of(1L, 2L, 3L))).thenReturn(List.of(p1, p2, p3));
+        when(curationRawProductRepository.findAllByIdWithFurnitureTags(List.of(1L, 2L, 3L))).thenReturn(List.of());
+        when(curationRawProductFurnitureRepository.findAllByCurationRawProductIdInWithFurniture(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of());
         when(floorPlanImageJsonCodec.read("[]"))
                 .thenReturn(List.of(FloorPlanImageItem.create("https://floorplan-view", "file", "orig", "png", 1, "창가 뷰")));
+        when(generateImageTransactionService.createTemplateHouseBeforeImageGeneration(
+                eq(user),
+                eq(null),
+                eq(11L),
+                eq(true),
+                eq("창가 뷰"),
+                any(),
+                eq(null),
+                eq(List.of()),
+                eq(null)
+        )).thenReturn(house);
         when(geminiImageService.createImageWithReferences(any(), any())).thenReturn(imageUploadResponseDTO);
         when(generateImageTransactionService.saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
+                eq(user), eq(lockedCredit), eq(house), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3)), eq(true)
         )).thenReturn(GenerateImageV4Response.of(999L, "https://generated-image", true));
 
         GenerateImageV4Response response = generateImageFacade.generateImageByProducts(user, request);
@@ -815,7 +857,7 @@ class GenerateImageFacadeTest {
                         && urls.contains("https://p3"))
         );
         verify(generateImageTransactionService).saveProductImageAndConfirmCredit(
-                eq(user), eq(lockedCredit), eq(11L), eq(true), any(), any(), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3))
+                eq(user), eq(lockedCredit), eq(house), eq(imageUploadResponseDTO), eq(List.of(p1, p2, p3)), eq(true)
         );
     }
 }

--- a/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/presentation/carousel/controller/CarouselControllerTest.java
@@ -119,12 +119,11 @@ class CarouselControllerTest {
                 new GetCarouselResponseDTO(12L, "url12")
         );
         GetCarouselV2ListResponseDTO responseDTO = GetCarouselV2ListResponseDTO.of(mockList);
-        when(carouselService.getCarouselV2(any(), eq(List.of(10L, 20L)))).thenReturn(responseDTO);
+        when(carouselService.getCarouselV2(any())).thenReturn(responseDTO);
 
         setAuthentication(testUserDetails);
 
         mockMvc.perform(get("/api/v2/carousels")
-                        .param("furnitureIds", "10", "20")
                         .requestAttr("userDetails", testUserDetails)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -136,19 +135,6 @@ class CarouselControllerTest {
                 .andExpect(jsonPath("$.data.carousels[1].rawProductId").value(12))
                 .andExpect(jsonPath("$.data.carousels[1].url").value("url12"));
     }
-
-    @Test
-    @DisplayName("GET /api/v2/carousels 요청 시 furnitureIds가 없으면 400을 반환한다")
-    @WithMockUser()
-    void getCarouselsV2_returnsBadRequest_whenFurnitureIdsMissing() throws Exception {
-        setAuthentication(testUserDetails);
-
-        mockMvc.perform(get("/api/v2/carousels")
-                        .requestAttr("userDetails", testUserDetails)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
-    }
-
 
     @Test
     @DisplayName("POST /api/v1/carousels/like 요청으로 좋아요를 추가 할 수 있다")

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
@@ -91,7 +91,7 @@ class CarouselCandidateServiceTest {
                 List.of(101L, 102L, 103L, 104L)
         )).thenReturn(List.of(rawProduct(105L)));
 
-        CarouselCandidateBundle result = carouselCandidateService.collectCandidates(1L, List.of(10L, 20L));
+        CarouselCandidateBundle result = carouselCandidateService.collectCandidates(1L, 99L, List.of(10L, 20L));
 
         assertThat(result.selectedFurnitureIds()).containsExactly(101L);
         assertThat(result.furnitureCategoryIds()).containsExactly(102L);

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselCandidateServiceTest.java
@@ -1,9 +1,15 @@
 package or.sopt.houme.domain.house.service.carousel;
 
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
 import or.sopt.houme.domain.furniture.model.entity.SoozipCategory;
 import or.sopt.houme.domain.furniture.repository.CurationRawProductRepository;
+import or.sopt.houme.domain.house.model.entity.House;
+import or.sopt.houme.domain.house.model.entity.mapping.HouseFurniture;
+import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
+import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.house.service.carousel.dto.CarouselCandidateBundle;
+import or.sopt.houme.domain.user.model.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +31,12 @@ class CarouselCandidateServiceTest {
 
     @Mock
     private CurationRawProductRepository curationRawProductRepository;
+
+    @Mock
+    private HouseRepository houseRepository;
+
+    @Mock
+    private HouseFurnitureRepository houseFurnitureRepository;
 
     @Test
     @DisplayName("후보군 조회 시 이전 버킷의 상품 ID를 excludedIds로 누적 전달한다")
@@ -86,6 +98,75 @@ class CarouselCandidateServiceTest {
         assertThat(result.otherCategoryIds().get(SoozipCategory.LIGHTING)).containsExactly(103L);
         assertThat(result.otherCategoryIds().get(SoozipCategory.LIVING_GOODS)).containsExactly(104L);
         assertThat(result.fallbackIds()).containsExactly(105L);
+    }
+
+    @Test
+    @DisplayName("후보군 조회 시 최신 house에 저장된 가구 ID를 기준으로 선택 가구 후보를 조회한다")
+    void collectCandidates_usesLatestHouseFurnitureIds() {
+        User user = User.builder().id(1L).build();
+        House house = House.builder().id(10L).user(user).build();
+        HouseFurniture sofa = HouseFurniture.builder()
+                .furniture(Furniture.builder().id(10L).build())
+                .build();
+        HouseFurniture desk = HouseFurniture.builder()
+                .furniture(Furniture.builder().id(20L).build())
+                .build();
+
+        when(houseRepository.findLatestHouse(user)).thenReturn(house);
+        when(houseFurnitureRepository.findAllByHouseIdWithFurniture(10L)).thenReturn(List.of(sofa, desk));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByFurnitureIds(
+                1L,
+                List.of(10L, 20L),
+                SoozipCategory.FURNITURE,
+                160,
+                List.of()
+        )).thenReturn(List.of(rawProduct(101L)));
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.FURNITURE),
+                eq(160),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.LIGHTING),
+                eq(60),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.LIVING_GOODS),
+                eq(60),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.HOME_FABRIC),
+                eq(60),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.ACCESSORY),
+                eq(60),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                eq(1L),
+                eq(SoozipCategory.MINI_ELECTRONICS),
+                eq(60),
+                eq(List.of(101L))
+        )).thenReturn(List.of());
+        when(curationRawProductRepository.findExposedRawProductsExcludingLikedByUserByCategory(
+                1L,
+                null,
+                220,
+                List.of(101L)
+        )).thenReturn(List.of());
+
+        CarouselCandidateBundle result = carouselCandidateService.collectCandidates(user);
+
+        assertThat(result.selectedFurnitureIds()).containsExactly(101L);
     }
 
     private CurationRawProduct rawProduct(Long id) {

--- a/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/house/service/carousel/CarouselServiceImplTest.java
@@ -130,12 +130,12 @@ class CarouselServiceImplTest {
                 List.of(101L, 102L, 103L)
         );
 
-        when(carouselCandidateService.collectCandidates(1L, List.of(21L, 22L))).thenReturn(candidateBundle);
+        when(carouselCandidateService.collectCandidates(user)).thenReturn(candidateBundle);
         when(carouselShuffleService.selectDisplayIds(candidateBundle, 1L)).thenReturn(List.of(103L, 101L, 102L));
         when(curationRawProductRepository.findAllById(List.of(103L, 101L, 102L)))
                 .thenReturn(List.of(rawProduct1, rawProduct2, rawProduct3));
 
-        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(user, List.of(21L, 22L));
+        GetCarouselV2ListResponseDTO result = carouselService.getCarouselV2(user);
 
         assertThat(result.carousels()).hasSize(3);
         assertThat(result.carousels())


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #569 

## 📝 Summary
- `/api/v2/carousels` 요청에서 `furnitureIds`를 제거하고, 최신 `house`에 저장된 가구 기준으로 캐러셀 후보를 계산하도록 변경했습니다.
- 아래의 이미지 생성 요청에서 AI 호출 전에 `house`가 먼저 저장되도록 흐름을 조정했습니다.
  - `/api/v4/generated-images/generate`
  - `/api/v1/generated-images/generate/banner`
  - `/api/v1/generated-images/generate/other-style`
  - `/api/v1/generated-images/generate/products`)
- 캐러셀 셔플 기준을 `recentImageId` -> `houseId`로 변경했고, 랜덤 시드를 초 단위로 보강했습니다.


## 🙏 Question & PR point
- 캐러셀 API 요청시 `furnitureIds`를 직접 전달하지 않아도 됩니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * 추천 상품 조회 API가 간소화되어 사용자 정보만으로 더 쉽게 접근할 수 있습니다.
  * 추천 시스템이 사용자의 최근 활동 데이터를 자동으로 활용합니다.

* **리팩터링**
  * 이미지 생성 서비스의 템플릿 처리 로직이 통합되었습니다.
  * 추천 알고리즘의 내부 처리 흐름이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->