### PR TITLE
[FEATURE] 백오피스 회원 크레딧 추가 기능

### DIFF
--- a/src/main/java/or/sopt/houme/domain/credit/repository/CreditRepository.java
+++ b/src/main/java/or/sopt/houme/domain/credit/repository/CreditRepository.java
@@ -1,10 +1,13 @@
 package or.sopt.houme.domain.credit.repository;
 
 import or.sopt.houme.domain.credit.model.entity.Credit;
+import or.sopt.houme.domain.credit.model.entity.CreditStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CreditRepository extends JpaRepository<Credit, Long>, CreditCustomRepository {
     void deleteByUserId(Long userId);
+
+    long countByUserIdAndStatus(Long userId, CreditStatus status);
 }

--- a/src/main/java/or/sopt/houme/domain/credit/service/CreditService.java
+++ b/src/main/java/or/sopt/houme/domain/credit/service/CreditService.java
@@ -21,4 +21,8 @@ public interface CreditService {
 
     // 락 수동 해제 메서드 추가
     void releaseLock(User user);
+
+    // 회원에게 ACTIVE 크레딧 amount 개를 지급하고, 지급 후 잔액(ACTIVE 개수)을 반환
+    @Transactional
+    long grantCredits(User user, int amount);
 }

--- a/src/main/java/or/sopt/houme/domain/credit/service/CreditServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/credit/service/CreditServiceImpl.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -128,6 +130,47 @@ public class CreditServiceImpl implements CreditService{
         final RLock lock = redissonClient.getLock(lockKey);
         if (lock.isLocked() && lock.isHeldByCurrentThread()) {
             lock.unlock();
+        }
+    }
+
+    // 회원에게 ACTIVE 크레딧 amount 개를 지급 (1 크레딧 = 1 row 모델).
+    // 지급은 소진과 경합하므로 소진과 동일한 락(credit_lock_user_{id})으로 동시성을 제어한다.
+    @Override
+    @Transactional
+    public long grantCredits(User user, int amount) {
+        final String lockKey = "credit_lock_user_" + user.getId();
+        final RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean isLocked = lock.tryLock(10, 210, TimeUnit.SECONDS);
+
+            if (!isLocked) {
+                log.error("크레딧 지급 락 획득 실패, user: {}", user.getId());
+                throw new CreditException(ErrorCode.CREDIT_LOCK_FAILED);
+            }
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                        lock.unlock();
+                    }
+                }
+            });
+
+            List<Credit> credits = new ArrayList<>();
+            for (int i = 0; i < amount; i++) {
+                credits.add(Credit.builder()
+                        .status(CreditStatus.ACTIVE)
+                        .user(user)
+                        .build());
+            }
+            creditRepository.saveAll(credits);
+
+            return creditRepository.countByUserIdAndStatus(user.getId(), CreditStatus.ACTIVE);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CreditException(ErrorCode.CREDIT_LOCK_INTERRUPTED);
         }
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminMemberController.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/AdminMemberController.java
@@ -1,0 +1,47 @@
+package or.sopt.houme.domain.user.presentation.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.request.AdminCreditGrantRequest;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminCreditGrantResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminMemberSearchResponse;
+import or.sopt.houme.domain.user.service.admin.AdminMemberService;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/members")
+@Tag(name = "어드민 회원 API")
+@Validated
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping
+    @Operation(summary = "회원 검색 API (이메일 완전일치 또는 닉네임 부분검색, 현재 크레딧 잔액 포함)")
+    public ResponseEntity<ApiResponse<AdminMemberSearchResponse>> searchMembers(
+            @RequestParam(required = false) String keyword
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminMemberService.searchMembers(keyword)));
+    }
+
+    @PostMapping("/{memberId}/credits")
+    @Operation(summary = "회원 크레딧 지급 API")
+    public ResponseEntity<ApiResponse<AdminCreditGrantResponse>> grantCredits(
+            @PathVariable Long memberId,
+            @Valid @RequestBody AdminCreditGrantRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminMemberService.grantCredits(memberId, request.amount())));
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/request/AdminCreditGrantRequest.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/request/AdminCreditGrantRequest.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.member.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record AdminCreditGrantRequest(
+        @NotNull @Positive @Max(1000) Integer amount
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminCreditGrantResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminCreditGrantResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response;
+
+public record AdminCreditGrantResponse(
+        Long memberId,
+        int grantedAmount,
+        long creditBalance
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminMemberResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminMemberResponse.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response;
+
+public record AdminMemberResponse(
+        Long memberId,
+        String nickname,
+        String nicknameTag,
+        String email,
+        long creditBalance
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminMemberSearchResponse.java
+++ b/src/main/java/or/sopt/houme/domain/user/presentation/admin/controller/dto/member/response/AdminMemberSearchResponse.java
@@ -1,0 +1,8 @@
+package or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response;
+
+import java.util.List;
+
+public record AdminMemberSearchResponse(
+        List<AdminMemberResponse> members
+) {
+}

--- a/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryCustom.java
@@ -1,11 +1,16 @@
 package or.sopt.houme.domain.user.repository;
 
 import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
+import or.sopt.houme.domain.user.model.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepositoryCustom {
     Long countByMemberIdAndStatus(Long userId);
 
     Optional<GenerateImage> findImageHistoryById(Long userId);
+
+    // 이메일 완전일치 또는 닉네임 부분일치로 회원 검색 (id 오름차순, limit 제한)
+    List<User> searchMembers(String keyword, int limit);
 }

--- a/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/repository/UserRepositoryImpl.java
@@ -7,8 +7,10 @@ import or.sopt.houme.domain.generateImage.model.entity.GenerateImage;
 import or.sopt.houme.domain.generateImage.model.entity.QGenerateImage;
 import or.sopt.houme.domain.house.model.entity.QHouse;
 import or.sopt.houme.domain.user.model.entity.QUser;
+import or.sopt.houme.domain.user.model.entity.User;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static or.sopt.houme.domain.credit.model.entity.QCredit.credit;
@@ -44,5 +46,17 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .where(user.id.eq(userId))
                 .limit(1)
                 .fetchOne());
+    }
+
+    @Override
+    public List<User> searchMembers(String keyword, int limit) {
+        QUser user = QUser.user;
+        return queryFactory
+                .selectFrom(user)
+                .where(user.email.eq(keyword)
+                        .or(user.nickname.containsIgnoreCase(keyword)))
+                .orderBy(user.id.asc())
+                .limit(limit)
+                .fetch();
     }
 }

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminMemberService.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminMemberService.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminCreditGrantResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminMemberSearchResponse;
+
+public interface AdminMemberService {
+
+    AdminMemberSearchResponse searchMembers(String keyword);
+
+    AdminCreditGrantResponse grantCredits(Long memberId, int amount);
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminMemberServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminMemberServiceImpl.java
@@ -1,0 +1,57 @@
+package or.sopt.houme.domain.user.service.admin;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.credit.service.CreditService;
+import or.sopt.houme.domain.user.model.entity.User;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminCreditGrantResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminMemberResponse;
+import or.sopt.houme.domain.user.presentation.admin.controller.dto.member.response.AdminMemberSearchResponse;
+import or.sopt.houme.domain.user.repository.UserRepository;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminMemberServiceImpl implements AdminMemberService {
+
+    private static final int MEMBER_SEARCH_LIMIT = 20;
+
+    private final UserRepository userRepository;
+    private final CreditService creditService;
+
+    @Override
+    public AdminMemberSearchResponse searchMembers(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return new AdminMemberSearchResponse(List.of());
+        }
+
+        List<AdminMemberResponse> members = userRepository.searchMembers(keyword.trim(), MEMBER_SEARCH_LIMIT)
+                .stream()
+                .map(user -> new AdminMemberResponse(
+                        user.getId(),
+                        user.getNickname(),
+                        user.getNicknameTag(),
+                        user.getEmail(),
+                        userRepository.countByMemberIdAndStatus(user.getId())
+                ))
+                .toList();
+
+        return new AdminMemberSearchResponse(members);
+    }
+
+    @Override
+    @Transactional
+    public AdminCreditGrantResponse grantCredits(Long memberId, int amount) {
+        User member = userRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+        long balance = creditService.grantCredits(member, amount);
+
+        return new AdminCreditGrantResponse(member.getId(), amount, balance);
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -909,6 +909,11 @@
                 <i class="fas fa-drafting-compass"></i>도면 관리
             </a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="credit-management">
+                <i class="fas fa-coins"></i>회원 크레딧 추가
+            </a>
+        </li>
     </ul>
 </div>
 
@@ -2026,6 +2031,57 @@
                     </div>
                 </form>
                 <div id="floor-plan-form-result" class="api-result"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 회원 크레딧 추가 섹션 -->
+    <div id="credit-management" class="content-section">
+        <h2>회원 크레딧 추가</h2>
+
+        <div class="card">
+            <div class="card-header">1. 회원 검색</div>
+            <div class="card-body">
+                <form id="credit-member-search-form" class="d-flex flex-wrap gap-2 align-items-end">
+                    <div class="flex-grow-1" style="min-width: 260px;">
+                        <label for="credit-search-keyword" class="form-label">이메일 또는 닉네임</label>
+                        <input type="text" class="form-control" id="credit-search-keyword"
+                               placeholder="이메일 전체 또는 닉네임 일부" autocomplete="off">
+                    </div>
+                    <button type="submit" class="btn btn-secondary">검색</button>
+                </form>
+                <div class="table-responsive mt-3">
+                    <table class="table table-hover align-middle" id="credit-search-table" style="display:none;">
+                        <thead>
+                            <tr>
+                                <th>회원 ID</th>
+                                <th>닉네임</th>
+                                <th>이메일</th>
+                                <th class="text-end">현재 크레딧</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="credit-search-tbody"></tbody>
+                    </table>
+                </div>
+                <div id="credit-search-result" class="api-result"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">2. 크레딧 지급</div>
+            <div class="card-body">
+                <p id="credit-selected-member" class="text-muted mb-3">위 목록에서 회원을 선택하세요.</p>
+                <form id="credit-grant-form">
+                    <input type="hidden" id="credit-selected-member-id">
+                    <div class="mb-3" style="max-width: 220px;">
+                        <label for="credit-grant-amount" class="form-label">추가할 크레딧 개수</label>
+                        <input type="number" class="form-control" id="credit-grant-amount"
+                               min="1" max="1000" value="5" required>
+                    </div>
+                    <button type="submit" id="credit-grant-button" class="btn btn-primary" disabled>크레딧 지급</button>
+                </form>
+                <div id="credit-grant-result" class="api-result"></div>
             </div>
         </div>
     </div>
@@ -6362,6 +6418,100 @@
                 console.error('Upload Error:', error);
             });
     }
