### PR TITLE
[FIX] #596 ClientAbortException 디스코드/Sentry 알림 노이즈 제거

### DIFF
--- a/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
+++ b/src/main/java/or/sopt/houme/global/api/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package or.sopt.houme.global.api;
 
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import or.sopt.houme.global.api.handler.ImageFallbackException;
+import org.apache.catalina.connector.ClientAbortException;
 import or.sopt.houme.global.discord.ErrorAlertNotifier;
 import org.springframework.beans.factory.ObjectProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -22,6 +25,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.concurrent.RejectedExecutionException;
 
+@Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
@@ -141,6 +145,14 @@ public class GlobalExceptionHandler {
         Sentry.captureException(e);
 
         return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.fail(errorCode.getCode(), errorCode.getMsg()));
+    }
+
+    // 응답 전송 중 클라이언트(Prometheus scrape, LB 헬스체크 등)가 먼저 연결을 끊은 경우.
+    // 서버 장애가 아니므로 Sentry/디스코드 알림 없이 debug 로그만 남기고,
+    // 연결이 이미 끊겨 응답을 쓸 수 없으므로 본문도 반환하지 않는다.
+    @ExceptionHandler(ClientAbortException.class)
+    public void handleClientAbort(ClientAbortException e, HttpServletRequest request) {
+        log.debug("클라이언트가 응답 수신 중 연결을 끊음: {} {}", request.getMethod(), request.getRequestURI());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 📣 Related Issue

- close #596

## 📝 Summary

dev 서버에서 `GET /actuator/prometheus` 요청에 대해 `ClientAbortException (Broken pipe)` 디스코드 알림이 반복 발생하는 문제를 수정합니다.

- `ClientAbortException`은 서버가 응답을 쓰는 도중 클라이언트(Prometheus scraper, LB 헬스체크 등)가 먼저 연결을 끊었다는 뜻으로, 서버 장애가 아니며 사용자 영향이 없습니다.
- 기존에는 `handleUnhandledException`(Exception catch-all)에 걸려 Sentry 캡처 + 디스코드 5xx 알림이 발송됐습니다.
- `GlobalExceptionHandler`에 전용 핸들러를 추가해 debug 로그만 남기고 무시합니다. 연결이 이미 끊긴 상태라 응답 본문을 쓰면 같은 예외가 다시 발생하므로 반환 타입은 `void`입니다.

## 🙏 Question & PR point

- 반복 발생 빈도가 높다면 `/actuator/prometheus` 응답 크기·시간과 Prometheus `scrape_timeout` 점검이 필요할 수 있습니다 (메트릭 카디널리티 확인).

## 📬 Postman

- 해당 없음 (예외 핸들링 변경, API 스펙 변화 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 클라이언트가 응답 수신 전에 연결을 종료하는 상황을 별도로 처리합니다.
  * 해당 상황에서는 불필요한 외부 알림을 보내지 않고 디버그 로그만 기록하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->