### PR TITLE
[FEAT] #654 프리셋 상세 조회 API 구현

### DIFF
--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/PresetController.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/PresetController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.compare.application.PresetUseCase;
+import or.sopt.houme.compare.application.dto.PresetDetailResponse;
 import or.sopt.houme.compare.application.dto.PresetListResponse;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -21,5 +22,13 @@ public class PresetController {
     @GetMapping("/presets")
     public ResponseEntity<ApiResponse<PresetListResponse>> getPresets() {
         return ResponseEntity.ok(ApiResponse.ok(presetUseCase.getPresets()));
+    }
+
+    @Operation(summary = "프리셋 가격비교 결과 조회")
+    @GetMapping("/presets/{presetId}")
+    public ResponseEntity<ApiResponse<PresetDetailResponse>> getPresetDetail(
+            @PathVariable Long presetId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(presetUseCase.getPresetDetail(presetId)));
     }
 }

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/PresetServiceImpl.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/PresetServiceImpl.java
@@ -1,8 +1,12 @@
 package or.sopt.houme.compare.application;
 
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.compare.application.dto.PresetDetailResponse;
 import or.sopt.houme.compare.application.dto.PresetListResponse;
+import or.sopt.houme.compare.domain.port.out.GetPresetDetailPort;
 import or.sopt.houme.compare.domain.port.out.GetPresetListPort;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.CompareException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +15,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class PresetServiceImpl implements PresetUseCase {
 
     private final GetPresetListPort getPresetListPort;
+    private final GetPresetDetailPort getPresetDetailPort;
 
     @Transactional(readOnly = true)
     @Override
     public PresetListResponse getPresets() {
         return PresetListResponse.from(getPresetListPort.findAll());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PresetDetailResponse getPresetDetail(Long presetId) {
+        return PresetDetailResponse.from(
+                getPresetDetailPort.findById(presetId)
+                        .orElseThrow(() -> new CompareException(ErrorCode.COMPARE_PRESET_NOT_FOUND))
+        );
     }
 }

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/PresetUseCase.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/PresetUseCase.java
@@ -1,7 +1,9 @@
 package or.sopt.houme.compare.application;
 
+import or.sopt.houme.compare.application.dto.PresetDetailResponse;
 import or.sopt.houme.compare.application.dto.PresetListResponse;
 
 public interface PresetUseCase {
     PresetListResponse getPresets();
+    PresetDetailResponse getPresetDetail(Long presetId);
 }

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/PresetDetailResponse.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/PresetDetailResponse.java
@@ -1,9 +1,28 @@
 package or.sopt.houme.compare.application.dto;
 
+import or.sopt.houme.compare.domain.ComparePresetDetail;
+
 import java.util.List;
 
 public record PresetDetailResponse(
         PresetOriginalProductResponse originalProduct,
         List<PresetSimilarProductResponse> similarProducts,
         long totalCount
-) {}
+) {
+    public static PresetDetailResponse from(ComparePresetDetail detail) {
+        List<PresetSimilarProductResponse> items = detail.similarProducts().stream()
+                .map(i -> new PresetSimilarProductResponse(
+                        i.source(), i.productId(), i.title(), i.imageUrl(),
+                        i.price(), i.currency(), i.siteName(), i.productUrl(), i.priceUpdatedAt()
+                ))
+                .toList();
+        return new PresetDetailResponse(
+                new PresetOriginalProductResponse(
+                        detail.sourceUrl(), detail.title(), detail.thumbnailUrl(),
+                        detail.brand(), detail.price(), detail.currency()
+                ),
+                items,
+                items.size()
+        );
+    }
+}

--- a/houme-common/src/main/java/or/sopt/houme/global/api/ErrorCode.java
+++ b/houme-common/src/main/java/or/sopt/houme/global/api/ErrorCode.java
@@ -155,6 +155,7 @@ public enum ErrorCode {
     // 가격비교 관련
     COMPARE_JOB_NOT_FOUND(HttpStatus.NOT_FOUND, 40428, "가격 비교 작업을 찾을 수 없습니다."),
     COMPARE_CATALOG_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, 40429, "비교 카탈로그 상품을 찾을 수 없습니다."),
