### PR TITLE
[FEAT] #607 Prometheus Alert → Discord 인프라 알림 (Alertmanager + node-exporter)

### DIFF
--- a/monitoring/stack/README.md
+++ b/monitoring/stack/README.md
@@ -1,0 +1,55 @@
+# 모니터링 스택 (Grafana + Loki + Prometheus + Alertmanager)
+
+prod EC2 에서 실행하는 중앙 모니터링 스택입니다.
+
+```bash
+cd monitoring/stack
+GRAFANA_ADMIN_PASSWORD=<팀비번> docker compose up -d
+```
+
+## 구성
+
+- **Prometheus** (`prometheus.yml`) — prod/dev 앱 `/actuator/prometheus` + node-exporter 스크랩, `rules/` 알림 룰 평가
+- **Alertmanager** (`alertmanager/`) — 룰 발화 시 Discord 로 알림 (native `discord_configs`)
+- **node-exporter** — 호스트(prod EC2) CPU/디스크/메모리 지표
+- **Grafana / Loki** — 대시보드 및 로그
+
+## 알림 룰 (`rules/houme-alerts.yml`)
+
+| alert | 조건 | 심각도 |
+|---|---|---|
+| HoumeAppDown | job 전체 인스턴스 다운 2분 | critical |
+| HoumeHighJvmHeap | JVM Heap > 80% 3분 | warning |
+| HighHostCpuUsage | 호스트 CPU > 80% 5분 | warning |
+| HighHostDiskUsage | 루트 디스크 > 85% 5분 | warning |
+
+## Discord 웹훅 시크릿 (⚠️ git 에 커밋 금지)
+
+Alertmanager 는 설정 파일에서 환경변수를 읽지 못하므로, 웹훅 URL 은
+`alertmanager/secrets/discord_webhook_url` **파일**로 읽습니다.
+이 파일은 `.gitignore` 로 제외되며 **서버에만** 배치합니다.
+
+```bash
+# 서버(스택 배포 경로)에서 1회 생성
+printf '%s' 'https://discord.com/api/webhooks/<CHANNEL_ID>/<TOKEN>' \
+  > alertmanager/secrets/discord_webhook_url
+chmod 600 alertmanager/secrets/discord_webhook_url
+
+# alertmanager 재시작(파일 반영)
+docker compose up -d alertmanager
+```
+
+파일이 없으면 alertmanager 가 기동 실패하므로, 스택 기동 전에 배치해야 합니다.
+
+## 발화 테스트
+
+```bash
+# amtool 없이 Alertmanager API 로 테스트 알림 전송
+curl -XPOST http://127.0.0.1:9093/api/v2/alerts -H 'Content-Type: application/json' -d '[{
+  "labels": {"alertname":"TestAlert","service":"houme-api","severity":"warning","job":"houme-dev"},
+  "annotations": {"summary":"테스트","description":"디스코드 연동 확인용"}
+}]'
+```
+
+> dev 호스트 CPU/디스크 지표가 필요하면 dev EC2 에도 node-exporter 를 띄우고
+> `prometheus.yml` 에 스크랩 타깃을 추가하면 됩니다 (본 스택은 prod 호스트 기준).

