### PR TITLE
[FIX] 회원탈퇴 시 generate_image_raw_products FK 제약조건 위반 수정

### DIFF
--- a/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepository.java
+++ b/src/main/java/or/sopt/houme/domain/generateImage/repository/GenerateImageRawProductRepository.java
@@ -4,7 +4,11 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImageRawProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GenerateImageRawProductRepository extends JpaRepository<GenerateImageRawProduct, Long>,
         GenerateImageRawProductRepositoryCustom {
+
+    void deleteAllByGenerateImageIdIn(List<Long> generateImageIds);
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserDeletionService.java
@@ -10,6 +10,8 @@ import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.house.repository.HouseFloorPlanRepository;
 import or.sopt.houme.domain.house.repository.HouseFurnitureRepository;
 import or.sopt.houme.domain.house.repository.HouseTasteRepository;
+import java.util.List;
+import or.sopt.houme.domain.generateImage.repository.GenerateImageRawProductRepository;
 import or.sopt.houme.domain.generateImage.repository.GenerateImageRepository;
 import or.sopt.houme.domain.generateImage.repository.ImageGenerationLogRepository;
 import or.sopt.houme.domain.preference.repository.*;
@@ -38,6 +40,7 @@ public class UserDeletionService {
     private final HouseTasteRepository houseTasteRepository;
 
     private final GenerateImageRepository generateImageRepository;
+    private final GenerateImageRawProductRepository generateImageRawProductRepository;
     private final ImageGenerationLogRepository imageGenerationLogRepository;
 
     private final GenerateImagePreferenceRepository generateImagePreferenceRepository;
@@ -112,6 +115,8 @@ public class UserDeletionService {
                 }
             });
             if (!images.isEmpty()) {
+                List<Long> imageIds = images.stream().map(image -> image.getId()).toList();
+                generateImageRawProductRepository.deleteAllByGenerateImageIdIn(imageIds);
                 generateImageRepository.deleteAll(images);
                 generateImageRepository.deleteByHouseId(house.getId());
                 generateImageRepository.flush();


### PR DESCRIPTION
## 📣 Related Issue

- close #576

## 📝 Summary

회원탈퇴 시 `generate_images` 삭제 전 `generate_image_raw_products` 레코드를 먼저 삭제하지 않아 DB FK 제약조건 위반으로 500 에러 발생하는 문제 수정

- `GenerateImageRawProductRepository`에 `deleteAllByGenerateImageIdIn()` 메서드 추가
- `UserDeletionService`에서 `generate_images` 삭제 직전에 해당 메서드 호출 추가

## 🙏 Question & PR point

- `generate_image_raw_products`는 생성 이미지-상품 매핑 테이블로, 실제 상품 원본(`curation_raw_products`)은 건드리지 않으므로 삭제 안전
- Sentry HOUME-BB-74 에서 확인된 이슈

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자 삭제 시 연관된 이미지 데이터뿐 아니라, 이미지와 연결된 추가 상품 정보까지 함께 정리되도록 개선했습니다.
  * 삭제 후 남아 있을 수 있던 관련 데이터가 더 잘 정리되어, 데이터 일관성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->