+
+    // ===== 회원 크레딧 추가 =====
+    (function () {
+        const searchForm = document.getElementById('credit-member-search-form');
+        const grantForm = document.getElementById('credit-grant-form');
+        if (!searchForm || !grantForm) return;
+
+        const searchResult = document.getElementById('credit-search-result');
+        const grantResult = document.getElementById('credit-grant-result');
+        const table = document.getElementById('credit-search-table');
+        const tbody = document.getElementById('credit-search-tbody');
+        const selectedIdInput = document.getElementById('credit-selected-member-id');
+        const selectedLabel = document.getElementById('credit-selected-member');
+        const grantButton = document.getElementById('credit-grant-button');
+
+        function escapeHtml(v) {
+            return String(v ?? '').replace(/[&<>"']/g, c =>
+                ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+        }
+
+        function renderMembers(data, resultDiv) {
+            const members = (data && data.data && data.data.members) || [];
+            if (!members.length) {
+                table.style.display = 'none';
+                tbody.innerHTML = '';
+                resultDiv.innerHTML = '<div class="alert alert-warning">일치하는 회원이 없습니다.</div>';
+                return;
+            }
+            resultDiv.innerHTML = '';
+            table.style.display = '';
+            tbody.innerHTML = members.map(m => {
+                const nick = m.nickname ? `${escapeHtml(m.nickname)} #${escapeHtml(m.nicknameTag)}` : '(닉네임 없음)';
+                return `<tr>
+                    <td>${escapeHtml(m.memberId)}</td>
+                    <td>${nick}</td>
+                    <td>${escapeHtml(m.email)}</td>
+                    <td class="text-end">${escapeHtml(m.creditBalance)}</td>
+                    <td class="text-end">
+                        <button type="button" class="btn btn-sm btn-info credit-select-btn"
+                            data-id="${escapeHtml(m.memberId)}" data-label="${nick} · ${escapeHtml(m.email)}">선택</button>
+                    </td>
+                </tr>`;
+            }).join('');
+
+            tbody.querySelectorAll('.credit-select-btn').forEach(btn => {
+                btn.addEventListener('click', function () {
+                    selectedIdInput.value = this.dataset.id;
+                    selectedLabel.textContent = `선택된 회원: ${this.dataset.label} (ID ${this.dataset.id})`;
+                    selectedLabel.classList.remove('text-muted');
+                    grantButton.disabled = false;
+                    grantResult.innerHTML = '';
+                });
+            });
+        }
+
+        searchForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const keyword = document.getElementById('credit-search-keyword').value.trim();
+            if (!keyword) {
+                searchResult.innerHTML = '<div class="alert alert-warning">검색어를 입력해주세요.</div>';
+                return;
+            }
+            const accessToken = localStorage.getItem('accessToken');
+            testApiCall(accessToken, searchResult,
+                '/api/v1/admin/members?keyword=' + encodeURIComponent(keyword), 'GET', null, renderMembers);
+        });
+
+        grantForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const memberId = selectedIdInput.value;
+            if (!memberId) {
+                grantResult.innerHTML = '<div class="alert alert-warning">먼저 회원을 선택해주세요.</div>';
+                return;
+            }
+            const amount = parseInt(document.getElementById('credit-grant-amount').value, 10);
+            if (!Number.isInteger(amount) || amount < 1) {
+                grantResult.innerHTML = '<div class="alert alert-warning">1 이상의 크레딧 개수를 입력해주세요.</div>';
+                return;
+            }
+            const accessToken = localStorage.getItem('accessToken');
+            testApiCall(accessToken, grantResult,
+                '/api/v1/admin/members/' + memberId + '/credits', 'POST', { amount: amount },
+                function (data, resultDiv) {
+                    const d = (data && data.data) || {};
+                    resultDiv.innerHTML = `<div class="alert alert-success">크레딧 ${escapeHtml(d.grantedAmount)}개 지급 완료 · 현재 보유 ${escapeHtml(d.creditBalance)}개</div>`;
+                    // 검색 결과 테이블의 해당 회원 잔액도 갱신
+                    const btn = tbody.querySelector(`.credit-select-btn[data-id="${memberId}"]`);
+                    if (btn) {
+                        const cell = btn.closest('tr').querySelector('td:nth-child(4)');
+                        if (cell) cell.textContent = d.creditBalance;
+                    }
+                });
+        });
+    })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 📣 Related Issue

