### PR TITLE
feat: #659 Gemini 검색어 검증 어드민 뷰 구현

### DIFF
--- a/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/AdminCompareController.java
+++ b/houme-api/src/main/java/or/sopt/houme/compare/presentation/controller/AdminCompareController.java
@@ -6,8 +6,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.sopt.houme.compare.application.AdminEbaySearchService;
 import or.sopt.houme.compare.application.AdminEbaySearchService.AdminSearchResult;
+import or.sopt.houme.compare.application.AdminKeywordCheckUseCase;
 import or.sopt.houme.compare.application.dto.AdminImageSearchRequest;
 import or.sopt.houme.compare.application.dto.AdminTextSearchRequest;
+import or.sopt.houme.compare.application.dto.KeywordCheckRequest;
+import or.sopt.houme.compare.application.dto.KeywordCheckResponse;
 import or.sopt.houme.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminCompareController {
 
     private final AdminEbaySearchService adminEbaySearchService;
+    private final AdminKeywordCheckUseCase adminKeywordCheckUseCase;
 
     @Operation(
             summary = "eBay 텍스트 검색 결과 조회",
@@ -45,5 +49,16 @@ public class AdminCompareController {
         return ResponseEntity.ok(ApiResponse.ok(
                 adminEbaySearchService.imageSearch(request.imageUrl(), request.priceKrw(), request.category())
         ));
+    }
+
+    @Operation(
+            summary = "Gemini 검색어 검증",
+            description = "한글 상품명 → Gemini 번역 → eBay 영문 키워드 + 쿠팡 한글 키워드 반환. 검색어 품질 확인용."
+    )
+    @PostMapping("/keyword-check")
+    public ResponseEntity<ApiResponse<KeywordCheckResponse>> keywordCheck(
+            @Valid @RequestBody KeywordCheckRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(adminKeywordCheckUseCase.check(request.productName())));
     }
 }

--- a/houme-api/src/main/resources/templates/admin/dashboard.html
+++ b/houme-api/src/main/resources/templates/admin/dashboard.html
@@ -924,6 +924,11 @@
                 <i class="fas fa-star"></i>프리셋 관리
             </a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#" data-target="keyword-check-management">
+                <i class="fas fa-language"></i>검색어 검증
+            </a>
+        </li>
     </ul>
 </div>
 
@@ -2228,6 +2233,41 @@
                     <button class="btn btn-outline-secondary" onclick="resetPresetForm()">초기화</button>
                 </div>
                 <div id="preset-form-result" class="api-result mt-3" style="display:none;"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 검색어 검증 섹션 -->
+    <div id="keyword-check-management" class="content-section">
+        <h2>Gemini 검색어 검증</h2>
+        <p class="text-muted">한글 상품명을 입력하면 Gemini가 생성한 eBay 영문 키워드와 쿠팡 한글 키워드를 확인합니다.</p>
+
+        <div class="card">
+            <div class="card-header fw-bold">검색어 변환 테스트</div>
+            <div class="card-body">
+                <div class="row g-3 mb-3">
+                    <div class="col-md-8">
+                        <label class="form-label">한글 상품명 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="kw-product-name" placeholder="예: 플렌토 속 깊은 5단 서랍장 800">
+                    </div>
+                    <div class="col-md-4 d-flex align-items-end">
+                        <button class="btn btn-primary w-100" id="kw-check-btn" onclick="runKeywordCheck()">검색어 생성</button>
+                    </div>
+                </div>
+                <div id="kw-loading" class="text-muted small mb-2" style="display:none;">⏳ Gemini 번역 중 (약 5~10초)...</div>
+                <div id="kw-result" style="display:none;">
+                    <div class="row g-3 mt-1">
+                        <div class="col-md-6">
+                            <label class="form-label fw-bold">eBay 영문 키워드</label>
+                            <input type="text" class="form-control" id="kw-english" readonly>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label fw-bold">쿠팡 한글 키워드</label>
+                            <input type="text" class="form-control" id="kw-korean" readonly>
+                        </div>
+                    </div>
+                </div>
+                <div id="kw-error" class="text-danger small mt-2" style="display:none;"></div>
             </div>
         </div>
     </div>
@@ -6902,6 +6942,41 @@
         document.querySelector('[data-target="compare-preset-management"]')
             ?.addEventListener('click', loadPresets);
     });
