### PR TITLE
[FEAT] #655 어드민 프리셋 등록/수정 SSR 구현

### DIFF
--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/AdminPresetController.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/AdminPresetController.java
@@ -1,0 +1,52 @@
+package or.sopt.houme.compare.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.compare.application.PresetUseCase;
+import or.sopt.houme.compare.application.dto.PresetListResponse;
+import or.sopt.houme.compare.application.dto.SavePresetRequest;
+import or.sopt.houme.global.api.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/v1/compare/presets")
+@RequiredArgsConstructor
+@Tag(name = "어드민 가격비교 프리셋 API")
+public class AdminPresetController {
+
+    private final PresetUseCase presetUseCase;
+
+    @Operation(summary = "프리셋 목록 조회 (어드민)")
+    @GetMapping
+    public ResponseEntity<ApiResponse<PresetListResponse>> getPresets() {
+        return ResponseEntity.ok(ApiResponse.ok(presetUseCase.getPresets()));
+    }
+
+    @Operation(summary = "프리셋 등록")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> createPreset(@RequestBody @Valid SavePresetRequest request) {
+        Long presetId = presetUseCase.createPreset(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>(201, "응답 성공", presetId));
+    }
+
+    @Operation(summary = "프리셋 수정")
+    @PutMapping("/{presetId}")
+    public ResponseEntity<ApiResponse<Void>> updatePreset(
+            @PathVariable Long presetId,
+            @RequestBody @Valid SavePresetRequest request
+    ) {
+        presetUseCase.updatePreset(presetId, request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "프리셋 삭제")
+    @DeleteMapping("/{presetId}")
+    public ResponseEntity<ApiResponse<Void>> deletePreset(@PathVariable Long presetId) {
+        presetUseCase.deletePreset(presetId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/houme-api/src/main/resources/templates/admin/dashboard.html
+++ b/houme-api/src/main/resources/templates/admin/dashboard.html
@@ -919,6 +919,11 @@
                 <i class="fas fa-search-dollar"></i>가격비교 검색
             </a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="compare-preset-management">
+                <i class="fas fa-star"></i>프리셋 관리
+            </a>
+        </li>
     </ul>
 </div>
 
@@ -2160,6 +2165,72 @@
         </div>
     </div>
 </div>
+
+    <!-- 프리셋 관리 섹션 -->
+    <div id="compare-preset-management" class="content-section">
+        <h2>프리셋 관리</h2>
+        <p class="text-muted">가격비교 홈에 노출되는 예시 상품 프리셋을 등록·수정·삭제합니다.</p>
+
+        <!-- 목록 -->
+        <div class="card mb-4">
+            <div class="card-header fw-bold d-flex justify-content-between align-items-center">
+                등록된 프리셋
+                <button class="btn btn-sm btn-secondary" onclick="loadPresets()">새로고침</button>
+            </div>
+            <div class="card-body">
+                <div id="preset-list-result"></div>
+            </div>
+        </div>
+
+        <!-- 등록 / 수정 폼 -->
+        <div class="card">
+            <div class="card-header fw-bold" id="preset-form-title">신규 프리셋 등록</div>
+            <div class="card-body">
+                <input type="hidden" id="preset-editing-id">
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <label class="form-label">원본 상품 URL <span class="text-danger">*</span></label>
+                        <input type="url" class="form-control" id="preset-source-url" placeholder="https://www.ohou.se/...">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">상품명 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="preset-title">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">썸네일 URL</label>
+                        <input type="url" class="form-control" id="preset-thumbnail-url">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">브랜드</label>
+                        <input type="text" class="form-control" id="preset-brand">
+                    </div>
+                    <div class="col-md-2">
+                        <label class="form-label">가격 (원)</label>
+                        <input type="number" class="form-control" id="preset-price" placeholder="299000">
+                    </div>
+                    <div class="col-md-1">
+                        <label class="form-label">통화</label>
+                        <input type="text" class="form-control" id="preset-currency" value="KRW">
+                    </div>
+                </div>
+
+                <!-- 유사상품 -->
+                <div class="mb-3">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <label class="form-label mb-0 fw-bold">유사상품 목록</label>
+                        <button type="button" class="btn btn-sm btn-outline-primary" onclick="addPresetItem()">+ 항목 추가</button>
+                    </div>
+                    <div id="preset-items-container"></div>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button class="btn btn-primary" onclick="submitPreset()">저장</button>
+                    <button class="btn btn-outline-secondary" onclick="resetPresetForm()">초기화</button>
+                </div>
+                <div id="preset-form-result" class="api-result mt-3" style="display:none;"></div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
@@ -6688,6 +6759,149 @@
             resultDiv.innerHTML = `<div class="alert alert-danger">오류: ${escapeHtml(String(err))}</div>`;
         });
     }
+
+    // ========== 프리셋 관리 ==========
+    function getToken() {
+        return new URLSearchParams(window.location.search).get('token') || '';
+    }
+
+    function authHeaders() {
+        return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + getToken() };
+    }
+
+    function loadPresets() {
+        fetch('/api/admin/v1/compare/presets', { headers: authHeaders() })
+            .then(r => r.json())
+            .then(data => {
+                const presets = data.data?.presets || [];
+                if (!presets.length) {
+                    document.getElementById('preset-list-result').innerHTML = '<p class="text-muted">등록된 프리셋이 없습니다.</p>';
+                    return;
+                }
+                let html = '<div class="table-responsive"><table class="table table-sm"><thead><tr><th>ID</th><th>썸네일</th><th>상품명</th><th>액션</th></tr></thead><tbody>';
+                presets.forEach(p => {
+                    html += `<tr>
+                        <td>${p.presetId}</td>
+                        <td>${p.thumbnailUrl ? `<img src="${escapeHtml(p.thumbnailUrl)}" style="width:48px;height:48px;object-fit:cover;border-radius:4px;">` : '-'}</td>
+                        <td>${escapeHtml(p.title)}</td>
+                        <td>
+                            <button class="btn btn-sm btn-outline-primary me-1" onclick="loadPresetForEdit(${p.presetId})">수정</button>
+                            <button class="btn btn-sm btn-outline-danger" onclick="deletePreset(${p.presetId})">삭제</button>
+                        </td>
+                    </tr>`;
+                });
+                html += '</tbody></table></div>';
+                document.getElementById('preset-list-result').innerHTML = html;
+            })
+            .catch(err => document.getElementById('preset-list-result').innerHTML = `<div class="alert alert-danger">${escapeHtml(String(err))}</div>`);
+    }
+
+    function loadPresetForEdit(presetId) {
+        fetch(`/api/v1/price-compare/presets/${presetId}`)
+            .then(r => r.json())
+            .then(data => {
+                const d = data.data;
+                document.getElementById('preset-editing-id').value = presetId;
+                document.getElementById('preset-form-title').textContent = `프리셋 수정 (ID: ${presetId})`;
+                document.getElementById('preset-source-url').value = d.originalProduct.sourceUrl || '';
+                document.getElementById('preset-title').value = d.originalProduct.title || '';
+                document.getElementById('preset-thumbnail-url').value = d.originalProduct.thumbnailUrl || '';
+                document.getElementById('preset-brand').value = d.originalProduct.brand || '';
+                document.getElementById('preset-price').value = d.originalProduct.price || '';
+                document.getElementById('preset-currency').value = d.originalProduct.currency || 'KRW';
+                document.getElementById('preset-items-container').innerHTML = '';
+                (d.similarProducts || []).forEach(i => addPresetItem(i));
+                document.querySelector('[data-target="compare-preset-management"]').click();
+            });
+    }
+
+    let presetItemIndex = 0;
+    function addPresetItem(data = {}) {
+        const idx = presetItemIndex++;
+        const container = document.getElementById('preset-items-container');
+        const div = document.createElement('div');
+        div.className = 'border rounded p-3 mb-2 bg-light';
+        div.id = `preset-item-${idx}`;
+        div.innerHTML = `
+            <div class="row g-2">
+                <div class="col-md-2"><label class="form-label small">소스</label><input class="form-control form-control-sm" placeholder="EBAY" value="${escapeHtml(data.source||'')}"></div>
+                <div class="col-md-2"><label class="form-label small">productId</label><input class="form-control form-control-sm" value="${escapeHtml(data.productId||'')}"></div>
+                <div class="col-md-3"><label class="form-label small">상품명</label><input class="form-control form-control-sm" value="${escapeHtml(data.title||'')}"></div>
+                <div class="col-md-3"><label class="form-label small">imageUrl</label><input class="form-control form-control-sm" value="${escapeHtml(data.imageUrl||'')}"></div>
+                <div class="col-md-1"><label class="form-label small">가격</label><input type="number" class="form-control form-control-sm" value="${data.price||''}"></div>
+                <div class="col-md-1"><label class="form-label small">통화</label><input class="form-control form-control-sm" value="${escapeHtml(data.currency||'KRW')}"></div>
+                <div class="col-md-2"><label class="form-label small">사이트명</label><input class="form-control form-control-sm" value="${escapeHtml(data.siteName||'')}"></div>
+                <div class="col-md-4"><label class="form-label small">productUrl</label><input class="form-control form-control-sm" value="${escapeHtml(data.productUrl||'')}"></div>
+                <div class="col-md-4"><label class="form-label small">priceUpdatedAt (ISO)</label><input class="form-control form-control-sm" placeholder="2026-08-24T05:10:00Z" value="${escapeHtml(data.priceUpdatedAt||'')}"></div>
+                <div class="col-md-2 d-flex align-items-end"><button class="btn btn-sm btn-outline-danger w-100" onclick="document.getElementById('preset-item-${idx}').remove()">삭제</button></div>
+            </div>`;
+        container.appendChild(div);
+    }
+
+    function collectPresetItems() {
+        const items = [];
+        document.querySelectorAll('#preset-items-container > div').forEach(div => {
+            const inputs = div.querySelectorAll('input');
+            items.push({
+                source: inputs[0].value.trim(),
+                productId: inputs[1].value.trim(),
+                title: inputs[2].value.trim(),
+                imageUrl: inputs[3].value.trim() || null,
+                price: parseFloat(inputs[4].value),
+                currency: inputs[5].value.trim(),
+                siteName: inputs[6].value.trim() || null,
+                productUrl: inputs[7].value.trim(),
+                priceUpdatedAt: inputs[8].value.trim()
+            });
+        });
+        return items;
+    }
+
+    function submitPreset() {
+        const editingId = document.getElementById('preset-editing-id').value;
+        const body = {
+            sourceUrl: document.getElementById('preset-source-url').value.trim(),
+            title: document.getElementById('preset-title').value.trim(),
+            thumbnailUrl: document.getElementById('preset-thumbnail-url').value.trim() || null,
+            brand: document.getElementById('preset-brand').value.trim() || null,
+            price: document.getElementById('preset-price').value ? parseInt(document.getElementById('preset-price').value) : null,
+            currency: document.getElementById('preset-currency').value.trim() || 'KRW',
+            similarProducts: collectPresetItems()
+        };
+        const url = editingId ? `/api/admin/v1/compare/presets/${editingId}` : '/api/admin/v1/compare/presets';
+        const method = editingId ? 'PUT' : 'POST';
+        const resultDiv = document.getElementById('preset-form-result');
+        resultDiv.style.display = 'block';
+        resultDiv.textContent = '저장 중...';
+        fetch(url, { method, headers: authHeaders(), body: JSON.stringify(body) })
+            .then(r => r.json())
+            .then(data => {
+                resultDiv.textContent = JSON.stringify(data, null, 2);
+                loadPresets();
+            })
+            .catch(err => { resultDiv.textContent = '오류: ' + err; });
+    }
+
+    function deletePreset(presetId) {
+        if (!confirm(`프리셋 ${presetId}를 삭제하시겠습니까?`)) return;
+        fetch(`/api/admin/v1/compare/presets/${presetId}`, { method: 'DELETE', headers: authHeaders() })
+            .then(() => loadPresets())
+            .catch(err => alert('삭제 실패: ' + err));
+    }
+
+    function resetPresetForm() {
+        document.getElementById('preset-editing-id').value = '';
+        document.getElementById('preset-form-title').textContent = '신규 프리셋 등록';
+        ['preset-source-url','preset-title','preset-thumbnail-url','preset-brand','preset-price'].forEach(id => document.getElementById(id).value = '');
+        document.getElementById('preset-currency').value = 'KRW';
+        document.getElementById('preset-items-container').innerHTML = '';
+        document.getElementById('preset-form-result').style.display = 'none';
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelector('[data-target="compare-preset-management"]')
+            ?.addEventListener('click', loadPresets);
+    });
 </script>
 </body>
 </html>