- close #602

## 📝 Summary

백오피스(어드민 대시보드)에서 운영자가 회원을 검색해 크레딧을 수동 지급하는 기능을 추가했습니다.

**API 2개**
- `GET /api/v1/admin/members?keyword=` — 이메일 완전일치 또는 닉네임 부분검색. 각 회원의 현재 ACTIVE 크레딧 수 포함.
- `POST /api/v1/admin/members/{memberId}/credits` `{ "amount": N }` — ACTIVE 크레딧 N개 지급 후 잔액 반환.

**설계 포인트**
- 크레딧은 "1 크레딧 = 1 row" 모델이라 지급 = `Credit(status=ACTIVE, user)` N개 `saveAll` (회원가입 지급 패턴 재사용).
- `CreditService.grantCredits`는 소진 로직과 동일한 Redisson 락(`credit_lock_user_{id}`)으로 동시성 제어 — 지급 중 사용과의 경합에서 카운트가 꼬이지 않도록.
- `amount` 검증: `@Positive` + `@Max(1000)`.

**UI**
- 신규 화면이 아니라 기존 어드민 대시보드(`templates/admin/dashboard.html`)에 "회원 크레딧 추가" 탭을 추가. 회원 검색 → 목록에서 선택 → 개수 입력 → 지급. 기존 `testApiCall` 헬퍼 + `localStorage` accessToken 패턴 그대로 재사용.