--- a/monitoring/stack/alertmanager/alertmanager.yml
+++ b/monitoring/stack/alertmanager/alertmanager.yml
@@ -1,0 +1,22 @@
+# Alertmanager — Prometheus 알림을 Discord 로 전달
+# 웹훅 URL 은 코드에 넣지 않는다 → webhook_url_file 로 시크릿 파일을 읽는다.
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: discord
+  group_by: ["alertname", "job"]
+  group_wait: 30s        # 첫 발화 후 묶기 대기
+  group_interval: 5m     # 같은 그룹 추가 알림 간격
+  repeat_interval: 3h    # 미해결 알림 반복 주기 (도배 방지)
+
+receivers:
+  - name: discord
+    discord_configs:
+      # 실제 웹훅 URL 이 담긴 파일 (git 미포함, 서버에 배치)
+      - webhook_url_file: /etc/alertmanager/secrets/discord_webhook_url
+        title: '{{ template "houme.discord.title" . }}'
+        message: '{{ template "houme.discord.message" . }}'
+
+templates:
+  - /etc/alertmanager/templates/*.tmpl

--- a/monitoring/stack/alertmanager/secrets/.gitignore
+++ b/monitoring/stack/alertmanager/secrets/.gitignore
@@ -1,0 +1,4 @@
+# 실제 웹훅 URL 시크릿은 커밋 금지 — 예시/이 파일만 추적
+*
+!.gitignore
+!discord_webhook_url.example

--- a/monitoring/stack/alertmanager/secrets/discord_webhook_url.example
+++ b/monitoring/stack/alertmanager/secrets/discord_webhook_url.example
@@ -1,0 +1,1 @@
+https://discord.com/api/webhooks/<CHANNEL_ID>/<TOKEN>

--- a/monitoring/stack/alertmanager/templates/discord.tmpl
+++ b/monitoring/stack/alertmanager/templates/discord.tmpl
@@ -1,0 +1,11 @@
+{{ define "houme.discord.title" -}}
+[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
+{{- end }}
+
+{{ define "houme.discord.message" -}}
+{{ range .Alerts -}}
+- service={{ .Labels.service }} severity={{ .Labels.severity }} job={{ .Labels.job }}
+  summary={{ .Annotations.summary }}
+  description={{ .Annotations.description }}
+{{ end -}}
+{{- end }}

--- a/monitoring/stack/docker-compose.yml
+++ b/monitoring/stack/docker-compose.yml
@@ -31,11 +31,46 @@ services:
       - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     deploy:
       resources:
         limits:
           memory: 192m
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    container_name: houme-alertmanager
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    ports:
+      # 외부 노출 금지 — 로컬 바인딩만
+      - "127.0.0.1:9093:9093"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./alertmanager/templates:/etc/alertmanager/templates:ro
+      - ./alertmanager/secrets:/etc/alertmanager/secrets:ro   # 실제 웹훅은 서버에만 배치
+      - alertmanager_data:/alertmanager
+    deploy:
+      resources:
+        limits:
+          memory: 64m
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: houme-node-exporter
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    deploy:
+      resources:
+        limits:
+          memory: 64m
 
   grafana:
     image: grafana/grafana:11.1.4
@@ -64,3 +99,4 @@ volumes:
   loki_data:
   prometheus_data:
   grafana_data:
+  alertmanager_data:

--- a/monitoring/stack/prometheus.yml
+++ b/monitoring/stack/prometheus.yml
@@ -3,6 +3,16 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# 룰 발화 시 Alertmanager 로 전달 (같은 compose 네트워크의 서비스명)
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+# 알림 룰 파일 (rules/ 디렉토리 전체)
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   - job_name: houme-prod
     metrics_path: /actuator/prometheus
@@ -19,3 +29,10 @@ scrape_configs:
       - targets: ["10.0.1.217:8080"]
         labels:
           env: dev
+
+  - job_name: node-exporter
+    static_configs:
+      # 같은 compose 네트워크의 node-exporter (stack 이 도는 호스트 = prod EC2 자원 지표)
+      - targets: ["node-exporter:9100"]
+        labels:
+          env: prod

--- a/monitoring/stack/rules/houme-alerts.yml
+++ b/monitoring/stack/rules/houme-alerts.yml
@@ -1,0 +1,56 @@
+# HOUME 인프라 운영 알림 룰 — 발화 시 Alertmanager → Discord
+groups:
+  - name: houme-operational-alerts
+    rules:
+      # 앱 다운: job 의 모든 인스턴스가 수집 불가일 때만 (blue/green standby 오탐 방지)
+      - alert: HoumeAppDown
+        expr: sum by (job) (up{job=~"houme-(prod|dev)"}) < 1
+        for: 2m
+        labels:
+          severity: critical
+          service: houme-api
+        annotations:
+          summary: "HOUME {{ $labels.job }} 전체 다운"
+          description: "{{ $labels.job }}의 모든 인스턴스가 2분 이상 /actuator/prometheus 수집 불가 (서버 다운 의심)."
+
+      # JVM Heap 포화: 인스턴스 단위 (standby 는 metric 없어 자동 제외)
+      - alert: HoumeHighJvmHeap
+        expr: |
+          sum by (job, instance) (jvm_memory_used_bytes{job=~"houme-(prod|dev)", area="heap"})
+          /
+          sum by (job, instance) (jvm_memory_max_bytes{job=~"houme-(prod|dev)", area="heap"})
+          > 0.8
+        for: 3m
+        labels:
+          severity: warning
+          service: houme-api
+        annotations:
+          summary: "JVM Heap 사용률 높음 ({{ $labels.job }} {{ $labels.instance }})"
+          description: "JVM Heap 사용률이 3분 이상 80%를 초과했습니다."
+
+      # 호스트 CPU (node-exporter 필요)
+      - alert: HighHostCpuUsage
+        expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) > 0.8
+        for: 5m
+        labels:
+          severity: warning
+          service: host
+        annotations:
+          summary: "EC2 CPU 사용률 높음"
+          description: "호스트 CPU 사용률이 5분 이상 80%를 초과했습니다."
+
+      # 호스트 루트 디스크 (node-exporter 필요)
+      - alert: HighHostDiskUsage
+        expr: |
+          1 - (
+            node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}
+            /
+            node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}
+          ) > 0.85
+        for: 5m
+        labels:
+          severity: warning
+          service: host
+        annotations:
+          summary: "EC2 Disk 사용률 높음"
+          description: "루트 디스크 사용률이 5분 이상 85%를 초과했습니다."


### PR DESCRIPTION
## 📣 Related Issue

- close #607

## 📝 Summary

모니터링 스택에 **Alertmanager + alert 룰 + node-exporter**를 추가해, 서버 다운/자원 포화 같은 인프라 장애를 Discord로 자동 알림받습니다. 앱 5xx 예외 알림(`ErrorAlertNotifier`)이 못 잡는 '조용한 장애'(서버 다운, 디스크 풀, OOM 직전)를 커버합니다. 

**흐름**: Prometheus(룰 평가) → Alertmanager(라우팅) → Discord 웹훅

**추가/수정** (모두 `monitoring/stack/`)
| 파일 | 내용 |
|---|---|
| `prometheus.yml` | `alerting`(alertmanager:9093) + `rule_files` + node-exporter 잡 |
| `rules/houme-alerts.yml` | 앱다운·JVM Heap·CPU·디스크 4종 룰 |
| `alertmanager/alertmanager.yml` | Discord receiver (native `discord_configs`) |
| `alertmanager/templates/discord.tmpl` | 메시지 포맷 |
| `docker-compose.yml` | alertmanager(9093 localhost) + node-exporter |
| `alertmanager/secrets/{.gitignore,.example}` | 웹훅 시크릿 분리 |
| `README.md` | 배포/웹훅 배치 안내 |

**설계 포인트**
- blue/green standby 오탐 방지: 앱다운 룰은 `sum by(job)(up) < 1` (모든 인스턴스 다운일 때만).
- Alertmanager 9093은 `127.0.0.1` 바인딩 (외부 노출 금지).
- ✅ promtool(룰 4개) / amtool(config) 검증 통과.

## 🙏 Question & PR point

- ⚠️ **웹훅 URL은 코드에 커밋하지 않았습니다.** Alertmanager가 설정에서 env를 못 읽어서 `webhook_url_file`(시크릿 파일) 방식을 씁니다. 실제 값은 배포 시 서버 `alertmanager/secrets/discord_webhook_url`에 배치 예정(SSM). 파일 없으면 alertmanager 기동 실패하니 스택 기동 전 배치 필요.
- node-exporter는 stack이 도는 **prod 호스트** 기준입니다. dev 호스트 CPU/디스크가 필요하면 dev EC2에도 node-exporter 추가(후속).

## 📬 Postman

- 해당 없음 (인프라 설정). Alertmanager API 발화 테스트 명령은 README에 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 운영 환경 중앙 모니터링 스택에 Alertmanager와 Node Exporter를 추가했습니다.
  * 애플리케이션 장애, JVM 메모리, 호스트 CPU·디스크 사용량을 감지하는 알림을 제공합니다.
  * 알림을 Discord로 전달하고 상태와 주요 정보를 보기 쉽게 표시합니다.

* **문서**
  * 모니터링 스택 설치, 운영, 알림 테스트 및 시크릿 관리 절차를 문서화했습니다.
  * 개발 환경 지표 수집을 위한 설정 방법을 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->