### PR TITLE
[FEAT] 가격비교 Swagger 스텁 컨트롤러 추가

### DIFF
--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/CompareJobHistoryController.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/CompareJobHistoryController.java
@@ -1,0 +1,31 @@
+package or.sopt.houme.compare.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import or.sopt.houme.compare.presentation.dto.response.CompareJobHistoryResponse;
+import or.sopt.houme.global.api.ApiResponse;
+import or.sopt.houme.domain.user.presentation.controller.dto.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/price-compare")
+@Tag(name = "가격비교 API")
+public class CompareJobHistoryController {
+
+    @Operation(summary = "가격비교 검색 이력 조회")
+    @GetMapping("/jobs/history")
+    public ResponseEntity<ApiResponse<CompareJobHistoryResponse>> getHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "3") int limit
+    ) {
+        // TODO: implement
+        return ResponseEntity.ok(ApiResponse.ok(new CompareJobHistoryResponse(List.of())));
+    }
+}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/PresetController.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/PresetController.java
@@ -1,0 +1,36 @@
+package or.sopt.houme.compare.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import or.sopt.houme.compare.presentation.dto.response.PresetDetailResponse;
+import or.sopt.houme.compare.presentation.dto.response.PresetListResponse;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/price-compare")
+@Tag(name = "가격비교 API")
+public class PresetController {
+
+    @Operation(summary = "프리셋 목록 조회")
+    @GetMapping("/presets")
+    public ResponseEntity<ApiResponse<PresetListResponse>> getPresets() {
+        // TODO: implement
+        return ResponseEntity.ok(ApiResponse.ok(new PresetListResponse(List.of())));
+    }
+
+    @Operation(summary = "프리셋 가격비교 결과 조회")
+    @GetMapping("/presets/{presetId}")
+    public ResponseEntity<ApiResponse<PresetDetailResponse>> getPresetDetail(
+            @PathVariable Long presetId
+    ) {
+        // TODO: implement
+        return ResponseEntity.ok(ApiResponse.ok(new PresetDetailResponse(null, List.of(), 0)));
+    }
+}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/CompareJobHistoryItemResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/CompareJobHistoryItemResponse.java
@@ -1,0 +1,12 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+import java.time.OffsetDateTime;
+
+public record CompareJobHistoryItemResponse(
+        String sourceUrl,
+        String thumbnailUrl,
+        String title,
+        Double price,
+        String currency,
+        OffsetDateTime createdAt
+) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/CompareJobHistoryResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/CompareJobHistoryResponse.java
@@ -1,0 +1,5 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+import java.util.List;
+
+public record CompareJobHistoryResponse(List<CompareJobHistoryItemResponse> items) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetDetailResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetDetailResponse.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+import java.util.List;
+
+public record PresetDetailResponse(
+        PresetOriginalProductResponse originalProduct,
+        List<PresetSimilarProductResponse> similarProducts,
+        long totalCount
+) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetItemResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetItemResponse.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+public record PresetItemResponse(
+        Long presetId,
+        String thumbnailUrl,
+        String title
+) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetListResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetListResponse.java
@@ -1,0 +1,5 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+import java.util.List;
+
+public record PresetListResponse(List<PresetItemResponse> presets) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetOriginalProductResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetOriginalProductResponse.java
@@ -1,0 +1,10 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+public record PresetOriginalProductResponse(
+        String sourceUrl,
+        String title,
+        String thumbnailUrl,
+        String brand,
+        Long price,
+        String currency
+) {}

--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetSimilarProductResponse.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/dto/response/PresetSimilarProductResponse.java
@@ -1,0 +1,15 @@
+package or.sopt.houme.compare.presentation.dto.response;
+
+import java.time.OffsetDateTime;
+
+public record PresetSimilarProductResponse(
+        String source,
+        String productId,
+        String title,
+        String imageUrl,
+        Double price,
+        String currency,
+        String siteName,
+        String productUrl,
+        OffsetDateTime priceUpdatedAt
+) {}


### PR DESCRIPTION
## 📣 Related Issue

- close #641

## 📝 Summary

Swagger 노출 목적으로 가격비교 전체 5개 엔드포인트 컨트롤러·DTO 추가. 실제 구현은 추후 PR에서 진행.

**구현 완료 (파이프라인 연동)**
- `POST /api/v1/price-compare/jobs` — 외부 상품 URL로 가격비교 Job 생성 (202 Accepted)
- `GET /api/v1/price-compare/jobs/{jobId}` — Job 상태·결과 조회

**스텁 (빈 응답 반환)**
- `GET /api/v1/price-compare/jobs/history` — 가격비교 검색 이력 조회 (limit 기본값 3)
- `GET /api/v1/price-compare/presets` — 프리셋 목록 조회
- `GET /api/v1/price-compare/presets/{presetId}` — 프리셋 상세 조회

응답 DTO 11개 추가 (`CreateJobResponse`, `CompareJobResponse`, `SourcesStatusResponse` 외 이력·프리셋 관련)

## 🙏 Question & PR point

- 이력·프리셋 엔드포인트는 현재 빈 배열 반환 — Swagger 스펙 확인 용도
- `POST /jobs` 응답에 `status`, `sourceUrl`, `title`, `thumbnail`, `price`, `brand` 필드 포함 (스크래핑 완료 후 즉시 반환)
- `SourcesStatusResponse`의 coupang·catalog 상태가 기존에 `WAITING`으로 하드코딩되어 있던 것을 ebay 상태와 동일하게 수정 (세 소스가 동일 파이프라인에서 실행됨)

## 📬 Postman

스텁 단계로 Postman 첨부 생략.