### PR TITLE
[CHORE] 필터 ID 중복 회피 로직 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/repository/CurationRawProductRepositoryImpl.java
@@ -36,6 +36,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class CurationRawProductRepositoryImpl implements CurationRawProductRepositoryCustom {
 
+    private static final long FURNITURE_ID_OFFSET = 10000L;
+
     private final JPAQueryFactory queryFactory;
 
     @Override
@@ -102,14 +104,17 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
         if ((typeIds != null && !typeIds.isEmpty()) || (additionalProductIds != null && !additionalProductIds.isEmpty())) {
             BooleanBuilder typeOrEtc = new BooleanBuilder();
             if (typeIds != null && !typeIds.isEmpty()) {
-                typeOrEtc.or(rawProduct.id.in(
-                        queryFactory.select(mapping.curationRawProduct.id)
-                                .from(mapping)
-                                .join(mapping.furnitureTag, fTag)
-                                .join(fTag.furniture, furniture)
-                                .leftJoin(furniture.furnitureType, fType)
-                                .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
-                ));
+                com.querydsl.core.types.Predicate typeCondition = buildFurnitureTypeCondition(typeIds, fType, furniture);
+                if (typeCondition != null) {
+                    typeOrEtc.or(rawProduct.id.in(
+                            queryFactory.select(mapping.curationRawProduct.id)
+                                    .from(mapping)
+                                    .join(mapping.furnitureTag, fTag)
+                                    .join(fTag.furniture, furniture)
+                                    .leftJoin(furniture.furnitureType, fType)
+                                    .where(typeCondition)
+                    ));
+                }
             }
             if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
                 typeOrEtc.or(rawProduct.id.in(additionalProductIds));
@@ -188,14 +193,17 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
         if ((typeIds != null && !typeIds.isEmpty()) || (additionalProductIds != null && !additionalProductIds.isEmpty())) {
             BooleanBuilder typeOrEtc = new BooleanBuilder();
             if (typeIds != null && !typeIds.isEmpty()) {
-                typeOrEtc.or(rawProduct.id.in(
-                        queryFactory.select(mapping.curationRawProduct.id)
-                                .from(mapping)
-                                .join(mapping.furnitureTag, fTag)
-                                .join(fTag.furniture, furniture)
-                                .leftJoin(furniture.furnitureType, fType)
-                                .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)))
-                ));
+                com.querydsl.core.types.Predicate typeCondition = buildFurnitureTypeCondition(typeIds, fType, furniture);
+                if (typeCondition != null) {
+                    typeOrEtc.or(rawProduct.id.in(
+                            queryFactory.select(mapping.curationRawProduct.id)
+                                    .from(mapping)
+                                    .join(mapping.furnitureTag, fTag)
+                                    .join(fTag.furniture, furniture)
+                                    .leftJoin(furniture.furnitureType, fType)
+                                    .where(typeCondition)
+                    ));
+                }
             }
             if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
                 typeOrEtc.or(rawProduct.id.in(additionalProductIds));
@@ -540,18 +548,21 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
         BooleanBuilder atLeastOne = new BooleanBuilder();
 
         if (typeIds != null && !typeIds.isEmpty()) {
-            var typeSubquery = JPAExpressions
-                    .select(mapping.curationRawProduct.id)
-                    .from(mapping)
-                    .join(mapping.furnitureTag, fTag)
-                    .join(fTag.furniture, furniture)
-                    .leftJoin(furniture.furnitureType, fType)
-                    .where(fType.id.in(typeIds).or(furniture.id.in(typeIds)));
+            com.querydsl.core.types.Predicate typeCondition = buildFurnitureTypeCondition(typeIds, fType, furniture);
+            if (typeCondition != null) {
+                var typeSubquery = JPAExpressions
+                        .select(mapping.curationRawProduct.id)
+                        .from(mapping)
+                        .join(mapping.furnitureTag, fTag)
+                        .join(fTag.furniture, furniture)
+                        .leftJoin(furniture.furnitureType, fType)
+                        .where(typeCondition);
 
-            matchScore = matchScore.add(
-                    new CaseBuilder().when(rawProduct.id.in(typeSubquery)).then(1).otherwise(0)
-            );
-            atLeastOne.or(rawProduct.id.in(typeSubquery));
+                matchScore = matchScore.add(
+                        new CaseBuilder().when(rawProduct.id.in(typeSubquery)).then(1).otherwise(0)
+                );
+                atLeastOne.or(rawProduct.id.in(typeSubquery));
+            }
         }
 
         if (additionalProductIds != null && !additionalProductIds.isEmpty()) {
@@ -680,5 +691,20 @@ public class CurationRawProductRepositoryImpl implements CurationRawProductRepos
             return null;
         }
         return field.in(brands);