--- a/houme-api/src/main/resources/templates/admin/dashboard.html
+++ b/houme-api/src/main/resources/templates/admin/dashboard.html
@@ -2204,11 +2204,11 @@
                         <label class="form-label">브랜드</label>
                         <input type="text" class="form-control" id="preset-brand">
                     </div>
-                    <div class="col-md-2">
+                    <div class="col-md-3">
                         <label class="form-label">가격 (원)</label>
                         <input type="number" class="form-control" id="preset-price" placeholder="299000">
                     </div>
-                    <div class="col-md-1">
+                    <div class="col-md-2">
                         <label class="form-label">통화</label>
                         <input type="text" class="form-control" id="preset-currency" value="KRW">
                     </div>

--- a/houme-api/src/main/resources/templates/admin/dashboard.html
+++ b/houme-api/src/main/resources/templates/admin/dashboard.html
@@ -6762,7 +6762,7 @@
 
     // ========== 프리셋 관리 ==========
     function getToken() {
-        return new URLSearchParams(window.location.search).get('token') || '';
+        return new URLSearchParams(window.location.search).get('token') || localStorage.getItem('accessToken') || '';
     }
 
     function authHeaders() {

--- a/houme-api/src/main/resources/templates/admin/dashboard.html
+++ b/houme-api/src/main/resources/templates/admin/dashboard.html
@@ -2197,8 +2197,8 @@
                         <input type="text" class="form-control" id="preset-title">
                     </div>
                     <div class="col-md-6">
-                        <label class="form-label">썸네일 URL</label>
-                        <input type="url" class="form-control" id="preset-thumbnail-url">
+                        <label class="form-label">썸네일 URL <span class="text-danger">*</span></label>
+                        <input type="url" class="form-control" id="preset-thumbnail-url" required>
                     </div>
                     <div class="col-md-3">
                         <label class="form-label">브랜드</label>
@@ -6862,7 +6862,7 @@
         const body = {
             sourceUrl: document.getElementById('preset-source-url').value.trim(),
             title: document.getElementById('preset-title').value.trim(),
-            thumbnailUrl: document.getElementById('preset-thumbnail-url').value.trim() || null,
+            thumbnailUrl: document.getElementById('preset-thumbnail-url').value.trim(),
             brand: document.getElementById('preset-brand').value.trim() || null,
             price: document.getElementById('preset-price').value ? parseInt(document.getElementById('preset-price').value) : null,
             currency: document.getElementById('preset-currency').value.trim() || 'KRW',

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/PresetServiceImpl.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/PresetServiceImpl.java
@@ -3,8 +3,10 @@ package or.sopt.houme.compare.application;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.compare.application.dto.PresetDetailResponse;
 import or.sopt.houme.compare.application.dto.PresetListResponse;
+import or.sopt.houme.compare.application.dto.SavePresetRequest;
 import or.sopt.houme.compare.domain.port.out.GetPresetDetailPort;
 import or.sopt.houme.compare.domain.port.out.GetPresetListPort;
+import or.sopt.houme.compare.domain.port.out.SavePresetPort;
 import or.sopt.houme.global.api.ErrorCode;
 import or.sopt.houme.global.api.handler.CompareException;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ public class PresetServiceImpl implements PresetUseCase {
 
     private final GetPresetListPort getPresetListPort;
     private final GetPresetDetailPort getPresetDetailPort;
+    private final SavePresetPort savePresetPort;
 
     @Transactional(readOnly = true)
     @Override
@@ -30,5 +33,23 @@ public class PresetServiceImpl implements PresetUseCase {
                 getPresetDetailPort.findById(presetId)
                         .orElseThrow(() -> new CompareException(ErrorCode.COMPARE_PRESET_NOT_FOUND))
         );
+    }
+
+    @Transactional
+    @Override
+    public Long createPreset(SavePresetRequest request) {
+        return savePresetPort.create(request.toDomain());
+    }
+
+    @Transactional
+    @Override
+    public void updatePreset(Long presetId, SavePresetRequest request) {
+        savePresetPort.update(presetId, request.toDomain());
+    }
+
+    @Transactional
+    @Override
+    public void deletePreset(Long presetId) {
+        savePresetPort.delete(presetId);
     }
 }

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/PresetUseCase.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/PresetUseCase.java
@@ -2,8 +2,12 @@ package or.sopt.houme.compare.application;
 
 import or.sopt.houme.compare.application.dto.PresetDetailResponse;
 import or.sopt.houme.compare.application.dto.PresetListResponse;
+import or.sopt.houme.compare.application.dto.SavePresetRequest;
 
 public interface PresetUseCase {
     PresetListResponse getPresets();
     PresetDetailResponse getPresetDetail(Long presetId);
+    Long createPreset(SavePresetRequest request);
+    void updatePreset(Long presetId, SavePresetRequest request);
+    void deletePreset(Long presetId);
 }

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SavePresetRequest.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SavePresetRequest.java
@@ -1,0 +1,31 @@
+package or.sopt.houme.compare.application.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import or.sopt.houme.compare.domain.ComparePresetDetail;
+
+import java.util.List;
+
+public record SavePresetRequest(
+        @NotBlank String sourceUrl,
+        @NotBlank String title,
+        String thumbnailUrl,
+        String brand,
+        Long price,
+        @NotBlank String currency,
+        @NotNull @Valid List<SimilarProductRequest> similarProducts
+) {
+    public ComparePresetDetail toDomain() {
+        return new ComparePresetDetail(
+                sourceUrl, title, thumbnailUrl, brand, price, currency,
+                similarProducts.stream()
+                        .map(i -> new ComparePresetDetail.SimilarItem(
+                                i.source(), i.productId(), i.title(), i.imageUrl(),
+                                i.price(), i.currency(), i.siteName(),
+                                i.productUrl(), i.priceUpdatedAt()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SavePresetRequest.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SavePresetRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record SavePresetRequest(
         @NotBlank String sourceUrl,
         @NotBlank String title,
-        String thumbnailUrl,
+        @NotBlank String thumbnailUrl,
         String brand,
         Long price,
         @NotBlank String currency,

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SimilarProductRequest.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/SimilarProductRequest.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.compare.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.OffsetDateTime;
+
+public record SimilarProductRequest(
+        @NotBlank String source,
+        @NotBlank String productId,
+        @NotBlank String title,
+        String imageUrl,
+        @NotNull Double price,
+        @NotBlank String currency,
+        String siteName,
+        @NotBlank String productUrl,
+        @NotNull OffsetDateTime priceUpdatedAt
+) {}

--- a/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/SavePresetPort.java
+++ b/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/SavePresetPort.java
@@ -1,0 +1,11 @@
+package or.sopt.houme.compare.domain.port.out;
+
+import or.sopt.houme.compare.domain.ComparePresetDetail;
+
+public interface SavePresetPort {
+    Long create(ComparePresetDetail preset);
+
+    void update(Long presetId, ComparePresetDetail preset);
+
+    void delete(Long presetId);
+}

--- a/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetAdapter.java
+++ b/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetAdapter.java
@@ -5,14 +5,18 @@ import or.sopt.houme.compare.domain.ComparePresetDetail;
 import or.sopt.houme.compare.domain.ComparePresetView;
 import or.sopt.houme.compare.domain.port.out.GetPresetDetailPort;
 import or.sopt.houme.compare.domain.port.out.GetPresetListPort;
+import or.sopt.houme.compare.domain.port.out.SavePresetPort;
+import or.sopt.houme.global.api.ErrorCode;
+import or.sopt.houme.global.api.handler.CompareException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class ComparePresetAdapter implements GetPresetListPort, GetPresetDetailPort {
+public class ComparePresetAdapter implements GetPresetListPort, GetPresetDetailPort, SavePresetPort {
 
     private final ComparePresetJpaRepository presetRepository;
     private final ComparePresetItemJpaRepository itemRepository;
@@ -39,5 +43,49 @@ public class ComparePresetAdapter implements GetPresetListPort, GetPresetDetailP
                     preset.getBrand(), preset.getPrice(), preset.getCurrency(), items
             );
         });
+    }
+
+    @Transactional
+    @Override
+    public Long create(ComparePresetDetail detail) {
+        ComparePresetJpaEntity preset = presetRepository.save(
+                ComparePresetJpaEntity.builder()
+                        .sourceUrl(detail.sourceUrl()).title(detail.title())
+                        .thumbnailUrl(detail.thumbnailUrl()).brand(detail.brand())
+                        .price(detail.price()).currency(detail.currency())
+                        .build()
+        );
+        saveItems(preset, detail.similarProducts());
+        return preset.getId();
+    }
+
+    @Transactional
+    @Override
+    public void update(Long presetId, ComparePresetDetail detail) {
+        ComparePresetJpaEntity preset = presetRepository.findById(presetId)
+                .orElseThrow(() -> new CompareException(ErrorCode.COMPARE_PRESET_NOT_FOUND));
+        preset.update(detail.sourceUrl(), detail.title(), detail.thumbnailUrl(), detail.brand(), detail.price(), detail.currency());
+        itemRepository.deleteAll(itemRepository.findByPreset(preset));
+        saveItems(preset, detail.similarProducts());
+    }
+
+    @Transactional
+    @Override
+    public void delete(Long presetId) {
+        ComparePresetJpaEntity preset = presetRepository.findById(presetId)
+                .orElseThrow(() -> new CompareException(ErrorCode.COMPARE_PRESET_NOT_FOUND));
+        itemRepository.deleteAll(itemRepository.findByPreset(preset));
+        presetRepository.delete(preset);
+    }
+
+    private void saveItems(ComparePresetJpaEntity preset, List<ComparePresetDetail.SimilarItem> items) {
+        items.forEach(i -> itemRepository.save(
+                ComparePresetItemJpaEntity.builder()
+                        .preset(preset).source(i.source()).productId(i.productId())
+                        .title(i.title()).imageUrl(i.imageUrl()).price(i.price())
+                        .currency(i.currency()).siteName(i.siteName())
+                        .productUrl(i.productUrl()).priceUpdatedAt(i.priceUpdatedAt())
+                        .build()
+        ));
     }
 }

--- a/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetJpaEntity.java
+++ b/houme-infra/src/main/java/or/sopt/houme/compare/infra/persistence/ComparePresetJpaEntity.java
@@ -43,7 +43,8 @@ public class ComparePresetJpaEntity extends BaseEntity {
         this.currency = currency;
     }
 
-    public void update(String title, String thumbnailUrl, String brand, Long price, String currency) {
+    public void update(String sourceUrl, String title, String thumbnailUrl, String brand, Long price, String currency) {
+        this.sourceUrl = sourceUrl;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
         this.brand = brand;


### PR DESCRIPTION
## 📣 Related Issue

- close #655

## 📝 Summary

- `SavePresetPort` 도메인 포트 추가 (create/update/delete)
- `ComparePresetAdapter`에 저장·수정·삭제 구현 — update 시 기존 items 전체 교체 방식
- `PresetServiceImpl`에 `createPreset()`, `updatePreset()`, `deletePreset()` 추가
- 요청 DTO: `SavePresetRequest`, `SimilarProductRequest` (@Valid 포함)
- `AdminPresetController` 추가 (`/api/admin/v1/compare/presets`)
  - `GET` 목록, `POST` 등록, `PUT /{id}` 수정, `DELETE /{id}` 삭제
- 어드민 대시보드 사이드바에 "프리셋 관리" 메뉴 추가
- 대시보드에 프리셋 관리 섹션 추가 (목록 테이블 + 등록/수정 폼 + JS AJAX)

## 🙏 Question & PR point

- #654 머지 후 머지 필요
- 어드민 JWT 토큰은 기존 쿼리파라미터(`?token=`) 방식 그대로 사용
- 프리셋 등록: URL + 원본 상품 정보 + 유사상품 목록을 어드민이 직접 입력 (compare-management 탭에서 검색 후 수동 입력)

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 관리자 대시보드에서 가격비교 프리셋 목록을 조회하고 관리할 수 있습니다.
  - 프리셋을 새로 등록하거나 기존 프리셋의 상품 정보와 유사상품 항목을 수정할 수 있습니다.
  - 더 이상 필요하지 않은 프리셋을 삭제할 수 있습니다.
  - 프리셋 저장 및 수정 시 필수 입력값과 유사상품 정보가 검증됩니다.
  - 프리셋 관리 작업 결과와 인증 상태가 화면에 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->