### PR TITLE
[FIX] #619 JVM 힙 알림 룰 교체 — G1 톱니파 오탐 제거 + GC 부하·호스트 메모리 알림 신설

### DIFF
--- a/monitoring/stack/rules/houme-alerts.yml
+++ b/monitoring/stack/rules/houme-alerts.yml
@@ -12,34 +12,67 @@ groups:
         annotations:
           summary: "HOUME {{ $labels.job }} 전체 다운"
           description: "{{ $labels.job }}의 모든 인스턴스가 2분 이상 /actuator/prometheus 수집 불가 (서버 다운 의심)."
+          action: "서버·컨테이너 상태와 최근 배포를 확인하고, 필요 시 재기동하세요."
 
-      # JVM Heap 포화: 인스턴스 단위 (standby 는 metric 없어 자동 제외)
-      - alert: HoumeHighJvmHeap
+      # JVM Old Gen 포화: GC 가 끝나도 내려가지 않는 메모리 기준 (#619)
+      # 이전 룰은 Eden 포함 순간값(used/max)이라 G1 의 정상 톱니파(Eden 을 다 채우고 한 번에
+      # 비우는 동작)를 장애로 오인해 48시간 플래핑했다. 누수·포화는 Old Gen 으로 판단한다.
+      - alert: HoumeHighJvmOldGen
         expr: |
-          sum by (job, instance) (jvm_memory_used_bytes{job=~"houme-(prod|dev)", area="heap"})
+          jvm_memory_used_bytes{job=~"houme-(prod|dev)", id="G1 Old Gen"}
           /
-          sum by (job, instance) (jvm_memory_max_bytes{job=~"houme-(prod|dev)", area="heap"})
+          jvm_memory_max_bytes{job=~"houme-(prod|dev)", id="G1 Old Gen"}
           > 0.8
-        for: 3m
+        for: 5m
         labels:
           severity: warning
           service: houme-api
         annotations:
-          summary: "JVM Heap 사용률 높음 ({{ $labels.job }} {{ $labels.instance }})"
-          description: "JVM Heap 사용률이 3분 이상 80%를 초과했습니다."
+          summary: "JVM Old Gen 사용률 높음 ({{ $labels.job }} {{ $labels.instance }})"
+          description: "GC 후에도 잔존하는 Old Gen 사용률이 5분 이상 80%를 초과했습니다 (누수 또는 힙 부족 의심)."
+          action: "Old Gen 추이가 우상향이면 누수(힙덤프 분석), 평평하게 높으면 힙 부족(캐시/트래픽 점검)입니다."
 
-      # 호스트 CPU (node-exporter 필요)
+      # GC 부하: 애플리케이션 스레드가 실제로 GC 에 뺏기는 시간 비율 (#619)
+      # Old Gen 이 낮아도 할당 폭주로 GC 가 과열될 수 있어 별도 감시
+      - alert: HoumeHighGcLoad
+        expr: |
+          sum by (job, instance) (rate(jvm_gc_pause_seconds_sum{job=~"houme-(prod|dev)"}[5m])) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+          service: houme-api
+        annotations:
+          summary: "JVM GC 부하 높음 ({{ $labels.job }} {{ $labels.instance }})"
+          description: "GC pause 가 5분 이상 실행 시간의 10%를 초과했습니다 (할당 폭주 또는 힙 부족)."
+          action: "최근 배포·트래픽 변화를 확인하고, 할당이 많은 엔드포인트(대량 조회/직렬화)를 점검하세요."
+
+      # 호스트 CPU (node-exporter 필요). instance 별로 평가 — prod/dev 호스트가 섞이지 않도록
       - alert: HighHostCpuUsage
-        expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) > 0.8
+        expr: 1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) > 0.8
         for: 5m
         labels:
           severity: warning
           service: host
         annotations:
-          summary: "EC2 CPU 사용률 높음"
-          description: "호스트 CPU 사용률이 5분 이상 80%를 초과했습니다."
+          summary: "EC2 CPU 사용률 높음 ({{ $labels.instance }})"
+          description: "호스트({{ $labels.instance }}) CPU 사용률이 5분 이상 80%를 초과했습니다."
+          action: "top 으로 상위 프로세스를 확인하고 비정상 부하/트래픽 급증을 점검하세요."
 