+    }
+
+    private com.querydsl.core.types.Predicate buildFurnitureTypeCondition(List<Long> typeIds, QFurnitureType fType, QFurniture furniture) {
+        if (typeIds == null || typeIds.isEmpty()) return null;
+
+        List<Long> typeFilterIds = typeIds.stream().filter(id -> id < FURNITURE_ID_OFFSET).toList();
+        List<Long> furnitureFilterIds = typeIds.stream()
+                .filter(id -> id >= FURNITURE_ID_OFFSET)
+                .map(id -> id - FURNITURE_ID_OFFSET)
+                .toList();
+
+        BooleanBuilder condition = new BooleanBuilder();
+        if (!typeFilterIds.isEmpty()) condition.or(fType.id.in(typeFilterIds));
+        if (!furnitureFilterIds.isEmpty()) condition.or(furniture.id.in(furnitureFilterIds));
+        return condition.hasValue() ? condition : null;
     }
 }

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CurationProductServiceImpl implements CurationProductService {
 
+    private static final long FURNITURE_ID_OFFSET = 10000L;
     private static final String ETC_TYPE_NAMEENG = "ETC";
     private static final String SELECTIVE_TYPE_NAMEENG = "SELECTIVE";
     private static final List<String> INDIVIDUAL_FILTER_FURNITURE_NAMEENGS = List.of(
@@ -493,7 +494,7 @@ public class CurationProductServiceImpl implements CurationProductService {
         return furnitures.stream()
                 .filter(f -> f.getFurnitureNameEng() != null && f.getFurnitureNameEng().trim().equalsIgnoreCase(nameEng))
                 .findFirst()
-                .map(f -> new FurnitureTypeFilterResponse(f.getId(), labelKr, f.getFurnitureNameEng().trim()))
+                .map(f -> new FurnitureTypeFilterResponse(f.getId() + FURNITURE_ID_OFFSET, labelKr, f.getFurnitureNameEng().trim()))
                 .orElse(new FurnitureTypeFilterResponse(fallbackId, labelKr, nameEng));
     }
 


### PR DESCRIPTION
## 📣 Related Issue

- close #572

## 📝 Summary

- `furniture` 테이블 ID와 `furniture_type` 테이블 ID가 동일한 값(7)을 가질 때, 필터 메타 응답에서 `식탁`과 `기타`가 같은 ID로 반환되는 버그 수정
- `findFurniture()`에서 furniture ID에 `FURNITURE_ID_OFFSET(10000)` 적용하여 furniture_type ID와 네임스페이스 분리
- 레포지토리에 `buildFurnitureTypeCondition()` 헬퍼 추가 — 10000 이상 ID는 `furniture` 테이블, 미만은 `furniture_type` 테이블로 분기
- `findAllByCurationFilters`, `findAllByCurationFiltersV2`, `findAllByCurationFiltersRecommend` 3곳 동일 적용

## 🙏 Question & PR point

- 클라이언트는 필터 메타 API 응답값을 그대로 사용하므로 별도 클라이언트 수정 불필요
- 기존에 `식탁(id=7)` 필터 선택 시 `기타` 상품도 함께 노출되던 문제 해결

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 가구 검색 및 필터링 쿼리 처리 로직을 개선하여 더 정확한 검색 결과 제공
  * 필터 응답의 가구 ID 처리를 개선하여 데이터 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->