### PR TITLE
[FIX]: 이미지 원본 픽셀 크기 상한 상향 (50MP->51MP)

### DIFF
--- a/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
+++ b/src/main/java/or/sopt/houme/global/image/ImageSweepService.java
@@ -32,8 +32,10 @@ public class ImageSweepService {
     /** 변환 대상 원본 확장자 (이미 webp인 이미지나 variant는 제외) */
     private static final Set<String> TARGET_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
-    /** 디코딩 시 메모리를 과도하게 쓰는 큰 이미지를 거르기 위한 픽셀 수 상한 (약 50MP) */
-    private static final long MAX_PIXELS = 50_000_000L;
+    /**
+     * 디코딩 시 메모리를 과도하게 쓰는 큰 이미지를 거르기 위한 픽셀 수 상한 (약 51MP)
+     */
+    private static final long MAX_PIXELS = 51_000_000L;
 
     private final S3Util s3Util;
     private final ImageOptimizer imageOptimizer;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #586 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

어드민 이미지 자동 최적화(sweep)에는 서버 메모리를 보호하기 위한 두 개의 스킵 가드가 있습니다. ([이 PR](https://github.com/TEAM-HOUME/HOUME-SERVER/pull/563)에서 구현했었어요)

- 바이트 상한 20MB (`S3UtilImpl.maxSourceBytes`): 원본을 heap에 올리기 전에 Content-Length로 걸러 다운로드 단계의 OOM 방지
- 픽셀 상한 50MP (`ImageSweepService.MAX_PIXELS`): 다운로드 후 디코딩 시 메모리를 과도하게 쓰는 초대형 이미지 거름망

### 문제
어드민 이미지 중 /styles의 '워커홀릭의 모던 안식처'(styleId 25) 원본은 약 50.1MP로, 바이트 상한(17.4MiB < 20MB)은 통과하지만 픽셀 상한(50MP)을 0.2%(약 10만 픽셀) 초과 => 이 이미지만 variant(최적화본) 변환이 스킵되어 S3에 최적화본이 존재하지 않고, FE의 `OptimizedImage` 컴포넌트의 이미지 폴백 체인에 따라 원본 18.2MB PNG를 그대로 내려받고 있었음. 

### 변경사항
 `ImageSweepService.MAX_PIXELS`를 50_000_000(50MP)에서 51_000_000(51MP)으로 상향

### 영향
다음 S3 자동 sweep(익일 04:00)에서 워커홀릭 원본의 variant가 정상 생성되어, /styles에서 18.2MB 원본 대신 최적화본이 로드됨 (자동 sweep과 FE측 최적화 이미지 자동 로드 로직은 이미 구현 완료되어있어요. MAX_PIXELS 값만 바꾸면 끝!)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

해당 어드민 이미지 하나를 제외하고는 모두 정상적으로 최적화된 상황, 이 이미지만 경계값에 딱 걸려서 S3에 최적화본이 없는 상태였어요. 이번 수정으로 모든 어드민 이미지의 최적화본이 정상적으로 생성됩니다!

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
