### PR TITLE
[FIX] 어드민 스타일 삭제 시 FK 제약 위반 해결 (House 참조 정리)

### DIFF
--- a/src/main/java/or/sopt/houme/domain/house/repository/HouseRepository.java
+++ b/src/main/java/or/sopt/houme/domain/house/repository/HouseRepository.java
@@ -2,9 +2,16 @@ package or.sopt.houme.domain.house.repository;
 
 import or.sopt.houme.domain.house.model.entity.House;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HouseRepository extends JpaRepository<House, Long>, HouseCustomRepository {
     java.util.List<House> findByUserId(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE House h SET h.banner = null WHERE h.banner.id = :bannerId")
+    int clearBannerReference(@Param("bannerId") Long bannerId);
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminStyleServiceImpl.java
@@ -5,6 +5,7 @@ import or.sopt.houme.domain.banner.model.entity.Banner;
 import or.sopt.houme.domain.banner.model.entity.BannerType;
 import or.sopt.houme.domain.banner.repository.BannerRepository;
 import or.sopt.houme.domain.furniture.model.entity.CurationRawProduct;
+import or.sopt.houme.domain.house.repository.HouseRepository;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.request.AdminBannerImageUploadRequest;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerImageUploadResponse;
 import or.sopt.houme.domain.user.presentation.admin.controller.dto.banner.response.AdminBannerRawProductSearchResponse;
@@ -27,6 +28,7 @@ import java.util.Map;
 public class AdminStyleServiceImpl implements AdminStyleService {
 
     private final BannerRepository bannerRepository;
+    private final HouseRepository houseRepository;
     private final AdminBannerSupport adminBannerSupport;
 
     @Override
@@ -108,6 +110,9 @@ public class AdminStyleServiceImpl implements AdminStyleService {
         Banner style = bannerRepository.findByIdWithRawProducts(styleId, BannerType.STYLE, false)
                 .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_STYLE));
         requireStyle(style);
+        // 이 스타일로 생성된 집(House)이 banner_id로 참조 중이면 FK 제약 위반으로 삭제가 막힌다.
+        // 집 자체는 생성 이력이므로 보존하고, 스타일 연결만 끊은 뒤 삭제한다.
+        houseRepository.clearBannerReference(styleId);
         bannerRepository.delete(style);
         bannerRepository.flush();
     }


### PR DESCRIPTION
## 📣 Related Issue

- close #591

## 📝 Summary

어드민에서 '스타일로 시작하기' 스타일을 삭제하려 하면 DB 예외가 나며 삭제가 막히던 버그를 수정했습니다.

**원인**
스타일은 `banners` 테이블(`banner_type = STYLE`)에 저장되는데, 사용자가 '스타일로 시작하기'로 집을 만들면 `houses.banner_id`가 그 스타일을 참조합니다. 어드민 삭제는 하드 삭제라, 해당 스타일로 만든 집이 하나라도 남아있으면 **FK 제약 위반**으로 삭제가 실패했습니다. (연관 매핑인 `banner_curation_raw_products`는 cascade로 정리되지만, House 참조는 아무도 정리하지 않았음)

**수정**
삭제 직전에 그 스타일을 참조하는 House들의 `banner_id` 연결을 끊은 뒤 삭제하도록 했습니다. 집 데이터 자체는 생성 이력이므로 지우지 않고 스타일 연결(`banner_id`)만 null로 비웁니다.

- `HouseRepository.clearBannerReference(bannerId)` — 해당 배너를 참조하는 House들의 `banner_id`를 한 번에 null 처리하는 벌크 업데이트 추가
- `AdminStyleServiceImpl.delete()` — 삭제 직전 위 메서드 호출

## 🙏 Question & PR point

- **House의 `banner_id`를 null로 비웁니다.** 즉 "이 집이 어떤 스타일로 만들어졌는지" 이력은 사라집니다. 지금은 이력 활용처가 없어 문제없다고 판단했는데, 나중에 이력이 필요하면 소프트 삭제(비노출 플래그) 방식으로 바꾸는 게 맞습니다.
- 노출 순서 변경(id 기반)은 이번 PR 범위에서 제외했습니다. 순서 조정은 기존처럼 재등록 방식으로 진행하면 되고, 필요하면 별도 이슈로 `sort_order` 도입을 검토하면 좋겠습니다.
- 혹시 다른 스타일이 이 스타일을 `linked_banner_id`로 링크하는 예외 케이스가 남으면 여전히 FK 예외가 날 수 있으나, 이 경우 기존 전역 핸들러(`DataIntegrityViolationException`)가 응답을 정상 처리합니다. STYLE 타입은 서로 링크하지 않아 실사용상 문제 없을 것으로 봅니다.

## 📬 Postman

<!-- 로컬/dev에서 스타일로 생성된 집이 있는 스타일 삭제가 정상 동작하는지 확인 후 스크린샷 첨부 예정 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 스타일 삭제 시 연결된 집 정보와의 참조가 먼저 해제되어 삭제가 정상적으로 처리됩니다.
  * 스타일과 집 간 참조로 인해 삭제가 차단되던 문제가 해결되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->