+
+    function runKeywordCheck() {
+        const productName = document.getElementById('kw-product-name').value.trim();
+        if (!productName) { alert('상품명을 입력하세요.'); return; }
+
+        document.getElementById('kw-loading').style.display = 'block';
+        document.getElementById('kw-result').style.display = 'none';
+        document.getElementById('kw-error').style.display = 'none';
+        document.getElementById('kw-check-btn').disabled = true;
+
+        fetch('/api/admin/v1/compare/keyword-check', {
+            method: 'POST',
+            headers: authHeaders(),
+            body: JSON.stringify({ productName })
+        })
+        .then(res => res.json())
+        .then(json => {
+            if (json.data) {
+                document.getElementById('kw-english').value = json.data.english || '';
+                document.getElementById('kw-korean').value = json.data.korean || '';
+                document.getElementById('kw-result').style.display = 'block';
+            } else {
+                document.getElementById('kw-error').textContent = json.msg || '오류가 발생했습니다.';
+                document.getElementById('kw-error').style.display = 'block';
+            }
+        })
+        .catch(err => {
+            document.getElementById('kw-error').textContent = '오류: ' + err;
+            document.getElementById('kw-error').style.display = 'block';
+        })
+        .finally(() => {
+            document.getElementById('kw-loading').style.display = 'none';
+            document.getElementById('kw-check-btn').disabled = false;
+        });
+    }
 </script>
 </body>
 </html>

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/AdminKeywordCheckService.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/AdminKeywordCheckService.java
@@ -1,0 +1,18 @@
+package or.sopt.houme.compare.application;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.houme.compare.application.dto.KeywordCheckResponse;
+import or.sopt.houme.compare.domain.port.out.KeywordTranslationPort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminKeywordCheckService implements AdminKeywordCheckUseCase {
+
+    private final KeywordTranslationPort keywordTranslationPort;
+
+    @Override
+    public KeywordCheckResponse check(String productName) {
+        return KeywordCheckResponse.from(keywordTranslationPort.translateToBoth(productName));
+    }
+}

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/AdminKeywordCheckUseCase.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/AdminKeywordCheckUseCase.java
@@ -1,0 +1,7 @@
+package or.sopt.houme.compare.application;
+
+import or.sopt.houme.compare.application.dto.KeywordCheckResponse;
+
+public interface AdminKeywordCheckUseCase {
+    KeywordCheckResponse check(String productName);
+}

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/KeywordCheckRequest.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/KeywordCheckRequest.java
@@ -1,0 +1,5 @@
+package or.sopt.houme.compare.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KeywordCheckRequest(@NotBlank String productName) {}

--- a/houme-application/src/main/java/or/sopt/houme/compare/application/dto/KeywordCheckResponse.java
+++ b/houme-application/src/main/java/or/sopt/houme/compare/application/dto/KeywordCheckResponse.java
@@ -1,0 +1,9 @@
+package or.sopt.houme.compare.application.dto;
+
+import or.sopt.houme.compare.domain.KeywordPair;
+
+public record KeywordCheckResponse(String english, String korean) {
+    public static KeywordCheckResponse from(KeywordPair pair) {
+        return new KeywordCheckResponse(pair.english(), pair.korean());
+    }
+}

--- a/houme-domain/src/main/java/or/sopt/houme/compare/domain/KeywordPair.java
+++ b/houme-domain/src/main/java/or/sopt/houme/compare/domain/KeywordPair.java
@@ -1,0 +1,3 @@
+package or.sopt.houme.compare.domain;
+
+public record KeywordPair(String english, String korean) {}

--- a/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/KeywordTranslationPort.java
+++ b/houme-domain/src/main/java/or/sopt/houme/compare/domain/port/out/KeywordTranslationPort.java
@@ -1,5 +1,6 @@
 package or.sopt.houme.compare.domain.port.out;
 
+import or.sopt.houme.compare.domain.KeywordPair;
 import or.sopt.houme.compare.domain.MarketplaceSearchKeywords;
 import or.sopt.houme.furniture.domain.FurnitureWithTypeView;
 
@@ -13,4 +14,6 @@ public interface KeywordTranslationPort {
             String koreanProductName,
             List<FurnitureWithTypeView> furnitureCandidates
     );
+
+    KeywordPair translateToBoth(String koreanProductName);
 }

--- a/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
+++ b/houme-external/src/main/java/or/sopt/houme/compare/infrastructure/llm/GeminiKeywordTranslator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.sopt.houme.compare.domain.KeywordPair;
 import or.sopt.houme.compare.domain.MarketplaceSearchKeywords;
 import or.sopt.houme.compare.domain.port.out.KeywordTranslationPort;
 import or.sopt.houme.compare.infrastructure.gemini.client.GeminiTextGenerationClient;
@@ -31,8 +32,6 @@ public class GeminiKeywordTranslator implements KeywordTranslationPort {
 
     @Value("${gemini.compare-api-key:}")
     private String apiKey;
-
-    public record KeywordPair(String english, String korean) {}
 
     private record KeywordJson(String ebayKeywords, String coupangKeywords, Long furnitureId) {}
 
@@ -94,6 +93,7 @@ public class GeminiKeywordTranslator implements KeywordTranslationPort {
         );
     }
 
+    @Override
     public KeywordPair translateToBoth(String koreanProductName) {
         String raw = generateKeywordJson(koreanProductName, buildDualKeywordPrompt(koreanProductName, null));
         KeywordJson parsed = parseKeywordJson(koreanProductName, raw);


### PR DESCRIPTION
## 📣 Related Issue

- close #659

## 📝 Summary

한글 상품명을 입력하면 기존 Gemini 번역 기능을 통해 eBay 영문 키워드와 쿠팡 한글 키워드를 확인할 수 있는 어드민 뷰를 추가합니다.

- **houme-domain**: `KeywordPair(english, korean)` 도메인 레코드 추가, `KeywordTranslationPort`에 `translateToBoth()` 메서드 추가
- **houme-external**: `GeminiKeywordTranslator` inner record `KeywordPair` 제거 → 도메인 타입으로 교체, 포트 구현
- **houme-application**: `AdminKeywordCheckUseCase` / `AdminKeywordCheckService` / DTO 추가
- **houme-api**: `POST /api/admin/v1/compare/keyword-check` 엔드포인트 추가, 어드민 대시보드에 "검색어 검증" 탭 추가

## 🙏 Question & PR point

- 기존 `GeminiKeywordTranslator`의 inner record `KeywordPair`를 도메인 레코드로 분리했습니다. 외부 참조가 없어 사이드 이펙트는 없습니다.
- 어드민 뷰는 기존 `authHeaders()` / `getToken()` 함수를 그대로 재사용합니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->