### PR TITLE
[TEST] #580 통합 테스트 인프라 구축 — Testcontainers 기반, CI 시크릿 의존 제거

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -18,16 +18,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    # redis 서비스 제거: 테스트가 Testcontainers(PostgreSQL/Redis)로 자체 인프라를 띄운다 (#580)
 
     steps:
       - name: checkout the code
@@ -41,11 +32,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Add application-test.yml
-        run: |
-          mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_TEST }}" > ./src/main/resources/application-test.yml
-
+      # APPLICATION_TEST 시크릿 주입 제거: src/test/resources/application-test.yml 이 커밋되어 있고
+      # DB/Redis 는 Testcontainers 가 공급한다 (#580)
       - name: Run Gradle build and tests
         run: |
           ./gradlew clean build -Dspring.profiles.active=test

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // 통합 테스트 (Testcontainers)
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -148,10 +153,11 @@ clean {
 tasks.named('test') {
     useJUnitPlatform()
     // CI 환경에서 다수의 Spring 컨텍스트 + Jacoco로 인한 OOM을 완화하기 위해 HEAPsize를 줄임
-    maxHeapSize = '2g'
-    jvmArgs '-XX:MaxMetaspaceSize=512m'
+    maxHeapSize = '3g'
+    jvmArgs '-XX:MaxMetaspaceSize=1g'
     maxParallelForks = 1
-    forkEvery = 50
+    // forkEvery 제거: Testcontainers 와 fork 재기동이 충돌(Ryuk 셧다운 훅 hang)하고,
+    // 단일 JVM 이어야 PG/Redis 컨테이너 1세트를 전체 테스트가 공유한다
     finalizedBy 'jacocoTestReport'
 }
 

--- a/src/test/java/or/sopt/houme/support/IntegrationTestInfraVerificationTest.java
+++ b/src/test/java/or/sopt/houme/support/IntegrationTestInfraVerificationTest.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("통합 테스트 인프라 검증 (Testcontainers PostgreSQL/Redis + 전체 컨텍스트)")
+class IntegrationTestInfraVerificationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("전체 컨텍스트가 실제 PostgreSQL/Redis 위에서 기동된다")
+    void contextLoadsOnRealInfra() {
+        // IntegrationTestSupport 상속만으로 컨텍스트 기동이 검증된다
+    }
+
+    @Test
+    @DisplayName("공개 API(/api/v1/landings)가 ApiResponse 포맷으로 200을 반환한다")
+    void publicLandingsEndpointReturnsApiResponseFormat() throws Exception {
+        mockMvc.perform(get("/api/v1/landings"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("응답 성공"));
+    }
+}

--- a/src/test/java/or/sopt/houme/support/IntegrationTestSupport.java
+++ b/src/test/java/or/sopt/houme/support/IntegrationTestSupport.java
@@ -1,0 +1,63 @@
+package or.sopt.houme.support;
+
+import or.sopt.houme.domain.furniture.infrastructure.client.FastApiImageHashClient;
+import or.sopt.houme.domain.furniture.infrastructure.client.NaverShopApiClient;
+import or.sopt.houme.domain.generateImage.infrastructure.gemini.client.GeminiImageClient;
+import or.sopt.houme.domain.generateImage.infrastructure.openai.client.FastApiImageClient;
+import or.sopt.houme.domain.generateImage.infrastructure.openai.client.OpenAIImageClient;
+import or.sopt.houme.domain.user.infrastructure.client.KaKaoOAuthClient;
+import or.sopt.houme.domain.user.infrastructure.client.KaKaoUserInfoClient;
+import or.sopt.houme.global.util.S3Util;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * API 계약(통합) 테스트 공통 베이스.
+ *
+ * <p>실제 PostgreSQL 16 / Redis 7 컨테이너 위에서 전체 스프링 컨텍스트를 띄운다
+ * (컨테이너 공급은 {@link TestContainersInitializer} — application-test.yml 로 전역 등록).
+ * 운영과 동일한 DB(jsonb, pg_trgm)를 사용하므로 H2 방언 차이로 인한 오탐/미탐이 없다.
+ *
+ * <p>외부 시스템 경계(Feign 클라이언트, S3)만 {@link MockBean}으로 대체한다.
+ * 서비스/파사드/레포지토리 등 내부 컴포넌트는 절대 목으로 대체하지 않는다 —
+ * 이 테스트들의 목적은 구현 구조가 아니라 API 행동 계약을 고정하는 것이다(#580).
+ * 시나리오가 필요한 테스트는 protected 목 필드를 {@code given(...)}으로 스텁한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public abstract class IntegrationTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    // ===== 외부 시스템 경계 목 (네트워크/AWS 경계만 대체) =====
+
+    @MockBean
+    protected GeminiImageClient geminiImageClient;
+
+    @MockBean
+    protected OpenAIImageClient openAiImageClient;
+
+    @MockBean
+    protected FastApiImageClient fastApiImageClient;
+
+    @MockBean
+    protected FastApiImageHashClient fastApiImageHashClient;
+
+    @MockBean
+    protected KaKaoOAuthClient kakaoOAuthClient;
+
+    @MockBean
+    protected KaKaoUserInfoClient kakaoUserInfoClient;
+
+    @MockBean
+    protected NaverShopApiClient naverShopApiClient;
+
+    @MockBean
+    protected S3Util s3Util;
+}

--- a/src/test/java/or/sopt/houme/support/TestContainersInitializer.java
+++ b/src/test/java/or/sopt/houme/support/TestContainersInitializer.java
@@ -1,0 +1,47 @@
+package or.sopt.houme.support;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * test 프로파일의 모든 스프링 컨텍스트에 실제 PostgreSQL 16 / Redis 7 컨테이너를 공급한다.
+ *
+ * <p>application-test.yml 의 {@code context.initializer.classes} 로 등록되므로,
+ * {@link IntegrationTestSupport} 상속 여부와 무관하게 test 프로파일로 컨텍스트를 띄우는
+ * 모든 테스트(기존 @SpringBootTest 포함)가 동일한 인프라를 공유한다.
+ * 덕분에 CI 시크릿(APPLICATION_TEST)이나 로컬 Redis 설치 없이 어디서든 테스트가 돈다.
+ *
+ * <p>컨테이너는 JVM 당 한 번만 기동되는 static 싱글톤이며 Ryuk 이 테스트 종료 후 정리한다.
+ */
+public class TestContainersInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16")
+                    .withDatabaseName("houme")
+                    .withUsername("houme")
+                    .withPassword("houme");
+
+    private static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine")
+                    .withExposedPorts(6379);
+
+    static {
+        POSTGRES.start();
+        REDIS.start();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext context) {
+        TestPropertyValues.of(
+                "spring.datasource.url=" + POSTGRES.getJdbcUrl(),
+                "spring.datasource.username=" + POSTGRES.getUsername(),
+                "spring.datasource.password=" + POSTGRES.getPassword(),
+                "spring.data.redis.host=" + REDIS.getHost(),
+                "spring.data.redis.port=" + REDIS.getMappedPort(6379)
+        ).applyTo(context.getEnvironment());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,163 @@
+# test 프로파일의 모든 컨텍스트에 Testcontainers(PostgreSQL/Redis)를 공급한다.
+# datasource/redis 접속 정보는 이 initializer 가 동적으로 주입한다.
+context:
+  initializer:
+    classes: or.sopt.houme.support.TestContainersInitializer
+
+spring:
+  application:
+    name: houme
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      # 테스트는 컨텍스트가 여러 개 캐시되므로 풀을 작게 유지해 PG max_connections 고갈을 막는다
+      maximum-pool-size: 4
+      minimum-idle: 1
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        show_sql: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: test-kakao-client-id
+            redirect-uri: http://localhost:8080/oauth/kakao/callback
+            authorization-grant-type: authorization_code
+            scope: profile_nickname,account_email
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+  jwt:
+    header: Authorization
+    secret: test-jwt-secret-key-for-integration-tests-must-be-long-enough-0123456789
+    access-token-validity-in-seconds: 3600
+    refresh-token-validity-in-seconds: 2592000
+
+  web:
+    resources:
+      add-mappings: false
+
+openai:
+  api-key: test-openai-key
+  image:
+    model: gpt-image-1
+    n: 1
+    size: 1024x1024
+    quality: medium
+    background: auto
+    output-format: webp
+
+gemini:
+  api-key: test-gemini-key
+  api-base-url: http://localhost:65535
+  image:
+    model: gemini-3-pro-image-preview
+    size: 1024x1024
+
+naver:
+  client-id: test-naver-client-id
+  client-secret: test-naver-client-secret
+  allowed-malls: 테스트몰
+
+soozip:
+  base-url: http://localhost:65535
+
+discord:
+  webhook-url: http://localhost:65535/webhook
+
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket
+      bucket-domain: https://test-bucket.example.com
+    credentials:
+      access-key: test-access-key
+      secret-key: test-secret-key
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
+server:
+  env: test
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics,env
+  metrics:
+    tags:
+      application: houme
+
+app:
+  cookie:
+    domain: ""
+    same-site: Lax
+    secure: false
+
+auth:
+  signup-token:
+    ttl-seconds: 600
+
+external:
+  image-api:
+    base-url: http://localhost:65535
+
+houme:
+  async:
+    image-generation:
+      mode: platform
+      platform:
+        core-size: 2
+        max-size: 4
+        queue-capacity: 10
+      virtual:
+        concurrency-limit: 4
+
+image:
+  cwebp:
+    path: /usr/bin/false
+    timeout-seconds: 5
+  sweep:
+    cron: "-"
+    max-source-bytes: 10485760
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      imageClient:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 1000
+        readTimeout: 1000
+
+logging:
+  level:
+    or.sopt.houme.global.aop: INFO


### PR DESCRIPTION
## 📣 Related Issue

- ref #580

## 📝 Summary

**"테스트를 진짜 환경이랑 똑같은 곳에서 돌리게 만들었어요"**

지금까지 테스트는 이렇게 돌았어요:
- DB는 **가짜 DB(H2)** 를 썼어요. 진짜(PostgreSQL)랑 비슷하지만 다른 점이 있어서, 테스트는 통과했는데 실서버에서 터지는 일이 생길 수 있었어요
- 테스트 설정 파일이 GitHub 비밀금고(시크릿)에 있어서, **내 컴퓨터에서는 테스트를 돌릴 수가 없었어요**

이 PR 이후에는:
- 테스트를 돌리면 **진짜 PostgreSQL이랑 Redis가 도커로 자동으로 떠서** 그 위에서 테스트해요 (Testcontainers)
- 설정 파일을 리포에 넣어놔서(비밀값은 전부 가짜 더미값) **누구든 클론 받고 바로 테스트 가능**해요
- CI에서도 시크릿 주입 단계가 필요 없어져서 지웠어요

## 🙏 Question & PR point

- `IntegrationTestSupport`를 상속하면 통합 테스트를 쉽게 만들 수 있어요. 외부 API(카카오, Gemini, S3 등)는 가짜로 바꿔놨고, **우리 코드 내부는 절대 가짜로 안 바꿔요** — 진짜 동작을 검증하는 게 목적이라서요
- `forkEvery=50`을 지운 이유: 테스트 중간에 JVM을 재시작하는 옵션인데, 도커 컨테이너 정리 로직과 충돌해서 테스트가 끝나고도 멈춰있는 문제가 있었어요 (실제로 겪음)
- 도메인별 API 테스트 채우기는 후속 PR에서 계속해요

## 📬 Postman

- 해당 없음 (테스트 인프라)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - PostgreSQL과 Redis를 포함한 실제 통합 테스트 환경을 자동으로 구성합니다.
  - 애플리케이션 전체 컨텍스트가 정상적으로 실행되는지 자동 검증합니다.
  - 랜딩 목록 API의 성공 응답과 주요 응답 형식을 검증하는 테스트를 추가했습니다.

- **개선**
  - 테스트 실행 환경과 설정을 일관되게 관리합니다.
  - 테스트 안정성을 높이기 위해 메모리 및 실행 방식을 조정했습니다.
  - 외부 서비스는 테스트 중 대체 처리하여 검증 결과의 예측 가능성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->