## 🙏 Question & PR point

- **인가(권한) 검증은 넣지 않았습니다.** 기존 `/api/v1/admin/**`가 `ROLE_ADMIN` 검사를 실제로 하지 않는 관행(`SecurityConfig`에 `@PreAuthorize`/`hasRole` 전무)을 그대로 따랐습니다. 다만 크레딧은 값이 오가는 민감 기능이라, **프로덕션 배포 전 최소한 이 엔드포인트에 ROLE_ADMIN 인가 추가를 권장**합니다.
- **지급 이력을 남기지 않습니다.** 누가/언제/얼마/왜 지급했는지 추적할 테이블이 없습니다. 운영·CS 추적이 필요하면 별도 이슈로 이력 테이블 도입을 검토해주세요.
- 지급 크레딧은 만료 없이 계속 ACTIVE입니다.

## 📬 Postman

로컬(local 프로파일, PostgreSQL+Redis)에서 검증 완료:
- 닉네임 부분검색 / 이메일 완전일치 조회 정상, 잔액 포함 반환
- `홍길동` 잔액 3 → +5 지급 → 8 (DB `credits` ACTIVE row 8개로 실제 반영 확인)
- `amount=0`, `amount=5000` → 400 검증 실패 / 없는 회원 → 40401
- 대시보드 "회원 크레딧 추가" 탭 정상 서빙(HTTP 200)