-      # 호스트 루트 디스크 (node-exporter 필요)
+      # 호스트 메모리 (node-exporter 필요) (#619)
+      # prod EC2(2GB)에 앱+모니터링 스택이 함께 떠 있어 available 이 만성적으로 낮다(~10%).
+      # 10% 기준이면 상시 발화하므로, 실제 위험 구간(5% 미만)만 알린다. 근본 해법은 스택 분리.
+      - alert: HighHostMemoryUsage
+        expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.05
+        for: 10m
+        labels:
+          severity: warning
+          service: host
+        annotations:
+          summary: "EC2 가용 메모리 부족 ({{ $labels.instance }})"
+          description: "호스트({{ $labels.instance }}) 가용 메모리가 10분 이상 5% 미만입니다 (OOM killer/스왑 스래싱 위험)."
+          action: "docker stats 로 컨테이너별 사용량을 확인하고, 불필요 컨테이너 정리 또는 스택 분리를 검토하세요."
+
+      # 호스트 루트 디스크 (node-exporter 필요). node_filesystem_* 는 instance 라벨을 포함 — 호스트별로 평가됨
       - alert: HighHostDiskUsage
         expr: |
           1 - (
@@ -52,5 +85,6 @@ groups:
           severity: warning
           service: host
         annotations:
-          summary: "EC2 Disk 사용률 높음"
-          description: "루트 디스크 사용률이 5분 이상 85%를 초과했습니다."
+          summary: "EC2 Disk 사용률 높음 ({{ $labels.instance }})"
+          description: "호스트({{ $labels.instance }}) 루트 디스크 사용률이 5분 이상 85%를 초과했습니다."
+          action: "Docker image/container log/volume 사용량과 애플리케이션 로그를 정리하세요."


### PR DESCRIPTION
## 무엇이 문제였나요?

`HoumeHighJvmHeap` 알림이 prod에서 **48시간 동안 수십 번 pending↔firing을 반복**했습니다 (#619). 그런데 실측해보면 서버는 멀쩡했습니다:

| 지표 (prod, uptime 12일) | 값 | 판정 |
| --- | --- | --- |
| G1 Old Gen 추이 (48h) | 115~250MB 진동, 항상 베이스라인 복귀 | 누수 아님 ✅ |
| GC pause 비율 | 0.04% | GC 건강 ✅ |

### 원인 — 룰이 G1의 정상 동작을 장애로 오인

기존 룰은 `sum(used) / sum(max)` 인데, G1에서 `jvm_memory_max_bytes`는 **Eden/Survivor가 -1(무제한)** 이라 분모는 사실상 Old Gen max = 전체 힙 512MB뿐입니다. 분자에는 Eden이 포함되고요.

G1은 설계상 **Eden을 힙이 찰 때까지 채웠다가 한 번에 비웁니다.** Old Gen이 200MB일 때 Eden이 210MB만 차도 80%를 넘습니다. 즉 512MB 고정 힙에서는 정상 트래픽만으로 필연적으로 플래핑하는 룰이었습니다.

## 어떻게 바꿨나요?

| | 기준 | 의미 |
| --- | --- | --- |
| ❌ `HoumeHighJvmHeap` (제거) | Eden 포함 순간값 | GC가 곧 비울 메모리까지 세서 오탐 |
| ✅ `HoumeHighJvmOldGen` (신설) | **GC 후에도 남는** Old Gen > 80%, 5m | 누수/힙 부족만 잡음 |
| ✅ `HoumeHighGcLoad` (신설) | GC pause가 실행 시간의 10%+, 5m | Old Gen이 낮아도 할당 폭주로 GC가 과열되는 케이스 |

### 덤: 진짜 위험했던 건 호스트 메모리 (알림이 없었음)

prod EC2(2GB) 실측: **available 184MB, 스왑 1082MB 사용 중.** 앱 + Prometheus + Grafana + Loki + Metabase + Redis가 한 호스트에 다 떠 있는데, 룰셋에는 CPU/디스크만 있고 메모리 알림이 없었습니다. JVM이 스왑에 밀리면 GC pause가 수 초로 튑니다.

→ `HighHostMemoryUsage` 신설: available < 5%, 10분. (10% 기준이면 현재 상태(9.6%)에서 상시 발화라 실위험 구간만 알리도록 5%로 잡았습니다. 근본 해법은 스택 분리 — 별도 논의 필요)

## 서버 반영 (완료)

레포↔서버가 수동 동기화 구조라(모니터링 경로 CI 없음), 플래핑 노이즈를 멈추기 위해 서버 먼저 반영했습니다:

1. ✅ `promtool check rules` 통과 (6 rules found)
2. ✅ 기존 파일 백업 (`/tmp/houme-alerts-backup-20260728.yml`)
3. ✅ 교체 후 `SIGHUP` 리로드 (무중단)
4. ✅ `/api/v1/rules`로 새 룰 6개 로드 확인, 현재 발화 알림 0건

이 PR은 그 서버 상태를 레포(소스 오브 트루스)에 동기화하는 것입니다. **서버에만 있던 기존 개선**(`action:` 어노테이션, CPU 룰의 `avg by (instance)`)도 함께 레포로 가져왔습니다.

## 머지 후 확인

- [ ] 48시간 관찰: `HoumeHighJvmOldGen`/`HoumeHighGcLoad` 오탐 없는지
- [ ] `HighHostMemoryUsage` 발화 시 → 스택 분리/인스턴스 업그레이드 논의 시작

## 관련

- Closes #619
- 참고: dev 필터 API 500은 별개 문제 → #618 / #620



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * JVM Old Gen 사용률 및 GC 부하를 감지하는 운영 알림을 추가했습니다.
  * CPU, 메모리, 디스크 알림에 대상 인스턴스와 대응 방법을 포함했습니다.

* **개선**
  * JVM 힙 알림을 Old Gen 사용률 기반 알림으로 변경했습니다.
  * 호스트별 CPU 사용량을 정확히 평가하도록 조정했습니다.
  * 메모리 부족 및 디스크 정리 필요 상황에 대한 알림 설명을 구체화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
