### PR TITLE
[FEAT] #600 유저 로그인 이력 DB 적재 (login_histories)

### DIFF
--- a/src/main/java/or/sopt/houme/domain/user/model/entity/LoginHistory.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/LoginHistory.java
@@ -1,0 +1,44 @@
+package or.sopt.houme.domain.user.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.houme.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "login_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginHistory extends BaseEntity {
+    // 로그인 이력 (createdAt = 로그인 시각)
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 로그인한 유저
+    @Comment(value = "로그인한 유저 식별자")
+    @Column(nullable = false)
+    private Long userId;
+
+    // 로그인 종류 (신규 가입 / 기존 로그인)
+    @Comment(value = "로그인 종류 (SIGN_UP / LOGIN)")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private LoginType loginType;
+
+    // 소셜 종류
+    @Comment(value = "소셜 종류 (KAKAO)")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SocialType socialType;
+
+    @Builder
+    public LoginHistory(Long userId, LoginType loginType, SocialType socialType) {
+        this.userId = userId;
+        this.loginType = loginType;
+        this.socialType = socialType;
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/model/entity/LoginType.java
+++ b/src/main/java/or/sopt/houme/domain/user/model/entity/LoginType.java
@@ -1,0 +1,6 @@
+package or.sopt.houme.domain.user.model.entity;
+
+public enum LoginType {
+    SIGN_UP, // 신규 가입 완료(최초 로그인)
+    LOGIN    // 기존 유저 로그인
+}

--- a/src/main/java/or/sopt/houme/domain/user/repository/LoginHistoryRepository.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/LoginHistoryRepository.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.domain.user.repository;
+
+import or.sopt.houme.domain.user.model.entity.LoginHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginHistoryRepository extends JpaRepository<LoginHistory, Long> {
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/LoginHistoryService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/LoginHistoryService.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.user.service;
+
+import or.sopt.houme.domain.user.model.entity.LoginType;
+import or.sopt.houme.domain.user.model.entity.SocialType;
+
+public interface LoginHistoryService {
+
+    // 로그인 이력 적재 (신규 가입 / 기존 로그인)
+    void record(Long userId, LoginType loginType, SocialType socialType);
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/LoginHistoryServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/LoginHistoryServiceImpl.java
@@ -1,0 +1,28 @@
+package or.sopt.houme.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.model.entity.LoginHistory;
+import or.sopt.houme.domain.user.model.entity.LoginType;
+import or.sopt.houme.domain.user.model.entity.SocialType;
+import or.sopt.houme.domain.user.repository.LoginHistoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LoginHistoryServiceImpl implements LoginHistoryService {
+
+    private final LoginHistoryRepository loginHistoryRepository;
+
+    // 로그인/가입 트랜잭션과 독립적으로 커밋되도록 REQUIRES_NEW 로 분리한다
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public void record(Long userId, LoginType loginType, SocialType socialType) {
+        loginHistoryRepository.save(LoginHistory.builder()
+                .userId(userId)
+                .loginType(loginType)
+                .socialType(socialType)
+                .build());
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/OAuthService.java
@@ -64,6 +64,7 @@ public class OAuthService {
     private final SignupSessionRepository signupSessionRepository;
     private final NicknameService nicknameService;
     private final UserNicknameTagTransactionService userNicknameTagTransactionService;
+    private final LoginHistoryService loginHistoryService;
 
     private final KaKaoConfig kaKaoConfig;
     private final CookieConfig cookieConfig;
@@ -162,22 +163,7 @@ public class OAuthService {
         User byEmail = userRepository.findByEmail(email)
                 .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        String access = jwtUtil.createJwt("access", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
-        String refresh = jwtUtil.createJwt("refresh", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
-
-        refreshTokenRepository.saveRefreshToken(byEmail.getId(),refresh,jwtConfig.getRefreshTokenValidityInSeconds());
-
-        response.setHeader("access-token", access);
-
-        CookieUtil.addSameSiteCookie(
-                response,
-                "refresh-token",
-                refresh,
-                jwtConfig.getRefreshTokenValidityInSeconds().intValue(),
-                cookieConfig.getDomain(),
-                cookieConfig.isSecure(),
-                cookieConfig.getSameSite()
-        );
+        issueTokens(byEmail, response, LoginType.LOGIN);
 
         return KakaoLoginResponse.existingUser();
     }
@@ -209,7 +195,7 @@ public class OAuthService {
         }
 
         User savedUser = createUserWithNicknameTagRetry(signupSession, nickname, gender, birthday);
-        issueTokens(savedUser, response);
+        issueTokens(savedUser, response, LoginType.SIGN_UP);
         return savedUser.getDisplayName();
     }
 
@@ -260,7 +246,7 @@ public class OAuthService {
             throw new CreditException(ErrorCode.CREDIT_CREATE_EXCEPTION);
         }
 
-        issueTokens(savedUser, response);
+        issueTokens(savedUser, response, LoginType.SIGN_UP);
 
         if (StringUtils.hasText(nickname)) {
             return savedUser.getDisplayName();
@@ -294,7 +280,7 @@ public class OAuthService {
         throw new UserException(ErrorCode.NICKNAME_TAG_GENERATION_FAILED);
     }
 
-    private void issueTokens(User savedUser, HttpServletResponse response) {
+    private void issueTokens(User savedUser, HttpServletResponse response, LoginType loginType) {
         String access = jwtUtil.createJwt("access", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
         String refresh = jwtUtil.createJwt("refresh", savedUser.getId(), savedUser.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
 
@@ -311,6 +297,17 @@ public class OAuthService {
                 cookieConfig.isSecure(),
                 cookieConfig.getSameSite()
         );
+
+        recordLoginHistorySafely(savedUser.getId(), loginType, savedUser.getSocialType());
+    }
+
+    // 로그인 이력 적재. 적재 실패가 로그인/가입 자체를 깨지 않도록 예외를 삼킨다.
+    private void recordLoginHistorySafely(Long userId, LoginType loginType, SocialType socialType) {
+        try {
+            loginHistoryService.record(userId, loginType, socialType);
+        } catch (Exception e) {
+            log.warn("로그인 이력 적재 실패 (로그인/가입은 정상 처리됨) userId={}, type={}: {}", userId, loginType, e.getMessage());
+        }
     }
 
     private boolean isNicknameTagConstraintViolation(DataIntegrityViolationException exception) {

--- a/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/OAuthServiceTest.java
@@ -12,7 +12,9 @@ import or.sopt.houme.domain.user.presentation.controller.dto.KaKaoOAuthTokenDTO;
 import or.sopt.houme.domain.user.presentation.controller.dto.KaKaoUserInfoResponse;
 import or.sopt.houme.domain.credit.repository.CreditRepository;
 import or.sopt.houme.domain.user.model.entity.Gender;
+import or.sopt.houme.domain.user.model.entity.LoginType;
 import or.sopt.houme.domain.user.model.entity.Role;
+import or.sopt.houme.domain.user.model.entity.SocialType;
 import or.sopt.houme.domain.user.model.entity.User;
 import or.sopt.houme.domain.user.repository.BlacklistTokenRepository;
 import or.sopt.houme.domain.user.repository.RefreshTokenRepository;
@@ -71,6 +73,8 @@ class OAuthServiceTest {
     private NicknameService nicknameService;
     @Mock
     private UserNicknameTagTransactionService userNicknameTagTransactionService;
+    @Mock
+    private LoginHistoryService loginHistoryService;
 
     @Mock
     private HttpServletResponse response;
@@ -85,6 +89,7 @@ class OAuthServiceTest {
                 .nickname("느긋한펭귄")
                 .nicknameTag("#4821")
                 .role(Role.ROLE_USER)
+                .socialType(SocialType.KAKAO)
                 .build();
 
         when(signupSessionRepository.consume("signup-token")).thenReturn(Optional.of(signupSession));
@@ -122,6 +127,45 @@ class OAuthServiceTest {
                 Gender.MALE,
                 java.time.LocalDate.of(2000, 1, 1)
         );
+        verify(loginHistoryService).record(1L, LoginType.SIGN_UP, SocialType.KAKAO);
+    }
+
+    @Test
+    @DisplayName("로그인 이력 적재가 실패해도 로그인은 정상 처리된다")
+    void kakaoLogin_loginHistoryFailure_doesNotBreakLogin() {
+        String code = "authCode";
+        KaKaoOAuthTokenDTO tokenDTO = new KaKaoOAuthTokenDTO();
+        tokenDTO.setAccess_token("kakaoAccessToken");
+
+        KaKaoUserInfoResponse.KakaoAccount kakaoAccount = new KaKaoUserInfoResponse.KakaoAccount();
+        kakaoAccount.setEmail("test@houme.kr");
+        KaKaoUserInfoResponse userInfo = new KaKaoUserInfoResponse();
+        userInfo.setId(1234L);
+        userInfo.setKakao_account(kakaoAccount);
+
+        when(kaKaoOAuthClient.getToken(any(), any(), any(), any())).thenReturn(tokenDTO);
+        when(kaKaoUserInfoClient.getUserInfo("Bearer kakaoAccessToken")).thenReturn(userInfo);
+        when(userRepository.existsByEmail("test@houme.kr")).thenReturn(true);
+        when(userRepository.findByEmail("test@houme.kr")).thenReturn(Optional.of(
+                User.builder().id(1L).email("test@houme.kr").role(Role.ROLE_USER).socialType(SocialType.KAKAO).build()
+        ));
+        when(jwtUtil.createJwt(eq("access"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("accessToken");
+        when(jwtUtil.createJwt(eq("refresh"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("refreshToken");
+        when(jwtConfig.getAccessTokenValidityInSeconds()).thenReturn(3600L);
+        when(jwtConfig.getRefreshTokenValidityInSeconds()).thenReturn(86400L);
+        when(cookieConfig.getDomain()).thenReturn("domain");
+        when(cookieConfig.getSameSite()).thenReturn("true");
+        // 이력 적재가 예외를 던져도
+        doThrow(new RuntimeException("DB down")).when(loginHistoryService).record(anyLong(), any(), any());
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("Origin")).thenReturn("http://localhost:5173");
+
+        // 로그인 자체는 정상 완료되어야 한다
+        KakaoLoginResponse result = oAuthService.kakaoLogin(code, request, response);
+
+        assertFalse(result.isNewUser());
+        verify(response).setHeader("access-token", "accessToken");
     }
 
     @Test
@@ -236,6 +280,8 @@ class OAuthServiceTest {
         verify(userRepository, never()).save(any(User.class));
         verify(refreshTokenRepository, never()).saveRefreshToken(anyLong(), anyString(), anyLong());
         verify(response, never()).setHeader(eq("access-token"), anyString());
+        // 아직 회원 생성 전(임시토큰만 발급)이므로 로그인 이력을 남기지 않는다
+        verify(loginHistoryService, never()).record(anyLong(), any(), any());
     }
 
     @Test
@@ -257,7 +303,7 @@ class OAuthServiceTest {
         when(kaKaoUserInfoClient.getUserInfo("Bearer kakaoAccessToken")).thenReturn(userInfo);
         when(userRepository.existsByEmail("test@houme.kr")).thenReturn(true);
         when(userRepository.findByEmail("test@houme.kr")).thenReturn(Optional.of(
-                User.builder().id(1L).email("test@houme.kr").role(Role.ROLE_USER).build()
+                User.builder().id(1L).email("test@houme.kr").role(Role.ROLE_USER).socialType(SocialType.KAKAO).build()
         ));
 
         when(jwtUtil.createJwt(eq("access"), eq(1L), eq("ROLE_USER"), anyLong())).thenReturn("accessToken");
@@ -278,6 +324,7 @@ class OAuthServiceTest {
         assertFalse(result.isNewUser());
         verify(refreshTokenRepository).saveRefreshToken(eq(1L), eq("refreshToken"), eq(86400L));
         verify(response).setHeader("access-token", "accessToken");
+        verify(loginHistoryService).record(1L, LoginType.LOGIN, SocialType.KAKAO);
     }
 
 


### PR DESCRIPTION
## 📣 Related Issue

- close #600

## 📝 Summary

카카오 로그인 시 로그인 이력을 DB에 적재해, 신규 사용자 대시보드에서 '신규 vs 기존' 로그인을 집계할 수 있게 합니다. (기존에는 로그인 이력 테이블 자체가 없었음)

**신규 파일**
- `LoginHistory` 엔티티 (`login_histories`), `LoginType` enum(`SIGN_UP`/`LOGIN`)
- `LoginHistoryRepository`, `LoginHistoryService`(+Impl)

**적재 시점**
- 신규 가입 완료 → `SIGN_UP`
- 기존 유저 카카오 로그인 → `LOGIN`
- 토큰 재발급(refresh)은 세션 연장이라 **제외**

**설계 포인트**
- 기존 유저 분기의 인라인 토큰 발급 코드를 `issueTokens(user, response, loginType)`로 통일 → 신규/기존이 **단일 지점**에서 이력 기록 (중복 제거 겸).
- 이력 적재는 `@Transactional(REQUIRES_NEW)` + 호출부 `try/catch`로 로그인/가입 트랜잭션과 독립 처리. **적재가 실패해도 로그인/가입은 정상 완료**됩니다.

**스키마** (`login_histories`)
| 컬럼 | 설명 |
|---|---|
| user_id | 로그인 유저 |
| login_type | SIGN_UP / LOGIN |
| social_type | KAKAO |
| created_at | 로그인 시각 (BaseEntity) |

## 🙏 Question & PR point

- ⚠️ **운영 `ddl-auto` 확인 필요**: `update`면 `login_histories`가 자동 생성되지만, `validate`/`none`이면 배포 전 수동 `CREATE TABLE`이 필요합니다.
- 소셜 확장 대비 `social_type` 컬럼을 남겨뒀습니다(현재 KAKAO 단일).

## 📬 Postman

- 해당 없음 (로그인 플로우 내부 적재, API 스펙 변화 없음). `OAuthServiceTest`에 신규/기존/미가입/적재실패 케이스 테스트 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)