### PR TITLE
[FEAT] Gemini 키워드 번역기 추가

### DIFF
--- a/houme-api/src/main/resources/application-local.yml
+++ b/houme-api/src/main/resources/application-local.yml
@@ -66,6 +66,7 @@ openai:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
+  compare-api-key: ${GEMINI_COMPARE_API_KEY}
   api-base-url: ${GEMINI_API_BASE_URL:https://generativelanguage.googleapis.com/v1beta}
   image:
     model: gemini-3-pro-image-preview

--- a/houme-api/src/test/resources/application-test.yml
+++ b/houme-api/src/test/resources/application-test.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: false

--- a/houme-api/src/test/resources/application-test.yml
+++ b/houme-api/src/test/resources/application-test.yml
@@ -64,6 +64,7 @@ openai:
 
 gemini:
   api-key: test-gemini-key
+  compare-api-key: test-gemini-compare-key
   api-base-url: http://localhost:65535
   image:
     model: gemini-3-pro-image-preview
@@ -150,6 +151,17 @@ resilience4j:
         waitDurationInOpenState: 10s
         permittedNumberOfCallsInHalfOpenState: 3
         automaticTransitionFromOpenToHalfOpenEnabled: true
+
+ebay:
+  client-id: test-ebay-client-id
+  client-secret: test-ebay-client-secret
+  api-base-url: http://localhost:65535
+  oauth-base-url: http://localhost:65535
+
+compare:
+  pipeline:
+    top-n: 7
+    usd-to-krw-rate: 1350
 
 feign:
   client:

--- a/houme-api/src/test/resources/application-test.yml
+++ b/houme-api/src/test/resources/application-test.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: false

--- a/houme-common/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/houme-common/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -143,6 +143,14 @@ public enum ErrorCode {
     NOT_FOUND_BANNER(HttpStatus.NOT_FOUND, 40426, "배너 객체를 찾을 수 없습니다."),
     NOT_FOUND_STYLE(HttpStatus.NOT_FOUND, 40427, "스타일 객체를 찾을 수 없습니다."),
 
+    // 가격비교 관련
+    COMPARE_JOB_NOT_FOUND(HttpStatus.NOT_FOUND, 40428, "비교 Job을 찾을 수 없습니다."),
+    COMPARE_DUMMY_NOT_ALLOWED_IN_PROD(HttpStatus.FORBIDDEN, 40301, "더미 모드는 프로덕션 환경에서 사용할 수 없습니다."),
+    COMPARE_SCRAPING_NOT_IMPLEMENTED(HttpStatus.BAD_REQUEST, 40033, "URL 스크래핑은 아직 구현되지 않았습니다. dummyProduct를 사용하세요."),
+    COMPARE_EBAY_SEARCH_FAILED(HttpStatus.BAD_GATEWAY, 50204, "eBay 검색 중 오류가 발생했습니다."),
+    COMPARE_EMBEDDING_FAILED(HttpStatus.BAD_GATEWAY, 50205, "임베딩 생성 중 오류가 발생했습니다."),
+    COMPARE_KEYWORD_TRANSLATION_FAILED(HttpStatus.BAD_GATEWAY, 50206, "키워드 번역 중 오류가 발생했습니다."),
+
 
     /**
      * 405 METHOD_NOT_ALLOWED

--- a/houme-common/src/main/java/or/sopt/houme/global/api/handler/CompareException.java
+++ b/houme-common/src/main/java/or/sopt/houme/global/api/handler/CompareException.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.global.api.handler;
+
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.GeneralException;
+
+public class CompareException extends GeneralException {
+    public CompareException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/client/GeminiTextGenerationClient.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/client/GeminiTextGenerationClient.java
@@ -1,0 +1,27 @@
+package or.sopt.houme.compare.infrastructure.gemini.client;
+
+import or.sopt.houme.compare.infrastructure.gemini.dto.GeminiTextGenerationRequest;
+import or.sopt.houme.compare.infrastructure.gemini.dto.GeminiTextGenerationResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "geminiTextGenerationClient",
+        url = "${gemini.api-base-url:https://generativelanguage.googleapis.com/v1beta}"
+)
+public interface GeminiTextGenerationClient {
+
+    @PostMapping(
+            value = "/models/{model}:generateContent",
+            consumes = MediaType.APPLICATION_JSON_VALUE
+    )
+    GeminiTextGenerationResponse generateContent(
+            @PathVariable("model") String model,
+            @RequestHeader("x-goog-api-key") String apiKey,
+            @RequestBody GeminiTextGenerationRequest request
+    );
+}

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/dto/GeminiTextGenerationRequest.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/dto/GeminiTextGenerationRequest.java
@@ -1,0 +1,16 @@
+package or.sopt.houme.compare.infrastructure.gemini.dto;
+
+import java.util.List;
+
+public record GeminiTextGenerationRequest(List<Content> contents) {
+
+    public static GeminiTextGenerationRequest of(String text) {
+        return new GeminiTextGenerationRequest(
+                List.of(new Content("user", List.of(new Part(text))))
+        );
+    }
+
+    public record Content(String role, List<Part> parts) {}
+
+    public record Part(String text) {}
+}

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/dto/GeminiTextGenerationResponse.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/gemini/dto/GeminiTextGenerationResponse.java
@@ -1,0 +1,19 @@
+package or.sopt.houme.compare.infrastructure.gemini.dto;
+
+import java.util.List;
+
+public record GeminiTextGenerationResponse(List<Candidate> candidates) {
+
+    public record Candidate(Content content) {}
+
+    public record Content(List<Part> parts) {}
+
+    public record Part(String text) {}
+
+    public String extractText() {
+        if (candidates == null || candidates.isEmpty()) return "";
+        Candidate c = candidates.get(0);
+        if (c.content() == null || c.content().parts() == null || c.content().parts().isEmpty()) return "";
+        return c.content().parts().get(0).text();
+    }
+}

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
@@ -37,6 +37,10 @@ public class GeminiKeywordTranslator {
             GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
             GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
             String result = resp.extractText().trim();
+            if (result.isBlank()) {
+                log.error("키워드 번역 결과가 비어있음: product={}", koreanProductName);
+                throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+            }
             log.debug("키워드 번역: '{}' → '{}'", koreanProductName, result);
             return result;
         } catch (FeignException e) {

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
@@ -23,6 +23,8 @@ public class GeminiKeywordTranslator {
     @Value("${gemini.compare-api-key:}")
     private String apiKey;
 
+    public record KeywordPair(String english, String korean) {}
+
     public String translateToEnglish(String koreanProductName) {
         String prompt = """
                 Extract eBay search keywords from this Korean furniture/home product name.
@@ -33,6 +35,38 @@ public class GeminiKeywordTranslator {
                 - Example: "플렌토 속 깊은 5단 서랍장 800" → "5 drawer chest dresser"
                 - Example: "린넨 2인용 소파" → "linen 2 seater sofa"
                 Product: """ + koreanProductName;
+        return callGemini(koreanProductName, prompt);
+    }
+
+    public KeywordPair translateToBoth(String koreanProductName) {
+        String prompt = """
+                Extract search keywords from this Korean furniture/home product name.
+                Output EXACTLY 2 lines, nothing else:
+                LINE1: 2-4 generic English keywords for eBay (no brand, no model number, no size)
+                LINE2: 2-4 Korean keywords for Coupang (no brand, no model number, no size)
+                Example input: "플렌토 속 깊은 5단 서랍장 800"
+                LINE1: 5 drawer chest dresser
+                LINE2: 5단 서랍장 원목
+                Product: """ + koreanProductName;
+        try {
+            GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
+            GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
+            String[] lines = resp.extractText().trim().split("\\r?\\n", 2);
+            if (lines.length < 2 || lines[0].isBlank() || lines[1].isBlank()) {
+                log.error("키워드 번역 결과가 비어있음: product={}", koreanProductName);
+                throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+            }
+            String english = lines[0].trim();
+            String korean = lines[1].trim();
+            log.debug("키워드 번역: '{}' → en='{}', ko='{}'", koreanProductName, english, korean);
+            return new KeywordPair(english, korean);
+        } catch (FeignException e) {
+            log.error("키워드 번역 실패: product={}", koreanProductName, e);
+            throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+        }
+    }
+
+    private String callGemini(String koreanProductName, String prompt) {
         try {
             GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
             GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
@@ -1,0 +1,47 @@
+package or.sopt.houme.compare.infrastructure.llm;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.compare.infrastructure.gemini.client.GeminiTextGenerationClient;
+import or.sopt.houme.compare.infrastructure.gemini.dto.GeminiTextGenerationRequest;
+import or.sopt.houme.compare.infrastructure.gemini.dto.GeminiTextGenerationResponse;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.CompareException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiKeywordTranslator {
+
+    private static final String TRANSLATION_MODEL = "gemini-3.5-flash-lite";
+
+    private final GeminiTextGenerationClient textGenerationClient;
+
+    @Value("${gemini.compare-api-key:}")
+    private String apiKey;
+
+    public String translateToEnglish(String koreanProductName) {
+        String prompt = """
+                Extract eBay search keywords from this Korean furniture/home product name.
+                Rules:
+                - Output ONLY 2-4 generic English keywords describing the product type
+                - Do NOT include brand names, model numbers, or sizes (like 800, 1200)
+                - Focus on the product category and key features (e.g. material, style, number of drawers)
+                - Example: "플렌토 속 깊은 5단 서랍장 800" → "5 drawer chest dresser"
+                - Example: "린넨 2인용 소파" → "linen 2 seater sofa"
+                Product: """ + koreanProductName;
+        try {
+            GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
+            GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
+            String result = resp.extractText().trim();
+            log.debug("키워드 번역: '{}' → '{}'", koreanProductName, result);
+            return result;
+        } catch (FeignException e) {
+            log.error("키워드 번역 실패: product={}", koreanProductName, e);
+            throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+        }
+    }
+}

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
@@ -1,5 +1,7 @@
 package or.sopt.houme.compare.infrastructure.llm;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +21,14 @@ public class GeminiKeywordTranslator {
     private static final String TRANSLATION_MODEL = "gemini-3.5-flash-lite";
 
     private final GeminiTextGenerationClient textGenerationClient;
+    private final ObjectMapper objectMapper;
 
     @Value("${gemini.compare-api-key:}")
     private String apiKey;
 
     public record KeywordPair(String english, String korean) {}
+
+    private record KeywordJson(String ebayKeywords, String coupangKeywords) {}
 
     public String translateToEnglish(String koreanProductName) {
         String prompt = """
@@ -35,38 +40,6 @@ public class GeminiKeywordTranslator {
                 - Example: "플렌토 속 깊은 5단 서랍장 800" → "5 drawer chest dresser"
                 - Example: "린넨 2인용 소파" → "linen 2 seater sofa"
                 Product: """ + koreanProductName;
-        return callGemini(koreanProductName, prompt);
-    }
-
-    public KeywordPair translateToBoth(String koreanProductName) {
-        String prompt = """
-                Extract search keywords from this Korean furniture/home product name.
-                Output EXACTLY 2 lines, nothing else:
-                LINE1: 2-4 generic English keywords for eBay (no brand, no model number, no size)
-                LINE2: 2-4 Korean keywords for Coupang (no brand, no model number, no size)
-                Example input: "플렌토 속 깊은 5단 서랍장 800"
-                LINE1: 5 drawer chest dresser
-                LINE2: 5단 서랍장 원목
-                Product: """ + koreanProductName;
-        try {
-            GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
-            GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
-            String[] lines = resp.extractText().trim().split("\\r?\\n", 2);
-            if (lines.length < 2 || lines[0].isBlank() || lines[1].isBlank()) {
-                log.error("키워드 번역 결과가 비어있음: product={}", koreanProductName);
-                throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
-            }
-            String english = lines[0].trim();
-            String korean = lines[1].trim();
-            log.debug("키워드 번역: '{}' → en='{}', ko='{}'", koreanProductName, english, korean);
-            return new KeywordPair(english, korean);
-        } catch (FeignException e) {
-            log.error("키워드 번역 실패: product={}", koreanProductName, e);
-            throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
-        }
-    }
-
-    private String callGemini(String koreanProductName, String prompt) {
         try {
             GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
             GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
@@ -81,5 +54,77 @@ public class GeminiKeywordTranslator {
             log.error("키워드 번역 실패: product={}", koreanProductName, e);
             throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
         }
+    }
+
+    public KeywordPair translateToBoth(String koreanProductName) {
+        String prompt = buildDualKeywordPrompt(koreanProductName);
+        try {
+            GeminiTextGenerationRequest req = GeminiTextGenerationRequest.of(prompt);
+            GeminiTextGenerationResponse resp = textGenerationClient.generateContent(TRANSLATION_MODEL, apiKey, req);
+            String raw = stripCodeFence(resp.extractText().trim());
+
+            KeywordJson parsed;
+            try {
+                parsed = objectMapper.readValue(raw, KeywordJson.class);
+            } catch (JsonProcessingException e) {
+                log.error("키워드 JSON 파싱 실패: product={}, raw={}", koreanProductName, raw);
+                throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+            }
+
+            if (parsed.ebayKeywords() == null || parsed.ebayKeywords().isBlank()
+                    || parsed.coupangKeywords() == null || parsed.coupangKeywords().isBlank()) {
+                log.error("키워드 결과가 비어있음: product={}, raw={}", koreanProductName, raw);
+                throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+            }
+
+            log.debug("키워드 번역: '{}' → en='{}', ko='{}'", koreanProductName, parsed.ebayKeywords(), parsed.coupangKeywords());
+            return new KeywordPair(parsed.ebayKeywords().trim(), parsed.coupangKeywords().trim());
+        } catch (FeignException e) {
+            log.error("키워드 번역 실패: product={}", koreanProductName, e);
+            throw new CompareException(ErrorCode.COMPARE_KEYWORD_TRANSLATION_FAILED);
+        }
+    }
+
+    private String buildDualKeywordPrompt(String koreanProductName) {
+        return """
+                You are extracting search keywords for a Korean furniture/home-goods product,
+                to be used on two different marketplaces: eBay (English) and Coupang (Korean).
+
+                GOAL: The keywords must match SIMILAR products from OTHER sellers — not just
+                this exact listing. So remove anything that only identifies THIS ONE SKU.
+
+                REMOVE:
+                - Brand / manufacturer / shop names (e.g. "플렌토", "룬드")
+                - Model numbers or product codes (e.g. "800", "K-2201")
+                - Exact size/dimension codes that are catalog-specific (e.g. "SS Q 슈퍼싱글 퀸", "1200x600")
+                - Marketing words (e.g. "프리미엄", "인기", "베스트", "특가")
+
+                KEEP (these describe what the product actually IS, not which SKU it is):
+                - Product type/category (침대 프레임, 서랍장, 펜던트 조명, 소파 커버)
+                - Material (원목, 린넨, 라탄, 패브릭)
+                - Structural/functional descriptors that generalize across sellers
+                  (5단, 2인용, 무헤드, 접이식, 방수)
+
+                OUTPUT: valid JSON only. No explanation, no markdown code fence, no extra text.
+                {"ebayKeywords": "2-4 generic English words", "coupangKeywords": "2-4 generic Korean words"}
+
+                Examples:
+                Input: "플렌토 속 깊은 5단 서랍장 800"
+                Output: {"ebayKeywords": "5 drawer chest dresser", "coupangKeywords": "5단 서랍장"}
+
+                Input: "룬드 무헤드 수납 침대 프레임 SS Q 슈퍼싱글 퀸"
+                Output: {"ebayKeywords": "storage bed frame no headboard", "coupangKeywords": "무헤드 수납 침대 프레임"}
+
+                Input: "노르딕 라탄 펜던트 조명 1등 골드"
+                Output: {"ebayKeywords": "rattan pendant light", "coupangKeywords": "라탄 펜던트 조명"}
+
+                Input: "린넨 2인용 소파 커버 방수 아이보리"
+                Output: {"ebayKeywords": "linen sofa cover waterproof", "coupangKeywords": "린넨 소파 커버 방수"}
+
+                Product: """ + koreanProductName;
+    }
+
+    private String stripCodeFence(String raw) {
+        return raw.replaceAll("(?s)```json\\s*|```", "").trim();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #636

## 📝 Summary

- 한국어 상품명 → eBay 검색 키워드 변환 (`GeminiKeywordTranslator`)
- Gemini `gemini-3.5-flash-lite` 모델 사용
- 브랜드명/모델번호 제거하고 상품 유형 중심 영어 키워드 추출
- 쿠팡 배치 등 내부 파이프라인에서 빈 주입하여 사용

```java
@RequiredArgsConstructor
public class YourBatchJob {
    private final GeminiKeywordTranslator keywordTranslator;
    // keywordTranslator.translateToEnglish("린넨 2인용 소파") → "linen 2 seater sofa"
}
```

## 🙏 Question & PR point

- `GEMINI_COMPARE_API_KEY` 환경변수 별도 추가 필요 (기존 `GEMINI_API_KEY`와 분리)

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->