### PR TITLE
[FIX] #609 furniture_tags (furniture,tag) 유니크 제약 + 관리자 등록 중복 방지

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/model/entity/FurnitureTag.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/model/entity/FurnitureTag.java
@@ -7,7 +7,13 @@ import or.sopt.houme.domain.house.model.taste.entity.Tag;
 
 @Entity
 @Getter
-@Table(name = "furniture_tags")
+@Table(
+        name = "furniture_tags",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_furniture_tags_furniture_id_tag_id",
+                columnNames = {"furniture_id", "tag_id"}
+        )
+)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
@@ -85,6 +85,11 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
         Furniture byFurnitureNameKr = furnitureRepository.findByFurnitureNameKr(dto.furnitureNameKr())
                 .orElseThrow(()-> new GeneralException(ErrorCode.NOT_FOUND_FURNITURE));;
 
+        // (furniture, tag) 유니크 제약이 있으므로, 중복 등록은 raw DB 예외 대신 명확한 409 로 사전 차단한다
+        if (furnitureTagRepository.findByFurnitureAndTag(byFurnitureNameKr, byIdTag).isPresent()) {
+            throw new GeneralException(ErrorCode.ALREADY_EXIST_FURNITURE_TAG);
+        }
+
         S3PresignedUrlResponseDTO presignedUrl;
 
         try {

--- a/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -153,6 +153,7 @@ public enum ErrorCode {
      * 409 CONFLICT
      */
     CREDIT_LOCK_FAILED(HttpStatus.CONFLICT, 40900, "다른 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
+    ALREADY_EXIST_FURNITURE_TAG(HttpStatus.CONFLICT, 40901, "이미 해당 가구와 태그 조합의 스타일 태그가 존재합니다."),
 
     /**
      * 429 Too_Many_Requests

--- a/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImplTest.java
@@ -162,6 +162,28 @@ class AdminFurnitureServiceImplTest {
         assertEquals(ErrorCode.NOT_FOUND_FURNITURE, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("registerFurniturePrompt()는 이미 존재하는 (가구,태그) 조합이면 저장 없이 ALREADY_EXIST_FURNITURE_TAG 를 던진다")
+    void registerFurniturePrompt_duplicate() {
+        // given
+        AdminFurniturePromptRequestDTO requestDTO = new AdminFurniturePromptRequestDTO(
+                "테스트 가구", "테스트 프롬프트", 1L, "키워드", 0, "jpg", "orig");
+        Tag tag = Tag.builder().id(1L).build();
+        Furniture furniture = Furniture.builder().furnitureNameKr("테스트 가구").build();
+
+        when(tagRepository.findById(1L)).thenReturn(Optional.of(tag));
+        when(furnitureRepository.findByFurnitureNameKr("테스트 가구")).thenReturn(Optional.of(furniture));
+        when(furnitureTagRepository.findByFurnitureAndTag(furniture, tag))
+                .thenReturn(Optional.of(FurnitureTag.builder().id(1L).build()));
+
+        // when & then
+        GeneralException exception = assertThrows(GeneralException.class, () -> {
+            adminFurnitureService.registerFurniturePrompt(requestDTO, "image/jpeg");
+        });
+        assertEquals(ErrorCode.ALREADY_EXIST_FURNITURE_TAG, exception.getErrorCode());
+        verify(furnitureTagRepository, never()).save(any(FurnitureTag.class));
+    }
+
 
     @Test
     @DisplayName("getFurniture()는 모든 가구 정보를 성공적으로 조회한다")


### PR DESCRIPTION
## 📣 Related Issue

- close #609

## 📝 Summary

중복 `furniture_tag`로 인한 `IncorrectResultSizeDataAccessException`(큐레이션 상품 조회 500) **재발 방지** 코드입니다. 중복 데이터 자체는 이미 prod·dev DB에서 안전 병합(손실 0)했고, DB에 유니크 제약도 적용 완료했습니다. 본 PR은 코드/스키마 일관성 + 애플리케이션 레벨 방지입니다.

**변경**
- `FurnitureTag` 엔티티 `@Table`에 `uniqueConstraints (furniture_id, tag_id)` 반영
- `AdminFurnitureServiceImpl.registerFurniturePrompt`: 저장 전 `findByFurnitureAndTag` 중복 사전 체크 → `ALREADY_EXIST_FURNITURE_TAG`(409) 반환
- `ErrorCode.ALREADY_EXIST_FURNITURE_TAG` 추가
- 중복 등록 단위 테스트 추가

**왜 안전한가**
- `furniture_tags`에 INSERT하는 유일한 코드 경로는 관리자 등록 하나뿐(확인 완료). 이제 중복 시 raw `DataIntegrityViolationException`(+디스코드 노이즈) 대신 명확한 409로 사전 차단.
- 유니크 제약이 생겨 `findByFurnitureAndTag`는 구조적으로 2건 반환 불가 → 장애 재발 차단.

## 🙏 Question & PR point

- ⚠️ **DB 제약은 이미 prod·dev 양쪽에 적용됨** (`ALTER TABLE ... ADD CONSTRAINT uk_furniture_tags_furniture_id_tag_id UNIQUE (furniture_id, tag_id)`). 두 환경 모두 중복 정리 후 적용해서, ddl-auto=update 배포 시 기존 제약을 재생성하지 않아 충돌 없음.
- 엔티티 `@UniqueConstraint`는 DB와 일치시키는 문서화/일관성 목적입니다.

## 📬 Postman

- 해당 없음 (관리자 등록 중복 시 409 응답으로 변경). `AdminFurnitureServiceImplTest`에 중복 케이스 테스트 추가, 컴파일·테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 크레딧 발급, 차감, 예약·확정·복구 및 잔액 조회 흐름을 개선했습니다.
  * 이미지 생성 중 크레딧을 안전하게 예약하고, 성공·실패에 따라 확정 또는 복구합니다.
  * 중복된 가구·태그 조합 등록 시 명확한 충돌 오류를 제공합니다.

* **문서**
  * 헥사고날 구조와 크레딧 처리 흐름에 대한 가이드를 추가했습니다.

* **버그 수정**
  * 크레딧 동시 처리와 중복 태그 등록 오류를 보다 안정적으로 처리합니다.

* **테스트**
  * 크레딧 API, 잔액 조회, 이미지 생성 및 아키텍처 규칙 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->