### PR TITLE
[FEATURE] 마이페이지 기본 정보 API 응답에 이메일 필드 추가

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageInfoResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/controller/dto/MyPageInfoResponse.java
@@ -3,9 +3,10 @@ package or.sopt.houme.domain.user.presentation.controller.dto;
 public record MyPageInfoResponse(
         Long userId,
         String name,
-        Long CreditCount
+        Long CreditCount,
+        String email
 ) {
-    public static MyPageInfoResponse of(Long userId, String name, Long creditCount) {
-        return new MyPageInfoResponse(userId, name, creditCount);
+    public static MyPageInfoResponse of(Long userId, String name, Long creditCount, String email) {
+        return new MyPageInfoResponse(userId, name, creditCount, email);
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/UserServiceImpl.java
@@ -107,7 +107,7 @@ public class UserServiceImpl implements UserService {
         User findUser = findUser(user);
         String name = findUser.getDisplayName();
         Long creditCount = userRepository.countByMemberIdAndStatus(findUser.getId());
-        return MyPageInfoResponse.of(findUser.getId(), name, creditCount);
+        return MyPageInfoResponse.of(findUser.getId(), name, creditCount, findUser.getEmail());
     }
 
     @Override

--- a/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/presentation/controller/UserControllerTest.java
@@ -94,7 +94,7 @@ class UserControllerTest {
                 .build();
 
         mockUserDetails = new CustomUserDetails(mockUser);
-        mockResponse = MyPageInfoResponse.of(1L, "테스트유저", 10L);
+        mockResponse = MyPageInfoResponse.of(1L, "테스트유저", 10L, "test@example.com");
     }
 
     @Test

--- a/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/UserServiceImplTest.java
@@ -119,6 +119,7 @@ class UserServiceImplTest {
         user = User.builder()
                 .id(1L)
                 .name("테스트유저")
+                .email("test@example.com")
                 .build();
 
         house = House.builder()
@@ -151,6 +152,7 @@ class UserServiceImplTest {
 
         // then
         assertThat(response.name()).isEqualTo("테스트유저");
+        assertThat(response.email()).isEqualTo("test@example.com");
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

- close #588

## 📝 Summary

- `MyPageInfoResponse`에 `email` 필드 추가
- `UserServiceImpl.getMyPageInfo()`에서 `findUser.getEmail()` 포함하여 반환
- 관련 테스트 픽스처 및 assertion 업데이트

## 🙏 Question & PR point

기존 응답 필드(`userId`, `name`, `CreditCount`)는 그대로 유지하고 `email`만 추가했습니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 정보에 이메일 주소가 표시됩니다.

* **테스트**
  * 마이페이지 응답에 이메일 정보가 포함되는지 검증하도록 테스트를 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->