### PR TITLE
[CHORE] #613 큐레이션 필터 메타데이터 캐싱 적용

### DIFF
--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -32,6 +32,7 @@ import or.sopt.houme.global.api.handler.FurnitureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +61,7 @@ public class CurationProductServiceImpl implements CurationProductService {
     private final JjymRepository jjymRepository;
 
     @Override
+    @Cacheable(value = "curationFilterMetadataCache")
     public CurationProductFilterResponse getFilterMetadata() {
         return new CurationProductFilterResponse(
                 getFurnitureTypeFilters(),

--- a/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -59,6 +59,7 @@ public class CurationProductServiceImpl implements CurationProductService {
     private final CurationRawProductColorRepository curationRawProductColorRepository;
     private final RecommendFurnitureRepository recommendFurnitureRepository;
     private final JjymRepository jjymRepository;
+    private final FurnitureMasterCacheService furnitureMasterCacheService;
 
     @Override
     @Cacheable(value = "curationFilterMetadataCache")
@@ -431,8 +432,8 @@ public class CurationProductServiceImpl implements CurationProductService {
     }
 
     private List<FurnitureTypeFilterResponse> getFurnitureTypeFilters() {
-        List<FurnitureType> types = furnitureTypeRepository.findAll();
-        List<Furniture> furnitures = furnitureRepository.findAll();
+        List<FurnitureType> types = furnitureMasterCacheService.getAllFurnitureTypes();
+        List<Furniture> furnitures = furnitureMasterCacheService.getAllFurnitures();
 
         // [pbem22, 2026-05-28, #548] DB 실제 등록값 기준으로 고정 음수 ID → findFurniture() 전환
         return List.of(
@@ -456,7 +457,7 @@ public class CurationProductServiceImpl implements CurationProductService {
     private EtcResolution resolveEtc(List<Long> rawTypeIds) {
         if (rawTypeIds == null || rawTypeIds.contains(0L)) return new EtcResolution(null, null);
 
-        List<FurnitureType> allTypes = furnitureTypeRepository.findAll();
+        List<FurnitureType> allTypes = furnitureMasterCacheService.getAllFurnitureTypes();
         Long etcTypeId = allTypes.stream()
                 .filter(t -> ETC_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
                 .map(FurnitureType::getId)
@@ -468,7 +469,7 @@ public class CurationProductServiceImpl implements CurationProductService {
                 .map(FurnitureType::getId)
                 .findFirst().orElse(null);
 
-        List<Furniture> allFurnitures = furnitureRepository.findAll();
+        List<Furniture> allFurnitures = furnitureMasterCacheService.getAllFurnitures();
         List<Long> excludedFurnitureIds = allFurnitures.stream()
                 .filter(f -> f.getFurnitureNameEng() != null &&
                         INDIVIDUAL_FILTER_FURNITURE_NAMEENGS.contains(f.getFurnitureNameEng().toUpperCase()))

--- a/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheService.java
+++ b/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheService.java
@@ -1,0 +1,31 @@
+package or.sopt.houme.domain.furniture.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.domain.furniture.model.entity.Furniture;
+import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
+import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
+import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FurnitureMasterCacheService {
+
+    private final FurnitureTypeRepository furnitureTypeRepository;
+    private final FurnitureRepository furnitureRepository;
+
+    @Cacheable(value = "allFurnitureTypesCache")
+    public List<FurnitureType> getAllFurnitureTypes() {
+        return furnitureTypeRepository.findAll();
+    }
+
+    @Cacheable(value = "allFurnituresCache")
+    public List<Furniture> getAllFurnitures() {
+        return furnitureRepository.findAll();
+    }
+}

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
@@ -19,6 +19,7 @@ import or.sopt.houme.global.api.GeneralException;
 import or.sopt.houme.global.api.handler.AdminException;
 import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
 import or.sopt.houme.global.util.S3PresignedUtil;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -345,6 +346,7 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 등록 메서드
      */
     @Override
+    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
     public void registerFurnitureType(AdminFurnitureTypeRequest request) {
 
         // 한글명이 이미 있는지 확인
@@ -370,6 +372,7 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 삭제 메서드
      */
     @Override
+    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
     public void deleteFurnitureType(long furnitureTypeId) {
 
         FurnitureType type = furnitureTypeRepository.findById(furnitureTypeId)
@@ -387,6 +390,7 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 수정 메서드
      */
     @Override
+    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
     public void updateFurnitureType(AdminUpdateFurnitureTypeRequest request) {
 
         FurnitureType furnitureType = furnitureTypeRepository.findById(request.id())

--- a/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
+++ b/src/main/java/or/sopt/houme/domain/user/service/admin/AdminFurnitureServiceImpl.java
@@ -20,6 +20,7 @@ import or.sopt.houme.global.api.handler.AdminException;
 import or.sopt.houme.global.dto.S3PresignedUrlResponseDTO;
 import or.sopt.houme.global.util.S3PresignedUtil;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +47,7 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * @throws DataIntegrityViolationException flush 시점에 데이터가 중복되면 예외 발생
      * */
     @Override
+    @CacheEvict(value = "allFurnituresCache", allEntries = true)
     public void registerFurniture(AdminFurnitureRequestDTO dto) {
 
         FurnitureType furnitureType;
@@ -286,6 +288,7 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * @throws GeneralException DB 단에서 가구의 매핑 데이터로 인해서 데이터를 삭제 할 수 없는 경우 예외 발생
      * */
     @Override
+    @CacheEvict(value = "allFurnituresCache", allEntries = true)
     public void deleteFurniture(AdminFurnitureDeleteDTO dto){
 
         Furniture byFurnitureNameKr = furnitureRepository.findByFurnitureNameKr(dto.furnitureNameKr())
@@ -346,7 +349,10 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 등록 메서드
      */
     @Override
-    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "curationFilterMetadataCache", allEntries = true),
+            @CacheEvict(value = "allFurnitureTypesCache", allEntries = true)
+    })
     public void registerFurnitureType(AdminFurnitureTypeRequest request) {
 
         // 한글명이 이미 있는지 확인
@@ -372,7 +378,10 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 삭제 메서드
      */
     @Override
-    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "curationFilterMetadataCache", allEntries = true),
+            @CacheEvict(value = "allFurnitureTypesCache", allEntries = true)
+    })
     public void deleteFurnitureType(long furnitureTypeId) {
 
         FurnitureType type = furnitureTypeRepository.findById(furnitureTypeId)
@@ -390,7 +399,10 @@ public class AdminFurnitureServiceImpl implements AdminFurnitureService {
      * FurnitureType 수정 메서드
      */
     @Override
-    @CacheEvict(value = "curationFilterMetadataCache", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "curationFilterMetadataCache", allEntries = true),
+            @CacheEvict(value = "allFurnitureTypesCache", allEntries = true)
+    })
     public void updateFurnitureType(AdminUpdateFurnitureTypeRequest request) {
 
         FurnitureType furnitureType = furnitureTypeRepository.findById(request.id())

--- a/src/main/java/or/sopt/houme/global/config/RedisConfig.java
+++ b/src/main/java/or/sopt/houme/global/config/RedisConfig.java
@@ -55,6 +55,7 @@ public class RedisConfig {
                 .RedisCacheManagerBuilder
                 .fromConnectionFactory(connectionFactory)
                 .cacheDefaults(cacheConfig)
+                .transactionAware()
                 .build();
     }
 }

--- a/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -17,6 +17,7 @@ import or.sopt.houme.domain.furniture.repository.CurationRawProductRepositoryCus
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
 import or.sopt.houme.domain.furniture.repository.JjymRepository;
+import or.sopt.houme.domain.furniture.service.FurnitureMasterCacheService;
 import or.sopt.houme.domain.furniture.repository.RecommendFurnitureRepository;
 import or.sopt.houme.domain.user.model.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -64,13 +65,16 @@ class CurationProductServiceImplTest {
     @Mock
     private JjymRepository jjymRepository;
 
+    @Mock
+    private FurnitureMasterCacheService furnitureMasterCacheService;
+
     @Test
     @DisplayName("getFilterMetadata()는 DB 데이터와 정적 필터를 조합하여 반환한다")
     void getFilterMetadata() {
         // given
         FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
-        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
-        given(furnitureRepository.findAll()).willReturn(List.of());
+        given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
+        given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
         // when
         CurationProductFilterResponse response = curationProductService.getFilterMetadata();
@@ -93,8 +97,8 @@ class CurationProductServiceImplTest {
         Integer size = 20;
 
         FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
-        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
-        given(furnitureRepository.findAll()).willReturn(List.of());
+        given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
+        given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
         CurationRawProduct product = CurationRawProduct.builder()
                 .id(99L)
@@ -173,8 +177,8 @@ class CurationProductServiceImplTest {
         Integer size = 20;
 
         FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
-        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
-        given(furnitureRepository.findAll()).willReturn(List.of());
+        given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
+        given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
         Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
         CurationRawProduct recommended = CurationRawProduct.builder()
@@ -233,8 +237,8 @@ class CurationProductServiceImplTest {
         Integer size = 20;
 
         FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
-        given(furnitureTypeRepository.findAll()).willReturn(List.of(bedType));
-        given(furnitureRepository.findAll()).willReturn(List.of());
+        given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
+        given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
         Slice<CurationRawProduct> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, size), false);
         CurationRawProduct recommended = CurationRawProduct.builder()


### PR DESCRIPTION
## 📣 Related Issue
- close #613

## 📝 Summary
- `CurationProductServiceImpl.getFilterMetadata()`에 `@Cacheable("curationFilterMetadataCache")` 적용
  - 호출마다 발생하던 `furnitureTypeRepository.findAll()` + `furnitureRepository.findAll()` DB 조회를 Redis 캐시로 대체
- `AdminFurnitureServiceImpl`의 FurnitureType 변경 3개 메서드(`registerFurnitureType`, `deleteFurnitureType`, `updateFurnitureType`)에 `@CacheEvict(allEntries = true)` 적용
  - 가구 유형 변경 시 캐시 즉시 무효화하여 정합성 보장

## 🙏 Question & PR point
- 필터 선택지(가구 유형/가격대/색상 목록)는 FurnitureType 변경 시에만 바뀌는 정적 데이터이므로 `@CacheEvict` 타이밍을 FurnitureType 조작 메서드로만 한정했습니다
- `@EnableCaching`, Redis 연결은 기존 설정 그대로 활용

## 📬 Postman
- `GET /api/v1/curations/products/filters` 첫 호출 후 Redis에 캐시 적재 확인
- `POST /api/v1/admin/furniture/types` 등 FurnitureType 변경 후 캐시 무효화 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 큐레이션 필터 메타데이터를 캐싱해 반복 조회 응답 속도를 개선했습니다.
  * 가구 타입/가구 목록을 캐시로 제공해 불필요한 반복 조회를 줄였습니다.
* **캐시 동기화**
  * 가구 등록/삭제 및 가구 타입 등록/수정/삭제 시 관련 캐시 무효화 범위를 확대해 최신 데이터가 반영되도록 했습니다.
* **인프라/설정**
  * Redis 캐시 매니저를 트랜잭션 인지 방식으로 조정했습니다.
* **테스트**
  * 캐시 기반 조회 흐름에 맞춰 단위 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->