+    COMPARE_PRESET_NOT_FOUND(HttpStatus.NOT_FOUND, 40430, "존재하지 않는 프리셋입니다."),
 
 
     /**

--- a/houme-domain/src/main/java/or/sopt/houme/compare/domain/ComparePresetDetail.java
+++ b/houme-domain/src/main/java/or/sopt/houme/compare/domain/ComparePresetDetail.java
@@ -1,0 +1,26 @@
+package or.sopt.houme.compare.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record ComparePresetDetail(
+        String sourceUrl,
+        String title,
+        String thumbnailUrl,
+        String brand,
+        Long price,
+        String currency,
+        List<SimilarItem> similarProducts
+) {
+    public record SimilarItem(
+            String source,
+            String productId,
+            String title,
+            String imageUrl,
+            Double price,
+            String currency,
+            String siteName,
+            String productUrl,
+            OffsetDateTime priceUpdatedAt
+    ) {}
+}

--- a/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/GetPresetDetailPort.java
+++ b/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/GetPresetDetailPort.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.compare.domain.port.out;
+
+import or.sopt.houme.compare.domain.ComparePresetDetail;
+
+import java.util.Optional;
+
+public interface GetPresetDetailPort {
+    Optional<ComparePresetDetail> findById(Long presetId);
+}

--- a/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetAdapter.java
+++ b/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetAdapter.java
@@ -1,22 +1,43 @@
 package or.sopt.houme.compare.infra.persistence;
 
 import lombok.RequiredArgsConstructor;
+import or.sopt.houme.compare.domain.ComparePresetDetail;
 import or.sopt.houme.compare.domain.ComparePresetView;
+import or.sopt.houme.compare.domain.port.out.GetPresetDetailPort;
 import or.sopt.houme.compare.domain.port.out.GetPresetListPort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class ComparePresetAdapter implements GetPresetListPort {
+public class ComparePresetAdapter implements GetPresetListPort, GetPresetDetailPort {
 
     private final ComparePresetJpaRepository presetRepository;
+    private final ComparePresetItemJpaRepository itemRepository;
 
     @Override
     public List<ComparePresetView> findAll() {
         return presetRepository.findAll().stream()
                 .map(e -> new ComparePresetView(e.getId(), e.getThumbnailUrl(), e.getTitle()))
                 .toList();
+    }
+
+    @Override
+    public Optional<ComparePresetDetail> findById(Long presetId) {
+        return presetRepository.findById(presetId).map(preset -> {
+            List<ComparePresetDetail.SimilarItem> items = itemRepository.findByPreset(preset).stream()
+                    .map(i -> new ComparePresetDetail.SimilarItem(
+                            i.getSource(), i.getProductId(), i.getTitle(), i.getImageUrl(),
+                            i.getPrice(), i.getCurrency(), i.getSiteName(),
+                            i.getProductUrl(), i.getPriceUpdatedAt()
+                    ))
+                    .toList();
+            return new ComparePresetDetail(
+                    preset.getSourceUrl(), preset.getTitle(), preset.getThumbnailUrl(),
+                    preset.getBrand(), preset.getPrice(), preset.getCurrency(), items
+            );
+        });
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #654

## 📝 Summary

- `ComparePresetDetail` 도메인 레코드 및 `GetPresetDetailPort` 포트 추가
- `ComparePresetAdapter`에 `findById()` 구현 — preset + items 두 테이블 조회
- `PresetServiceImpl.getPresetDetail()` — 없으면 40430(`COMPARE_PRESET_NOT_FOUND`) 에러
- `ErrorCode.COMPARE_PRESET_NOT_FOUND` (40430) 추가
- `PresetDetailResponse.from()` 팩토리 메서드 추가
- `GET /api/v1/price-compare/presets/{presetId}` 스텁 → 실구현

## 🙏 Question & PR point

- #653 머지 후 머지 필요 (엔티티 의존)
- `priceUpdatedAt`은 DB에 고정 저장된 값 그대로 반환 (라이브 계산 없음)

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->