### PR TITLE
[CHORE] 모니터링 스택 서버 적용 조정 + 404 알림 오탐 수정

### DIFF
--- a/monitoring/dev/docker-compose.yml
+++ b/monitoring/dev/docker-compose.yml
@@ -2,7 +2,7 @@
 #   cd monitoring/dev && docker compose up -d
 services:
   promtail:
-    image: grafana/promtail:2.9.8
+    image: grafana/promtail:3.2.1
     container_name: promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml

--- a/monitoring/local/docker-compose.yml
+++ b/monitoring/local/docker-compose.yml
@@ -3,7 +3,7 @@
 #   cd monitoring/local && docker compose up -d
 services:
   promtail:
-    image: grafana/promtail:2.9.8
+    image: grafana/promtail:3.2.1
     container_name: promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml

--- a/monitoring/prod/docker-compose.yml
+++ b/monitoring/prod/docker-compose.yml
@@ -2,7 +2,7 @@
 #   cd monitoring/prod && docker compose up -d
 services:
   promtail:
-    image: grafana/promtail:2.9.8
+    image: grafana/promtail:3.2.1
     container_name: promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml

--- a/monitoring/stack/docker-compose.yml
+++ b/monitoring/stack/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=72h   # 로그와 동일하게 3일 (디스크 여유 부족)
     ports:
-      - "127.0.0.1:9090:9090"
+      - "127.0.0.1:9091:9090"   # 호스트 9090은 기존 네이티브 prometheus가 점유 (추후 폐기)
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/monitoring/stack/docker-compose.yml
+++ b/monitoring/stack/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=72h   # 로그와 동일하게 3일 (디스크 여유 부족)
     ports:
-      - "127.0.0.1:9091:9090"   # 호스트 9090은 기존 네이티브 prometheus가 점유 (추후 폐기)
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/monitoring/stack/prometheus.yml
+++ b/monitoring/stack/prometheus.yml
@@ -8,7 +8,7 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       # prod 앱 — 같은 호스트의 blue/green (호스트 포트 8080)
-      - targets: ["172.17.0.1:8080"]
+      - targets: ["172.17.0.1:8080", "172.17.0.1:8081"]   # blue/green
         labels:
           env: prod
 

--- a/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
+++ b/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.concurrent.RejectedExecutionException;
 
@@ -109,6 +110,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(NoHandlerFoundException ex) {
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_URL;
+
+        Sentry.captureException(ex);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.fail(errorCode.getCode(), errorCode.getMsg()));
+    }
+
+    // 정적 리소스 없음(예: /swagger-ui/) — 실제 404 이므로 NoHandlerFound 와 동일하게 처리하고 5xx 알림을 보내지 않는다
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFound(NoResourceFoundException ex) {
         ErrorCode errorCode = ErrorCode.NOT_FOUND_URL;
 
         Sentry.captureException(ex);


### PR DESCRIPTION
## 📣 Related Issue

- ref #583 (서버 적용 중 발견한 조정)
- close #594 (404 정적 리소스 요청이 5xx 알림으로 오탐되던 문제)

## 📝 Summary

dev/prod 서버에 모니터링 스택을 실제 배포하며 필요했던 조정 + 배포 후 발견한 알림 오탐 수정을 함께 반영합니다.

**모니터링 스택 조정 (서버 구동·검증 완료)**
- **promtail 2.9.8 → 3.2.1**: dev EC2 docker daemon 최신이라 2.9.8 클라이언트가 `API 1.42 too old` 에러 → 3.2.1(1.44 지원)
- **stack prometheus 호스트포트**: 네이티브 prometheus(구) 충돌 회피로 9091 사용 → 네이티브 폐기 후 **9090 원복**
- prometheus 타깃에 blue/green(8080,8081) 추가

**404 알림 오탐 수정 (#594)**
- `GET /swagger-ui/` 같은 정적 리소스 미존재 요청이 `NoResourceFoundException` → 전용 핸들러 부재로 `handleUnhandledException`(5xx 알림)에 떨어져 디스코드로 잘못 발송되던 문제
- `NoHandlerFoundException` 과 동일하게 404(NOT_FOUND_URL) 처리 + 알림 제외

## 🙏 Question & PR point

- 모니터링 스택은 서버에 이미 이 설정으로 구동 중 (Grafana 접속·traceId 검색·prometheus 타깃 up 검증 완료). 코드-실물 일치 목적
- 404 수정은 로컬에서 `/swagger-ui/` → 404(40400) 확인, handleUnhandledException 미진입 검증

## 📬 Postman

- 해당 없음 (인프라/예외처리)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 모니터링 로그 수집 구성에서 Promtail을 최신 버전으로 업데이트했습니다.
  * 운영 환경의 Prometheus가 Blue/Green 애플리케이션 포트 모두에서 메트릭을 수집하도록 개선했습니다.
  * 존재하지 않는 리소스/URL 요청 시 404 응답 처리가 기존 흐름과 동일하게 동작하도록 보완했습니다.
  * 개발·로컬 환경의 기존 서비스 설정과 모니터링 주기는 변경하지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->