### PR TITLE
[FIX] #618 가구 마스터 캐시에 엔티티 대신 읽기 모델 저장 — 필터 API 500 해결

### DIFF
--- a/houme-api/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
+++ b/houme-api/src/test/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImplTest.java
@@ -19,6 +19,7 @@ import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
 import or.sopt.houme.furniture.domain.port.out.JjymRepositoryPort;
 import or.sopt.houme.furniture.domain.port.out.RecommendFurniturePort;
 import or.sopt.houme.domain.furniture.service.FurnitureMasterCacheService;
+import or.sopt.houme.domain.furniture.service.FurnitureTypeCacheView;
 import or.sopt.houme.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,7 @@ class CurationProductServiceImplTest {
     @DisplayName("getFilterMetadata()는 DB 데이터와 정적 필터를 조합하여 반환한다")
     void getFilterMetadata() {
         // given
-        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        FurnitureTypeCacheView bedType = new FurnitureTypeCacheView(1L, "BED");
         given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
         given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
@@ -96,7 +97,7 @@ class CurationProductServiceImplTest {
         Long cursor = 100L;
         Integer size = 20;
 
-        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        FurnitureTypeCacheView bedType = new FurnitureTypeCacheView(1L, "BED");
         given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
         given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
@@ -176,7 +177,7 @@ class CurationProductServiceImplTest {
         List<String> priceRangeIds = List.of("P1");
         Integer size = 20;
 
-        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        FurnitureTypeCacheView bedType = new FurnitureTypeCacheView(1L, "BED");
         given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
         given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 
@@ -236,7 +237,7 @@ class CurationProductServiceImplTest {
         List<String> priceRangeIds = List.of("P1");
         Integer size = 20;
 
-        FurnitureType bedType = FurnitureType.builder().id(1L).nameKr("침대").nameEng("BED").build();
+        FurnitureTypeCacheView bedType = new FurnitureTypeCacheView(1L, "BED");
         given(furnitureMasterCacheService.getAllFurnitureTypes()).willReturn(List.of(bedType));
         given(furnitureMasterCacheService.getAllFurnitures()).willReturn(List.of());
 

--- a/houme-infra/build.gradle
+++ b/houme-infra/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
 def querydslDir = 'src/main/generated'
 
 tasks.withType(JavaCompile) {

--- a/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
+++ b/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/CurationProductServiceImpl.java
@@ -432,8 +432,8 @@ public class CurationProductServiceImpl implements CurationProductService {
     }
 
     private List<FurnitureTypeFilterResponse> getFurnitureTypeFilters() {
-        List<FurnitureType> types = furnitureMasterCacheService.getAllFurnitureTypes();
-        List<FurnitureJpaEntity> furnitures = furnitureMasterCacheService.getAllFurnitures();
+        List<FurnitureTypeCacheView> types = furnitureMasterCacheService.getAllFurnitureTypes();
+        List<FurnitureCacheView> furnitures = furnitureMasterCacheService.getAllFurnitures();
 
         // [pbem22, 2026-05-28, #548] DB 실제 등록값 기준으로 고정 음수 ID → findFurniture() 전환
         return List.of(
@@ -457,27 +457,27 @@ public class CurationProductServiceImpl implements CurationProductService {
     private EtcResolution resolveEtc(List<Long> rawTypeIds) {
         if (rawTypeIds == null || rawTypeIds.contains(0L)) return new EtcResolution(null, null);
 
-        List<FurnitureType> allTypes = furnitureMasterCacheService.getAllFurnitureTypes();
+        List<FurnitureTypeCacheView> allTypes = furnitureMasterCacheService.getAllFurnitureTypes();
         Long etcTypeId = allTypes.stream()
-                .filter(t -> ETC_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
-                .map(FurnitureType::getId)
+                .filter(t -> ETC_TYPE_NAMEENG.equalsIgnoreCase(t.nameEng()))
+                .map(FurnitureTypeCacheView::id)
                 .findFirst().orElse(null);
         if (etcTypeId == null || !rawTypeIds.contains(etcTypeId)) return new EtcResolution(etcTypeId, null);
 
         Long selectiveTypeId = allTypes.stream()
-                .filter(t -> SELECTIVE_TYPE_NAMEENG.equalsIgnoreCase(t.getNameEng()))
-                .map(FurnitureType::getId)
+                .filter(t -> SELECTIVE_TYPE_NAMEENG.equalsIgnoreCase(t.nameEng()))
+                .map(FurnitureTypeCacheView::id)
                 .findFirst().orElse(null);
 
-        List<FurnitureJpaEntity> allFurnitures = furnitureMasterCacheService.getAllFurnitures();
+        List<FurnitureCacheView> allFurnitures = furnitureMasterCacheService.getAllFurnitures();
         List<Long> excludedFurnitureIds = allFurnitures.stream()
-                .filter(f -> f.getFurnitureNameEng() != null &&
-                        INDIVIDUAL_FILTER_FURNITURE_NAMEENGS.contains(f.getFurnitureNameEng().toUpperCase()))
-                .map(FurnitureJpaEntity::getId)
+                .filter(f -> f.furnitureNameEng() != null &&
+                        INDIVIDUAL_FILTER_FURNITURE_NAMEENGS.contains(f.furnitureNameEng().toUpperCase()))
+                .map(FurnitureCacheView::id)
                 .toList();
         Long etcDirectFurnitureId = allFurnitures.stream()
-                .filter(f -> ETC_TYPE_NAMEENG.equalsIgnoreCase(f.getFurnitureNameEng()))
-                .map(FurnitureJpaEntity::getId)
+                .filter(f -> ETC_TYPE_NAMEENG.equalsIgnoreCase(f.furnitureNameEng()))
+                .map(FurnitureCacheView::id)
                 .findFirst().orElse(null);
 
         List<Long> productIds = curationRawProductRepository.findEtcProductIds(
@@ -485,19 +485,19 @@ public class CurationProductServiceImpl implements CurationProductService {
         return new EtcResolution(etcTypeId, productIds);
     }
 
-    private FurnitureTypeFilterResponse findType(List<FurnitureType> types, String nameEng, String labelKr, Long fallbackId) {
+    private FurnitureTypeFilterResponse findType(List<FurnitureTypeCacheView> types, String nameEng, String labelKr, Long fallbackId) {
         return types.stream()
-                .filter(t -> t.getNameEng() != null && t.getNameEng().trim().equalsIgnoreCase(nameEng))
+                .filter(t -> t.nameEng() != null && t.nameEng().trim().equalsIgnoreCase(nameEng))
                 .findFirst()
-                .map(t -> new FurnitureTypeFilterResponse(t.getId(), labelKr, t.getNameEng().trim()))
+                .map(t -> new FurnitureTypeFilterResponse(t.id(), labelKr, t.nameEng().trim()))
                 .orElse(new FurnitureTypeFilterResponse(fallbackId, labelKr, nameEng));
     }
 
-    private FurnitureTypeFilterResponse findFurniture(List<FurnitureJpaEntity> furnitures, String nameEng, String labelKr, Long fallbackId) {
+    private FurnitureTypeFilterResponse findFurniture(List<FurnitureCacheView> furnitures, String nameEng, String labelKr, Long fallbackId) {
         return furnitures.stream()
-                .filter(f -> f.getFurnitureNameEng() != null && f.getFurnitureNameEng().trim().equalsIgnoreCase(nameEng))
+                .filter(f -> f.furnitureNameEng() != null && f.furnitureNameEng().trim().equalsIgnoreCase(nameEng))
                 .findFirst()
-                .map(f -> new FurnitureTypeFilterResponse(f.getId() + FURNITURE_ID_OFFSET, labelKr, f.getFurnitureNameEng().trim()))
+                .map(f -> new FurnitureTypeFilterResponse(f.id() + FURNITURE_ID_OFFSET, labelKr, f.furnitureNameEng().trim()))
                 .orElse(new FurnitureTypeFilterResponse(fallbackId, labelKr, nameEng));
     }
 

--- a/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureCacheView.java
+++ b/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureCacheView.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.domain.furniture.service;
+
+/**
+ * 가구 마스터 캐시 전용 읽기 모델.
+ *
+ * JPA 엔티티({@code FurnitureJpaEntity})를 Redis에 그대로 직렬화하면
+ * 가구 ↔ 가구태그 양방향 참조 때문에 무한 재귀로 저장이 항상 실패한다(#618).
+ * 캐시 소비처가 실제로 쓰는 필드(id, nameEng)만 담아 순환이 캐시 경계를 넘지 않게 한다.
+ */
+public record FurnitureCacheView(Long id, String furnitureNameEng) {
+}

--- a/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheService.java
+++ b/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheService.java
@@ -1,8 +1,6 @@
 package or.sopt.houme.domain.furniture.service;
 
 import lombok.RequiredArgsConstructor;
-import or.sopt.houme.furniture.infra.persistence.FurnitureJpaEntity;
-import or.sopt.houme.domain.furniture.model.entity.FurnitureType;
 import or.sopt.houme.domain.furniture.repository.FurnitureRepository;
 import or.sopt.houme.domain.furniture.repository.FurnitureTypeRepository;
 import org.springframework.cache.annotation.Cacheable;
@@ -10,7 +8,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+/**
+ * 가구/가구타입 마스터 데이터 캐시.
+ *
+ * 엔티티를 그대로 캐시에 넣지 않고 읽기 모델(*CacheView)로 변환해 저장한다.
+ * 엔티티를 넣으면 가구 ↔ 가구태그 순환 참조로 Redis JSON 직렬화가 무한 재귀에 빠지고(#618),
+ * 캐시 값도 사용하지 않는 필드·지연 로딩 컬렉션까지 끌고 들어가 불필요하게 커진다.
+ *
+ * 반환 리스트는 ArrayList여야 한다 — Stream.toList()의 ImmutableCollections$ListN은
+ * GenericJackson2JsonRedisSerializer가 역직렬화(캐시 히트)할 때 인스턴스화하지 못한다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,12 +29,16 @@ public class FurnitureMasterCacheService {
     private final FurnitureRepository furnitureRepository;
 
     @Cacheable(value = "allFurnitureTypesCache")
-    public List<FurnitureType> getAllFurnitureTypes() {
-        return furnitureTypeRepository.findAll();
+    public List<FurnitureTypeCacheView> getAllFurnitureTypes() {
+        return furnitureTypeRepository.findAll().stream()
+                .map(type -> new FurnitureTypeCacheView(type.getId(), type.getNameEng()))
+                .collect(Collectors.toList());
     }
 
     @Cacheable(value = "allFurnituresCache")
-    public List<FurnitureJpaEntity> getAllFurnitures() {
-        return furnitureRepository.findAll();
+    public List<FurnitureCacheView> getAllFurnitures() {
+        return furnitureRepository.findAll().stream()
+                .map(furniture -> new FurnitureCacheView(furniture.getId(), furniture.getFurnitureNameEng()))
+                .collect(Collectors.toList());
     }
 }

--- a/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureTypeCacheView.java
+++ b/houme-infra/src/main/java/or/sopt/houme/domain/furniture/service/FurnitureTypeCacheView.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.domain.furniture.service;
+
+/**
+ * 가구 타입 마스터 캐시 전용 읽기 모델.
+ *
+ * {@code FurnitureType}은 다른 엔티티를 참조하지 않아 직렬화는 성공하지만,
+ * 엔티티가 캐시 경계를 넘는 패턴 자체를 없애기 위해 함께 읽기 모델로 전환한다(#618).
+ */
+public record FurnitureTypeCacheView(Long id, String nameEng) {
+}

--- a/houme-infra/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheSerializationTest.java
+++ b/houme-infra/src/test/java/or/sopt/houme/domain/furniture/service/FurnitureMasterCacheSerializationTest.java
@@ -1,0 +1,63 @@
+package or.sopt.houme.domain.furniture.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #618 회귀 테스트 — 캐시 값이 RedisConfig와 동일한 직렬화기
+ * ({@link GenericJackson2JsonRedisSerializer})로 저장·복원 가능한지 검증한다.
+ *
+ * 기존 테스트는 FurnitureMasterCacheService를 mock으로 대체해 실제 직렬화 경로를
+ * 한 번도 타지 않았고, 엔티티(순환 참조)를 캐시에 넣는 버그가 CI를 통과했다.
+ * 이 테스트는 캐시에 들어가는 실제 타입이 직렬화 왕복(round-trip)을 통과함을 보장한다.
+ */
+class FurnitureMasterCacheSerializationTest {
+
+    private final GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+
+    @Test
+    @DisplayName("가구 캐시 읽기 모델 리스트는 Redis JSON 직렬화 왕복이 가능하다")
+    void furnitureCacheViewListRoundTrip() {
+        List<FurnitureCacheView> original = Stream.of(
+                new FurnitureCacheView(1L, "OFFICE_DESK"),
+                new FurnitureCacheView(2L, "DINING_TABLE"),
+                new FurnitureCacheView(3L, null) // nameEng이 null인 행도 존재할 수 있다
+        ).collect(Collectors.toList());
+
+        byte[] bytes = serializer.serialize(original);
+        Object restored = serializer.deserialize(bytes);
+
+        assertThat(restored).isInstanceOf(List.class);
+        assertThat(restored).usingRecursiveComparison().isEqualTo(original);
+        // 캐시 히트 시 소비처가 record accessor로 바로 읽을 수 있어야 한다 (LinkedHashMap 강등 금지)
+        FurnitureCacheView first = ((List<FurnitureCacheView>) restored).get(0);
+        assertThat(first.id()).isEqualTo(1L);
+        assertThat(first.furnitureNameEng()).isEqualTo("OFFICE_DESK");
+    }
+
+    @Test
+    @DisplayName("가구 타입 캐시 읽기 모델 리스트는 Redis JSON 직렬화 왕복이 가능하다")
+    void furnitureTypeCacheViewListRoundTrip() {
+        List<FurnitureTypeCacheView> original = new ArrayList<>(List.of(
+                new FurnitureTypeCacheView(1L, "BED"),
+                new FurnitureTypeCacheView(2L, "SOFA"),
+                new FurnitureTypeCacheView(3L, "ETC")
+        ));
+
+        byte[] bytes = serializer.serialize(original);
+        Object restored = serializer.deserialize(bytes);
+
+        assertThat(restored).usingRecursiveComparison().isEqualTo(original);
+        FurnitureTypeCacheView first = ((List<FurnitureTypeCacheView>) restored).get(0);
+        assertThat(first.id()).isEqualTo(1L);
+        assertThat(first.nameEng()).isEqualTo("BED");
+    }
+}


### PR DESCRIPTION
## 무엇이 문제였나요?

dev에서 상품 필터 조회 API가 **매 요청 500**으로 실패하고 있었습니다 (#618).

```
GET /api/v1/curations/products/filters → 500
Could not write JSON: Infinite recursion (StackOverflowError)
(FurnitureJpaEntity["furnitureTags"] → FurnitureTag["furniture"] → ...)
```

#613 캐싱에서 `getAllFurnitures()`가 **JPA 엔티티를 그대로 Redis에 저장**하는데, 가구 ↔ 가구태그가 서로를 참조해서 JSON 변환이 `가구 → 태그 → 가구 → ...`를 끝없이 따라가다 터집니다.

### 왜 "자꾸" 터졌나요? (dev 서버 실측)

터지는 지점이 미묘합니다. `cacheManager`가 `.transactionAware()`라 캐시 저장이 **트랜잭션 커밋 후(afterCommit)** 로 미뤄지는데, 그때 등록 순서대로 실행되다가:

| afterCommit 실행 순서 | 결과 |
| --- | --- |
| 1️⃣ `allFurnitureTypesCache` 저장 | ✅ 성공 (순환 없음 — Redis에 키 존재 확인) |
| 2️⃣ `allFurnituresCache` 저장 | 💥 무한 재귀로 여기서 터짐 (키 없음 확인) |
| 3️⃣ `curationFilterMetadataCache` 저장 | ⛔ 실행 자체가 안 됨 (키 없음 확인) |

응답 전체를 담는 3️⃣이 한 번이라도 저장됐다면 이후 요청은 캐시 히트로 넘어갔겠지만, **2️⃣가 항상 먼저 터지므로 영영 저장되지 않고** 매 요청이 실패를 반복했습니다. 자연 복구가 불가능한 구조였습니다.

## 어떻게 고쳤나요?

**엔티티가 캐시 경계를 넘지 않도록, 캐시 전용 읽기 모델을 도입했습니다.**

소비처(`findFurniture`/`findType`/`resolveEtc`)가 실제로 쓰는 필드는 각각 2개뿐이라, 그것만 담습니다:

```java
public record FurnitureCacheView(Long id, String furnitureNameEng) {}
public record FurnitureTypeCacheView(Long id, String nameEng) {}
```

```java
@Cacheable(value = "allFurnituresCache")
public List<FurnitureCacheView> getAllFurnitures() {
    return furnitureRepository.findAll().stream()
            .map(f -> new FurnitureCacheView(f.getId(), f.getFurnitureNameEng()))
            .collect(Collectors.toList());
}
```

- 순환 참조가 애초에 캐시로 들어갈 수 없고, 직렬화 중 `furnitureTags` 지연 로딩(N+1)도 사라집니다
- 캐시 값이 "엔티티 전체 + 태그 컬렉션"에서 "필드 2개 × 행 수"로 줄어듭니다
- 캐시 이름은 그대로라 `AdminFurnitureServiceImpl`의 `@CacheEvict` 5곳은 손대지 않았습니다

### 디테일 하나: `Collectors.toList()`를 쓴 이유

`Stream.toList()`가 반환하는 `ImmutableCollections$ListN`은 `GenericJackson2JsonRedisSerializer`가 **역직렬화(캐시 히트) 시 인스턴스화하지 못합니다.** 저장은 되는데 읽을 때 터지는 2차 장애를 예방하기 위해 `ArrayList`가 보장되는 `Collectors.toList()`를 사용했습니다.

## 테스트

- **회귀 테스트 신규**: `FurnitureMasterCacheSerializationTest` — RedisConfig와 동일한 실제 직렬화기로 캐시 값의 저장→복원 왕복을 검증합니다. 기존 테스트는 `FurnitureMasterCacheService`를 mock으로 대체해서 이 경로를 한 번도 타지 않았고, 그래서 버그가 CI를 통과했습니다. (houme-infra 모듈 첫 테스트라 `useJUnitPlatform` 설정 포함)
- 기존 `CurationProductServiceImplTest` mock 반환 타입을 읽기 모델로 교체 — 전체 통과 ✅

## 배포 후 확인 (dev)

- [ ] `GET /api/v1/curations/products/filters` → 200
- [ ] `types`에 ETC 포함한 `GET /api/v1/curations/products` → 200
- [ ] redis-cli: `allFurnituresCache`·`curationFilterMetadataCache` 키가 실제로 생기는지 (현재는 요청 직후에도 없음)

## 관련

- Closes #618
- 원인 제공: #613 / #614
- 참고: prod `HoumeHighJvmHeap` 알림은 이 버그와 무관합니다 (prod에는 #613 미배포). 알림 룰 문제는 #619에서 별도 추적합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 가구 타입 및 가구 정보 처리 안정성이 향상되었습니다.
  - 가구 큐레이션의 필터와 추천 결과가 캐시된 정보를 기반으로 더욱 일관되게 제공됩니다.
  - 가구 정보 캐시 저장 및 복원 과정의 호환성이 개선되어 관련 오류 가능성이 줄었습니다.

- **테스트**
  - 가구 정보 캐시의 저장·복원과 큐레이션 필터 동작에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
